### PR TITLE
Some overdue updates.

### DIFF
--- a/Source/GTMSessionFetcher.h
+++ b/Source/GTMSessionFetcher.h
@@ -294,6 +294,8 @@ extern "C" {
   #ifndef GTM_USE_SESSION_FETCHER
     #define GTM_USE_SESSION_FETCHER 1
   #endif
+
+  #define GTMSESSION_DEPRECATE_OLD_ENUMS 1
 #endif
 
 #if !defined(GTMBridgeFetcher)
@@ -309,7 +311,7 @@ extern "C" {
     #define GTMBridgeSystemVersionString GTMFetcherSystemVersionString
     #define GTMBridgeApplicationIdentifier GTMFetcherApplicationIdentifier
     #define kGTMBridgeFetcherStatusDomain kGTMSessionFetcherStatusDomain
-    #define kGTMBridgeFetcherStatusBadRequest kGTMSessionFetcherStatusBadRequest
+    #define kGTMBridgeFetcherStatusBadRequest GTMSessionFetcherStatusBadRequest
   #else
     // Macros to old fetcher class.
     #define GTMBridgeFetcher GTMHTTPFetcher
@@ -354,21 +356,38 @@ extern NSString *const kGTMSessionFetcherStatusDataKey;  // data returned with a
 }
 #endif
 
-typedef NS_ENUM(NSInteger, GTMSessionFetcherErrorCode) {
-  kGTMSessionFetcherErrorDownloadFailed = -1,
-  kGTMSessionFetcherErrorUploadChunkUnavailable = -2,
-  kGTMSessionFetcherErrorBackgroundExpiration = -3,
-  kGTMSessionFetcherErrorBackgroundFetchFailed = -4,
-  kGTMSessionFetcherErrorInsecureRequest = -5,
-  kGTMSessionFetcherErrorTaskCreationFailed = -6,
-
-  // Standard http status codes.
-  kGTMSessionFetcherStatusNotModified = 304,
-  kGTMSessionFetcherStatusBadRequest = 400,
-  kGTMSessionFetcherStatusUnauthorized = 401,
-  kGTMSessionFetcherStatusForbidden = 403,
-  kGTMSessionFetcherStatusPreconditionFailed = 412
+typedef NS_ENUM(NSInteger, GTMSessionFetcherError) {
+  GTMSessionFetcherErrorDownloadFailed = -1,
+  GTMSessionFetcherErrorUploadChunkUnavailable = -2,
+  GTMSessionFetcherErrorBackgroundExpiration = -3,
+  GTMSessionFetcherErrorBackgroundFetchFailed = -4,
+  GTMSessionFetcherErrorInsecureRequest = -5,
+  GTMSessionFetcherErrorTaskCreationFailed = -6,
 };
+
+typedef NS_ENUM(NSInteger, GTMSessionFetcherStatus) {
+  // Standard http status codes.
+  GTMSessionFetcherStatusNotModified = 304,
+  GTMSessionFetcherStatusBadRequest = 400,
+  GTMSessionFetcherStatusUnauthorized = 401,
+  GTMSessionFetcherStatusForbidden = 403,
+  GTMSessionFetcherStatusPreconditionFailed = 412
+};
+
+#if !GTMSESSION_DEPRECATE_OLD_ENUMS
+#define kGTMSessionFetcherErrorDownloadFailed         GTMSessionFetcherErrorDownloadFailed
+#define kGTMSessionFetcherErrorUploadChunkUnavailable GTMSessionFetcherErrorUploadChunkUnavailable
+#define kGTMSessionFetcherErrorBackgroundExpiration   GTMSessionFetcherErrorBackgroundExpiration
+#define kGTMSessionFetcherErrorBackgroundFetchFailed  GTMSessionFetcherErrorBackgroundFetchFailed
+#define kGTMSessionFetcherErrorInsecureRequest        GTMSessionFetcherErrorInsecureRequest
+#define kGTMSessionFetcherErrorTaskCreationFailed     GTMSessionFetcherErrorTaskCreationFailed
+
+#define kGTMSessionFetcherStatusNotModified        GTMSessionFetcherStatusNotModified
+#define kGTMSessionFetcherStatusBadRequest         GTMSessionFetcherStatusBadRequest
+#define kGTMSessionFetcherStatusUnauthorized       GTMSessionFetcherStatusUnauthorized
+#define kGTMSessionFetcherStatusForbidden          GTMSessionFetcherStatusForbidden
+#define kGTMSessionFetcherStatusPreconditionFailed GTMSessionFetcherStatusPreconditionFailed
+#endif  // !GTMSESSION_DEPRECATE_OLD_ENUMS
 
 #ifdef __cplusplus
 extern "C" {
@@ -611,6 +630,10 @@ NSData *GTMDataFromInputStream(NSInputStream *inputStream, NSError **outError);
 
 // The human-readable description to be assigned to the task.
 @property(copy, GTM_NULLABLE) NSString *taskDescription;
+
+// The priority assigned to the task, if any.  Use NSURLSessionTaskPriorityLow,
+// NSURLSessionTaskPriorityDefault, or NSURLSessionTaskPriorityHigh.
+@property(assign) float taskPriority;
 
 // The fetcher encodes information used to resume a session in the session identifier.
 // This method, intended for internal use returns the encoded information.  The sessionUserInfo

--- a/Source/GTMSessionFetcherLogViewController.m
+++ b/Source/GTMSessionFetcherLogViewController.m
@@ -144,7 +144,7 @@ static NSString *const kHTTPLogsCell = @"kGTMHTTPLogsCell";
     didSelectRowAtIndexPath:(NSIndexPath *)indexPath {
   NSURL *folderURL = [logsFolderURLs_ objectAtIndex:indexPath.row];
   NSString *htmlName = [GTMSessionFetcher htmlFileName];
-  NSURL *htmlURL = [folderURL URLByAppendingPathComponent:htmlName];
+  NSURL *htmlURL = [folderURL URLByAppendingPathComponent:htmlName isDirectory:NO];
 
   // Show the webview controller.
   NSString *title = [self shortenedNameForURL:folderURL];

--- a/Source/UnitTests/GTMSessionFetcherChunkedUploadTest.m
+++ b/Source/UnitTests/GTMSessionFetcherChunkedUploadTest.m
@@ -81,7 +81,7 @@
   //
   NSData *bigUploadData = [GTMSessionFetcherTestServer generatedBodyDataWithLength:333];
   __block NSRange uploadedRange = NSMakeRange(0, 0);
-  NSRange expectedRange = NSMakeRange(0, [bigUploadData length]);
+  NSRange expectedRange = NSMakeRange(0, bigUploadData.length);
 
   fetcher = [GTMSessionUploadFetcher uploadFetcherWithRequest:request
                                                uploadMIMEType:@"text/plain"
@@ -107,12 +107,14 @@
   fetcher.useBackgroundSession = NO;
   fetcher.allowedInsecureSchemes = @[ @"http" ];
 
+  XCTestExpectation *expectation = [self expectationWithDescription:@"fetched"];
   [fetcher beginFetchWithCompletionHandler:^(NSData *data, NSError *error) {
       XCTAssertEqualObjects(data, fakedResultData);
       XCTAssertNil(error);
       XCTAssertEqual(fetcher.statusCode, (NSInteger)200);
+      [expectation fulfill];
   }];
-  XCTAssertTrue([fetcher waitForCompletionWithTimeout:_timeoutInterval], @"timed out");
+  [self waitForExpectationsWithTimeout:_timeoutInterval handler:nil];
   XCTAssertTrue(NSEqualRanges(uploadedRange, expectedRange), @"Uploaded %@ (expected %@)",
                 NSStringFromRange(uploadedRange), NSStringFromRange(expectedRange));
   [self assertCallbacksReleasedForFetcher:fetcher];
@@ -228,12 +230,14 @@ static void TestProgressBlock(GTMSessionUploadFetcher *fetcher,
                         @"UploadTest (GTMSUF/1)",
                         @"%@", fetcher.mutableRequest.allHTTPHeaderFields);
 
+  XCTestExpectation *expectation = [self expectationWithDescription:@"fetched"];
   [fetcher beginFetchWithCompletionHandler:^(NSData *data, NSError *error) {
       XCTAssertEqualObjects(data, [self gettysburgAddress]);
       XCTAssertNil(error);
       XCTAssertEqual(fetcher.statusCode, (NSInteger)200);
+      [expectation fulfill];
   }];
-  XCTAssertTrue([fetcher waitForCompletionWithTimeout:_timeoutInterval], @"timed out");
+  [self waitForExpectationsWithTimeout:_timeoutInterval handler:nil];
   [self assertCallbacksReleasedForFetcher:fetcher];
 
   [self assertSmallUploadFetchNotificationsWithCounter:fnctr];
@@ -262,7 +266,7 @@ static void TestProgressBlock(GTMSessionUploadFetcher *fetcher,
                                                                         uploadMIMEType:@"text/plain"
                                                                              chunkSize:75000
                                                                         fetcherService:_service];
-  [fetcher setUploadDataLength:[smallData length]
+  [fetcher setUploadDataLength:smallData.length
                       provider:^(int64_t offset, int64_t length,
                                  GTMSessionUploadFetcherDataProviderResponse response) {
       NSRange range = NSMakeRange((NSUInteger)offset, (NSUInteger)length);
@@ -281,12 +285,14 @@ static void TestProgressBlock(GTMSessionUploadFetcher *fetcher,
                         expectedUserAgent,
                         @"%@", fetcher.mutableRequest.allHTTPHeaderFields);
 
+  XCTestExpectation *expectation = [self expectationWithDescription:@"fetched"];
   [fetcher beginFetchWithCompletionHandler:^(NSData *data, NSError *error) {
       XCTAssertEqualObjects(data, [self gettysburgAddress]);
       XCTAssertNil(error);
       XCTAssertEqual(fetcher.statusCode, (NSInteger)200);
+      [expectation fulfill];
   }];
-  XCTAssertTrue([fetcher waitForCompletionWithTimeout:_timeoutInterval], @"timed out");
+  [self waitForExpectationsWithTimeout:_timeoutInterval handler:nil];
   [self assertCallbacksReleasedForFetcher:fetcher];
 
   [self assertSmallUploadFetchNotificationsWithCounter:fnctr];
@@ -311,7 +317,7 @@ static void TestProgressBlock(GTMSessionUploadFetcher *fetcher,
                                                                         uploadMIMEType:@"text/plain"
                                                                              chunkSize:75000
                                                                         fetcherService:_service];
-  [fetcher setUploadDataLength:[smallData length]
+  [fetcher setUploadDataLength:smallData.length
                       provider:^(int64_t offset, int64_t length,
                                  GTMSessionUploadFetcherDataProviderResponse response) {
     // Fail to provide NSData.
@@ -324,11 +330,13 @@ static void TestProgressBlock(GTMSessionUploadFetcher *fetcher,
   fetcher.useBackgroundSession = NO;
   fetcher.allowLocalhostRequest = YES;
 
+  XCTestExpectation *expectation = [self expectationWithDescription:@"fetched"];
   [fetcher beginFetchWithCompletionHandler:^(NSData *data, NSError *error) {
       XCTAssertNil(data);
-      XCTAssertEqual([error code], -123);
+      XCTAssertEqual(error.code, -123);
+      [expectation fulfill];
   }];
-  XCTAssertTrue([fetcher waitForCompletionWithTimeout:_timeoutInterval], @"timed out");
+  [self waitForExpectationsWithTimeout:_timeoutInterval handler:nil];
   [self assertCallbacksReleasedForFetcher:fetcher];
 
   XCTAssertEqual(fnctr.fetchStarted, 1);
@@ -412,13 +420,15 @@ static void TestProgressBlock(GTMSessionUploadFetcher *fetcher,
   fetcher.useBackgroundSession = NO;
   fetcher.allowLocalhostRequest = YES;
 
+  XCTestExpectation *expectation = [self expectationWithDescription:@"fetched"];
   [fetcher beginFetchWithCompletionHandler:^(NSData *data, NSError *error) {
       XCTAssertEqualObjects(data, [self gettysburgAddress]);
       XCTAssertNil(error);
       XCTAssertEqual(fetcher.statusCode, (NSInteger)200);
+      [expectation fulfill];
   }];
 
-  XCTAssertTrue([fetcher waitForCompletionWithTimeout:_timeoutInterval], @"timed out");
+  [self waitForExpectationsWithTimeout:_timeoutInterval handler:nil];
   [self assertCallbacksReleasedForFetcher:fetcher];
 
   [self assertBigUploadFetchNotificationsWithCounter:fnctr];
@@ -449,13 +459,15 @@ static void TestProgressBlock(GTMSessionUploadFetcher *fetcher,
   fetcher.useBackgroundSession = NO;
   fetcher.allowLocalhostRequest = YES;
 
+  XCTestExpectation *expectation = [self expectationWithDescription:@"fetched"];
   [fetcher beginFetchWithCompletionHandler:^(NSData *data, NSError *error) {
       XCTAssertEqualObjects(data, [self gettysburgAddress]);
       XCTAssertNil(error);
       XCTAssertEqual(fetcher.statusCode, (NSInteger)200);
+      [expectation fulfill];
   }];
 
-  XCTAssertTrue([fetcher waitForCompletionWithTimeout:_timeoutInterval], @"timed out");
+  [self waitForExpectationsWithTimeout:_timeoutInterval handler:nil];
   [self assertCallbacksReleasedForFetcher:fetcher];
 
   [self assertBigUploadFetchNotificationsWithCounter:fnctr];
@@ -487,13 +499,15 @@ static void TestProgressBlock(GTMSessionUploadFetcher *fetcher,
   fetcher.useBackgroundSession = NO;
   fetcher.allowLocalhostRequest = YES;
 
+  XCTestExpectation *expectation = [self expectationWithDescription:@"fetched"];
   [fetcher beginFetchWithCompletionHandler:^(NSData *data, NSError *error) {
       XCTAssertEqualObjects(data, [self gettysburgAddress]);
       XCTAssertNil(error);
       XCTAssertEqual(fetcher.statusCode, (NSInteger)200);
+      [expectation fulfill];
   }];
 
-  XCTAssertTrue([fetcher waitForCompletionWithTimeout:_timeoutInterval], @"timed out");
+  [self waitForExpectationsWithTimeout:_timeoutInterval handler:nil];
   [self assertCallbacksReleasedForFetcher:fetcher];
 
   NSArray *expectedURLStrings = @[ @"/gettysburgaddress.txt.upload",
@@ -543,13 +557,15 @@ static void TestProgressBlock(GTMSessionUploadFetcher *fetcher,
   fetcher.useBackgroundSession = NO;
   fetcher.allowLocalhostRequest = YES;
 
+  XCTestExpectation *expectation = [self expectationWithDescription:@"fetched"];
   [fetcher beginFetchWithCompletionHandler:^(NSData *data, NSError *error) {
       XCTAssertEqualObjects(data, [self gettysburgAddress]);
       XCTAssertNil(error);
       XCTAssertEqual(fetcher.statusCode, (NSInteger)200);
+      [expectation fulfill];
   }];
 
-  XCTAssertTrue([fetcher waitForCompletionWithTimeout:_timeoutInterval], @"timed out");
+  [self waitForExpectationsWithTimeout:_timeoutInterval handler:nil];
   [self assertCallbacksReleasedForFetcher:fetcher];
 
   // Check that we uploaded the expected chunks.
@@ -591,13 +607,15 @@ static void TestProgressBlock(GTMSessionUploadFetcher *fetcher,
   fetcher.useBackgroundSession = NO;
   fetcher.allowLocalhostRequest = YES;
 
+  XCTestExpectation *expectation = [self expectationWithDescription:@"fetched"];
   [fetcher beginFetchWithCompletionHandler:^(NSData *data, NSError *error) {
-    XCTAssertEqualObjects(data, [self gettysburgAddress]);
-    XCTAssertNil(error);
-    XCTAssertEqual(fetcher.statusCode, (NSInteger)200);
+      XCTAssertEqualObjects(data, [self gettysburgAddress]);
+      XCTAssertNil(error);
+      XCTAssertEqual(fetcher.statusCode, (NSInteger)200);
+      [expectation fulfill];
   }];
 
-  XCTAssertTrue([fetcher waitForCompletionWithTimeout:_timeoutInterval], @"timed out");
+  [self waitForExpectationsWithTimeout:_timeoutInterval handler:nil];
   [self assertCallbacksReleasedForFetcher:fetcher];
 
   // Chunk length is constrained to a sane buffer size.
@@ -618,21 +636,25 @@ static void TestProgressBlock(GTMSessionUploadFetcher *fetcher,
 }
 
 - (void)testBigFileURLResumeUploadFetch {
+  // Force a query that will resume at 9000 bytes before the file end (status active).
   FetcherNotificationsCounter *fnctr = [[FetcherNotificationsCounter alloc] init];
 
   NSURL *bigFileURL = [self bigFileToUploadURLWithBaseName:NSStringFromSelector(_cmd)];
-  NSString *filename = [NSString stringWithFormat:@"gettysburgaddress.txt.upload?bytesReceived=%lld",
-                        (int64_t)kBigUploadDataLength - 9000];
+  NSString *filename =
+      [NSString stringWithFormat:@"gettysburgaddress.txt.upload?bytesReceived=%lld",
+       (int64_t)kBigUploadDataLength - 9000];
   NSURL *uploadLocationURL = [_testServer localURLForFile:filename];
 
-  GTMSessionUploadFetcher *fetcher = [GTMSessionUploadFetcher uploadFetcherWithLocation:uploadLocationURL
-                                                                         uploadMIMEType:@"text/plain"
-                                                                              chunkSize:5000
-                                                                         fetcherService:_service];
+  GTMSessionUploadFetcher *fetcher =
+      [GTMSessionUploadFetcher uploadFetcherWithLocation:uploadLocationURL
+                                          uploadMIMEType:@"text/plain"
+                                               chunkSize:5000
+                                          fetcherService:_service];
   fetcher.uploadFileURL = bigFileURL;
   fetcher.useBackgroundSession = NO;
   fetcher.allowLocalhostRequest = YES;
 
+  XCTestExpectation *expectation = [self expectationWithDescription:@"fetched"];
   [fetcher beginFetchWithCompletionHandler:^(NSData *data, NSError *error) {
       XCTAssertEqualObjects(data, [self gettysburgAddress]);
       XCTAssertNil(error);
@@ -645,14 +667,89 @@ static void TestProgressBlock(GTMSessionUploadFetcher *fetcher,
                             @"195000");
       XCTAssertEqualObjects([lastChunkRequestHdrs objectForKey:@"X-Goog-Upload-Command"],
                             @"upload, finalize");
+      [expectation fulfill];
   }];
-  XCTAssertTrue([fetcher waitForCompletionWithTimeout:_timeoutInterval], @"timed out");
+  [self waitForExpectationsWithTimeout:_timeoutInterval handler:nil];
   [self assertCallbacksReleasedForFetcher:fetcher];
 
   XCTAssertEqual(fnctr.fetchStarted, 3);
   XCTAssertEqual(fnctr.fetchStopped, 3);
   XCTAssertEqual(fnctr.uploadChunkFetchStarted, 3);
   XCTAssertEqual(fnctr.uploadChunkFetchStopped, 3);
+  XCTAssertEqual(fnctr.retryDelayStarted, 0);
+  XCTAssertEqual(fnctr.retryDelayStopped, 0);
+  XCTAssertEqual(fnctr.uploadLocationObtained, 0);
+
+  [self removeTemporaryFileURL:bigFileURL];
+}
+
+- (void)testBigFileURLQueryFinalUploadFetch {
+  // Force a query that indicates the upload was done (status final.)
+  FetcherNotificationsCounter *fnctr = [[FetcherNotificationsCounter alloc] init];
+
+  NSURL *bigFileURL = [self bigFileToUploadURLWithBaseName:NSStringFromSelector(_cmd)];
+  NSString *filename = @"gettysburgaddress.txt.upload?queryStatus=final";
+  NSURL *uploadLocationURL = [_testServer localURLForFile:filename];
+
+  GTMSessionUploadFetcher *fetcher =
+      [GTMSessionUploadFetcher uploadFetcherWithLocation:uploadLocationURL
+                                          uploadMIMEType:@"text/plain"
+                                               chunkSize:5000
+                                          fetcherService:_service];
+  fetcher.uploadFileURL = bigFileURL;
+  fetcher.useBackgroundSession = NO;
+  fetcher.allowLocalhostRequest = YES;
+
+  XCTestExpectation *expectation = [self expectationWithDescription:@"fetched"];
+  [fetcher beginFetchWithCompletionHandler:^(NSData *data, NSError *error) {
+      XCTAssertEqualObjects(data, [self gettysburgAddress]);
+      XCTAssertNil(error);
+      [expectation fulfill];
+  }];
+  [self waitForExpectationsWithTimeout:_timeoutInterval handler:nil];
+  [self assertCallbacksReleasedForFetcher:fetcher];
+
+  XCTAssertEqual(fnctr.fetchStarted, 1);
+  XCTAssertEqual(fnctr.fetchStopped, 1);
+  XCTAssertEqual(fnctr.uploadChunkFetchStarted, 1);
+  XCTAssertEqual(fnctr.uploadChunkFetchStopped, 1);
+  XCTAssertEqual(fnctr.retryDelayStarted, 0);
+  XCTAssertEqual(fnctr.retryDelayStopped, 0);
+  XCTAssertEqual(fnctr.uploadLocationObtained, 0);
+
+  [self removeTemporaryFileURL:bigFileURL];
+}
+
+- (void)testBigFileURLQueryCanceledUploadFetch {
+  // Force a query that indicates the upload was abandoned (status cancelled.)
+  FetcherNotificationsCounter *fnctr = [[FetcherNotificationsCounter alloc] init];
+
+  NSURL *bigFileURL = [self bigFileToUploadURLWithBaseName:NSStringFromSelector(_cmd)];
+  NSString *filename = @"gettysburgaddress.txt.upload?queryStatus=cancelled";
+  NSURL *uploadLocationURL = [_testServer localURLForFile:filename];
+
+  GTMSessionUploadFetcher *fetcher =
+      [GTMSessionUploadFetcher uploadFetcherWithLocation:uploadLocationURL
+                                          uploadMIMEType:@"text/plain"
+                                               chunkSize:5000
+                                          fetcherService:_service];
+  fetcher.uploadFileURL = bigFileURL;
+  fetcher.useBackgroundSession = NO;
+  fetcher.allowLocalhostRequest = YES;
+
+  XCTestExpectation *expectation = [self expectationWithDescription:@"fetched"];
+  [fetcher beginFetchWithCompletionHandler:^(NSData *data, NSError *error) {
+      XCTAssertEqualObjects(data, [NSData data]);
+      XCTAssertEqual(error.code, (NSInteger)501);
+      [expectation fulfill];
+  }];
+  [self waitForExpectationsWithTimeout:_timeoutInterval handler:nil];
+  [self assertCallbacksReleasedForFetcher:fetcher];
+
+  XCTAssertEqual(fnctr.fetchStarted, 1);
+  XCTAssertEqual(fnctr.fetchStopped, 1);
+  XCTAssertEqual(fnctr.uploadChunkFetchStarted, 1);
+  XCTAssertEqual(fnctr.uploadChunkFetchStopped, 1);
   XCTAssertEqual(fnctr.retryDelayStarted, 0);
   XCTAssertEqual(fnctr.retryDelayStopped, 0);
   XCTAssertEqual(fnctr.uploadLocationObtained, 0);
@@ -674,12 +771,14 @@ static void TestProgressBlock(GTMSessionUploadFetcher *fetcher,
   fetcher.useBackgroundSession = NO;
   fetcher.allowLocalhostRequest = YES;
 
+  XCTestExpectation *expectation = [self expectationWithDescription:@"fetched"];
   [fetcher beginFetchWithCompletionHandler:^(NSData *data, NSError *error) {
       XCTAssertEqualObjects(data, [self gettysburgAddress]);
       XCTAssertNil(error);
       XCTAssertEqual(fetcher.statusCode, (NSInteger)200);
+      [expectation fulfill];
   }];
-  XCTAssertTrue([fetcher waitForCompletionWithTimeout:_timeoutInterval], @"timed out");
+  [self waitForExpectationsWithTimeout:_timeoutInterval handler:nil];
   [self assertCallbacksReleasedForFetcher:fetcher];
 
   [self assertBigUploadFetchNotificationsWithCounter:fnctr];
@@ -703,7 +802,7 @@ static void TestProgressBlock(GTMSessionUploadFetcher *fetcher,
                                                                         uploadMIMEType:@"text/plain"
                                                                              chunkSize:75000
                                                                         fetcherService:_service];
-  [fetcher setUploadDataLength:[bigData length]
+  [fetcher setUploadDataLength:bigData.length
                       provider:^(int64_t offset, int64_t length,
                                  GTMSessionUploadFetcherDataProviderResponse response) {
       NSRange range = NSMakeRange((NSUInteger)offset, (NSUInteger)length);
@@ -713,12 +812,14 @@ static void TestProgressBlock(GTMSessionUploadFetcher *fetcher,
   fetcher.useBackgroundSession = NO;
   fetcher.allowLocalhostRequest = YES;
 
+  XCTestExpectation *expectation = [self expectationWithDescription:@"fetched"];
   [fetcher beginFetchWithCompletionHandler:^(NSData *data, NSError *error) {
       XCTAssertEqualObjects(data, [self gettysburgAddress]);
       XCTAssertNil(error);
       XCTAssertEqual(fetcher.statusCode, (NSInteger)200);
+      [expectation fulfill];
   }];
-  XCTAssertTrue([fetcher waitForCompletionWithTimeout:_timeoutInterval], @"timed out");
+  [self waitForExpectationsWithTimeout:_timeoutInterval handler:nil];
   [self assertCallbacksReleasedForFetcher:fetcher];
 
   [self assertBigUploadFetchNotificationsWithCounter:fnctr];
@@ -758,30 +859,40 @@ static void TestProgressBlock(GTMSessionUploadFetcher *fetcher,
   [fetcher setProperty:@20000
                 forKey:kPauseAtKey];
 
+  XCTestExpectation *expectation = [self expectationWithDescription:@"fetched"];
   [fetcher beginFetchWithCompletionHandler:^(NSData *data, NSError *error) {
       XCTAssertEqualObjects(data, [self gettysburgAddress]);
       XCTAssertNil(error);
       XCTAssertEqual(fetcher.statusCode, (NSInteger)200);
+      [expectation fulfill];
   }];
-  XCTAssertTrue([fetcher waitForCompletionWithTimeout:_timeoutInterval], @"timed out");
+  [self waitForExpectationsWithTimeout:_timeoutInterval handler:nil];
   [self assertCallbacksReleasedForFetcher:fetcher];
 
-  NSArray *expectedURLStrings = @[ @"/gettysburgaddress.txt.upload",
-                                   @"/gettysburgaddress.txt.upload",
-                                   @"/gettysburgaddress.txt.upload",
-                                   @"/gettysburgaddress.txt.upload" ];
-  NSArray *expectedCommands = @[ @"upload",
-                                 @"query",
-                                 @"upload",
-                                 @"upload, finalize" ];
-  NSArray *expectedOffsets = @[ @0,
-                                @0,
-                                @75000,
-                                @150000 ];
-  NSArray *expectedLengths = @[ @75000,
-                                @0,
-                                @75000,
-                                @49000 ];
+  NSArray *expectedURLStrings = @[
+    @"/gettysburgaddress.txt.upload",
+    @"/gettysburgaddress.txt.upload",
+    @"/gettysburgaddress.txt.upload",
+    @"/gettysburgaddress.txt.upload"
+  ];
+  NSArray *expectedCommands = @[
+    @"upload",
+    @"query",
+    @"upload",
+    @"upload, finalize"
+  ];
+  NSArray *expectedOffsets = @[
+    @0,
+    @0,
+    @75000,
+    @150000
+  ];
+  NSArray *expectedLengths = @[
+    @75000,
+    @0,
+    @75000,
+    @49000
+  ];
   XCTAssertEqualObjects(fnctr.uploadChunkRequestPaths, expectedURLStrings);
   XCTAssertEqualObjects(fnctr.uploadChunkCommands, expectedCommands);
   XCTAssertEqualObjects(fnctr.uploadChunkOffsets, expectedOffsets);
@@ -949,11 +1060,13 @@ static void TestProgressBlock(GTMSessionUploadFetcher *fetcher,
   // Our test server looks for zero content length as a cue to prematurely stop the upload.
   [fetcher.mutableRequest setValue:@"0" forHTTPHeaderField:@"X-Goog-Upload-Content-Length"];
 
+  XCTestExpectation *expectation = [self expectationWithDescription:@"fetched"];
   [fetcher beginFetchWithCompletionHandler:^(NSData *data, NSError *error) {
       XCTAssertNil(data);
-      XCTAssertEqual([error code], (NSInteger)501);
+      XCTAssertEqual(error.code, (NSInteger)501);
+      [expectation fulfill];
   }];
-  XCTAssertTrue([fetcher waitForCompletionWithTimeout:_timeoutInterval], @"timed out");
+  [self waitForExpectationsWithTimeout:_timeoutInterval handler:nil];
   [self assertCallbacksReleasedForFetcher:fetcher];
 
   XCTAssertEqual(fnctr.fetchStarted, 1);

--- a/Source/UnitTests/GTMSessionFetcherFetchingTest.m
+++ b/Source/UnitTests/GTMSessionFetcherFetchingTest.m
@@ -1239,7 +1239,7 @@ NSString *const kGTMGettysburgFileName = @"gettysburgaddress.txt";
     NSInteger errorCode;
   };
 
-  const NSInteger kInsecureError = kGTMSessionFetcherErrorInsecureRequest;
+  const NSInteger kInsecureError = GTMSessionFetcherErrorInsecureRequest;
   const NSUInteger kAllowLocalhostFlag = 1UL << 0;
   const NSUInteger kAllowHTTPSchemeFlag = 1UL << 1;
   const NSUInteger kAllowFileSchemeFlag = 1UL << 2;


### PR DESCRIPTION
- Xcode 7 fixups
- Switch over to NSEnum for constants, drop the 'k' (for Swift), and #defines to bridge over.
- Support NSURLSession's task priority in iOS 8/OS X 10.10.
- Evaluate cert trust async on challenges, which hopefully will avoid simultaneous usage of challenge.protectionSpace.serverTrust.
- When memory mapping a file to create an upload chunk fails, always fall back on trying to create a file handle for the file.
- On a query response with "final" status, the client should not expect the X-Goog-Upload-Size-Received header.
- General cleanup/fixup of fetcher's background task handing.