### PR TITLE
Should copy block off stack before returning.

### DIFF
--- a/Source/GTMSessionFetcher.m
+++ b/Source/GTMSessionFetcher.m
@@ -344,7 +344,7 @@ static GTMSessionFetcherTestBlock gGlobalTestBlock;
         [invocation invoke];
       }
   };
-  return completionHandler;
+  return [[completionHandler copy] autorelease];
 }
 
 - (void)beginFetchWithDelegate:(id)target


### PR DESCRIPTION
This fixes a crash.