### PR TITLE
Bug fixing and general improvements

### DIFF
--- a/Source/GTMGatherInputStream.m
+++ b/Source/GTMGatherInputStream.m
@@ -28,7 +28,7 @@
 }
 
 + (NSInputStream *)streamWithArray:(NSArray *)dataArray {
-  return [[self alloc] initWithArray:dataArray];
+  return [(GTMGatherInputStream *)[self alloc] initWithArray:dataArray];
 }
 
 - (instancetype)initWithArray:(NSArray *)dataArray {

--- a/Source/GTMSessionFetcherService.h
+++ b/Source/GTMSessionFetcherService.h
@@ -133,6 +133,7 @@ extern NSString *const kGTMSessionFetcherServiceSessionKey;
 - (GTM_NULLABLE NSURLSession *)session;
 - (GTM_NULLABLE NSURLSession *)sessionForFetcherCreation;
 - (GTM_NULLABLE id<NSURLSessionDelegate>)sessionDelegate;
+- (GTM_NULLABLE NSDate *)stoppedAllFetchersDate;
 
 // The testBlock can inspect its fetcher parameter's mutableRequest property to
 // determine which fetcher is being faked.

--- a/Source/UnitTests/GTMSessionFetcherFetchingTest.h
+++ b/Source/UnitTests/GTMSessionFetcherFetchingTest.h
@@ -76,6 +76,7 @@ extern NSString *const kGTMGettysburgFileName;
 @interface FetcherNotificationsCounter : NSObject
 @property(nonatomic) int fetchStarted;
 @property(nonatomic) int fetchStopped;
+@property(nonatomic) int fetchCompletionInvoked;
 @property(nonatomic) int uploadChunkFetchStarted;  // Includes query fetches.
 @property(nonatomic) int uploadChunkFetchStopped;  // Includes query fetches.
 @property(nonatomic) int retryDelayStarted;

--- a/Source/UnitTests/GTMSessionFetcherFetchingTest.m
+++ b/Source/UnitTests/GTMSessionFetcherFetchingTest.m
@@ -282,6 +282,7 @@ NSString *const kGTMGettysburgFileName = @"gettysburgaddress.txt";
   // Check the notifications.
   XCTAssertEqual(fnctr.fetchStarted, 2);
   XCTAssertEqual(fnctr.fetchStopped, 2);
+  XCTAssertEqual(fnctr.fetchCompletionInvoked, 2);
   XCTAssertEqual(fnctr.uploadChunkFetchStarted, 0);
   XCTAssertEqual(fnctr.uploadChunkFetchStopped, 0);
   XCTAssertEqual(fnctr.retryDelayStarted, 0);
@@ -319,6 +320,7 @@ NSString *const kGTMGettysburgFileName = @"gettysburgaddress.txt";
   // Check the notifications.
   XCTAssertEqual(fnctr.fetchStarted, 1);
   XCTAssertEqual(fnctr.fetchStopped, 1);
+  XCTAssertEqual(fnctr.fetchCompletionInvoked, 1);
   XCTAssertEqual(fnctr.retryDelayStarted, 0);
   XCTAssertEqual(fnctr.retryDelayStopped, 0);
 }
@@ -376,6 +378,7 @@ NSString *const kGTMGettysburgFileName = @"gettysburgaddress.txt";
   // Check the notifications.
   XCTAssertEqual(fnctr.fetchStarted, 2);
   XCTAssertEqual(fnctr.fetchStopped, 2);
+  XCTAssertEqual(fnctr.fetchCompletionInvoked, 2);
   XCTAssertEqual(fnctr.retryDelayStarted, 0);
   XCTAssertEqual(fnctr.retryDelayStopped, 0);
 }
@@ -402,6 +405,7 @@ NSString *const kGTMGettysburgFileName = @"gettysburgaddress.txt";
   // Check the notifications.
   XCTAssertEqual(fnctr.fetchStarted, 0);
   XCTAssertEqual(fnctr.fetchStopped, 0);
+  XCTAssertEqual(fnctr.fetchCompletionInvoked, 1);
 }
 
 - (void)testDataBodyFetch {
@@ -432,6 +436,7 @@ NSString *const kGTMGettysburgFileName = @"gettysburgaddress.txt";
   // Check the notifications.
   XCTAssertEqual(fnctr.fetchStarted, 1);
   XCTAssertEqual(fnctr.fetchStopped, 1);
+  XCTAssertEqual(fnctr.fetchCompletionInvoked, 1);
   XCTAssertEqual(fnctr.retryDelayStarted, 0);
   XCTAssertEqual(fnctr.retryDelayStopped, 0);
 }
@@ -463,6 +468,7 @@ NSString *const kGTMGettysburgFileName = @"gettysburgaddress.txt";
   [self waitForExpectationsWithTimeout:_timeoutInterval
                                handler:nil];
   [self assertCallbacksReleasedForFetcher:fetcher];
+  XCTAssertTrue([fetcher waitForCompletionWithTimeout:_timeoutInterval], @"timed out");
 
   //
   // Setting a specific queue should call back on that queue.
@@ -490,6 +496,7 @@ NSString *const kGTMGettysburgFileName = @"gettysburgaddress.txt";
   [self waitForExpectationsWithTimeout:_timeoutInterval
                                handler:nil];
   [self assertCallbacksReleasedForFetcher:fetcher];
+  XCTAssertTrue([fetcher waitForCompletionWithTimeout:_timeoutInterval], @"timed out");
 }
 
 - (void)testStreamProviderFetch {
@@ -525,6 +532,7 @@ NSString *const kGTMGettysburgFileName = @"gettysburgaddress.txt";
   // Check the notifications.
   XCTAssertEqual(fnctr.fetchStarted, 1);
   XCTAssertEqual(fnctr.fetchStopped, 1);
+  XCTAssertEqual(fnctr.fetchCompletionInvoked, 1);
   XCTAssertEqual(fnctr.retryDelayStarted, 0);
   XCTAssertEqual(fnctr.retryDelayStopped, 0);
 }
@@ -565,6 +573,7 @@ NSString *const kGTMGettysburgFileName = @"gettysburgaddress.txt";
   // Check the notifications.
   XCTAssertEqual(fnctr.fetchStarted, 1);
   XCTAssertEqual(fnctr.fetchStopped, 1);
+  XCTAssertEqual(fnctr.fetchCompletionInvoked, 1);
   XCTAssertEqual(fnctr.retryDelayStarted, 0);
   XCTAssertEqual(fnctr.retryDelayStopped, 0);
 }
@@ -639,6 +648,7 @@ NSString *const kGTMGettysburgFileName = @"gettysburgaddress.txt";
   // Check the notifications.
   XCTAssertEqual(fnctr.fetchStarted, 3);
   XCTAssertEqual(fnctr.fetchStopped, 3);
+  XCTAssertEqual(fnctr.fetchCompletionInvoked, 3);
   XCTAssertEqual(fnctr.retryDelayStarted, 0);
   XCTAssertEqual(fnctr.retryDelayStopped, 0);
 }
@@ -770,6 +780,7 @@ NSString *const kGTMGettysburgFileName = @"gettysburgaddress.txt";
   // Check notifications.
   XCTAssertEqual(fnctr.fetchStarted, 8);
   XCTAssertEqual(fnctr.fetchStopped, 8);
+  XCTAssertEqual(fnctr.fetchCompletionInvoked, 6);
   XCTAssertEqual(fnctr.retryDelayStarted, 2);
   XCTAssertEqual(fnctr.retryDelayStopped, 2);
 }
@@ -832,6 +843,7 @@ NSString *const kGTMGettysburgFileName = @"gettysburgaddress.txt";
   // Check the notifications.
   XCTAssertEqual(fnctr.fetchStarted, 1);
   XCTAssertEqual(fnctr.fetchStopped, 1);
+  XCTAssertEqual(fnctr.fetchCompletionInvoked, 1);
   XCTAssertEqual(fnctr.retryDelayStarted, 0);
   XCTAssertEqual(fnctr.retryDelayStopped, 0);
 }
@@ -951,6 +963,7 @@ NSString *const kGTMGettysburgFileName = @"gettysburgaddress.txt";
   // Check the notifications.
   XCTAssertEqual(fnctr.fetchStarted, 11);
   XCTAssertEqual(fnctr.fetchStopped, 11);
+  XCTAssertEqual(fnctr.fetchCompletionInvoked, 4);
   XCTAssertEqual(fnctr.retryDelayStarted, 7);
   XCTAssertEqual(fnctr.retryDelayStopped, 7);
 }
@@ -1010,6 +1023,7 @@ NSString *const kGTMGettysburgFileName = @"gettysburgaddress.txt";
   // Check the notifications.
   XCTAssertEqual(fnctr.fetchStarted, 1);
   XCTAssertEqual(fnctr.fetchStopped, 1);
+  XCTAssertEqual(fnctr.fetchCompletionInvoked, 1);
   XCTAssertEqual(fnctr.retryDelayStarted, 0);
   XCTAssertEqual(fnctr.retryDelayStopped, 0);
 }
@@ -1047,6 +1061,7 @@ NSString *const kGTMGettysburgFileName = @"gettysburgaddress.txt";
   // Check the notifications.
   XCTAssertEqual(fnctr.fetchStarted, 1);
   XCTAssertEqual(fnctr.fetchStopped, 1);
+  XCTAssertEqual(fnctr.fetchCompletionInvoked, 1);
   XCTAssertEqual(fnctr.retryDelayStarted, 0);
   XCTAssertEqual(fnctr.retryDelayStopped, 0);
 }
@@ -1109,6 +1124,7 @@ NSString *const kGTMGettysburgFileName = @"gettysburgaddress.txt";
   // Check the notifications.
   XCTAssertEqual(fnctr.fetchStarted, 1);
   XCTAssertEqual(fnctr.fetchStopped, 1);
+  XCTAssertEqual(fnctr.fetchCompletionInvoked, 1);
   XCTAssertEqual(fnctr.retryDelayStarted, 0);
   XCTAssertEqual(fnctr.retryDelayStopped, 0);
 }
@@ -1130,6 +1146,7 @@ NSString *const kGTMGettysburgFileName = @"gettysburgaddress.txt";
   }
   XCTAssertEqual(fnctr.fetchStarted, kFetcherCreationCount);
   XCTAssertEqual(fnctr.fetchStopped, kFetcherCreationCount);
+  XCTAssertEqual(fnctr.fetchCompletionInvoked, 0);
 }
 
 - (void)testCancelAndResumeFetchToFile {
@@ -1218,6 +1235,7 @@ NSString *const kGTMGettysburgFileName = @"gettysburgaddress.txt";
   // Check the notifications.
   XCTAssertEqual(fnctr.fetchStarted, 2);
   XCTAssertEqual(fnctr.fetchStopped, 2);
+  XCTAssertEqual(fnctr.fetchCompletionInvoked, 1);
   XCTAssertEqual(fnctr.retryDelayStarted, 0);
   XCTAssertEqual(fnctr.retryDelayStopped, 0);
 }
@@ -1323,6 +1341,7 @@ NSString *const kGTMGettysburgFileName = @"gettysburgaddress.txt";
 
   XCTAssertEqual(fnctr.fetchStarted, 1);
   XCTAssertEqual(fnctr.fetchStopped, 1);
+  XCTAssertEqual(fnctr.fetchCompletionInvoked, 1);
   XCTAssertEqual(fnctr.retryDelayStarted, 0);
   XCTAssertEqual(fnctr.retryDelayStopped, 0);
 }
@@ -1379,6 +1398,7 @@ NSString *const kGTMGettysburgFileName = @"gettysburgaddress.txt";
 
   XCTAssertEqual(fnctr.fetchStarted, 3);
   XCTAssertEqual(fnctr.fetchStopped, 3);
+  XCTAssertEqual(fnctr.fetchCompletionInvoked, 1);
   XCTAssertEqual(fnctr.retryDelayStarted, 3);
   XCTAssertEqual(fnctr.retryDelayStopped, 3);
 }
@@ -1642,6 +1662,7 @@ NSString *const kGTMGettysburgFileName = @"gettysburgaddress.txt";
 
   XCTAssertEqual(fnctr.fetchStarted, 2);
   XCTAssertEqual(fnctr.fetchStopped, 2);
+  XCTAssertEqual(fnctr.fetchCompletionInvoked, 2);
   XCTAssertEqual(fnctr.retryDelayStarted, 0);
   XCTAssertEqual(fnctr.retryDelayStopped, 0);
 
@@ -1778,6 +1799,10 @@ NSString *const kGTMGettysburgFileName = @"gettysburgaddress.txt";
                name:kGTMSessionFetcherStoppedNotification
              object:nil];
     [nc addObserver:self
+           selector:@selector(fetchCompletionInvoked:)
+               name:kGTMSessionFetcherCompletionInvokedNotification
+             object:nil];
+    [nc addObserver:self
            selector:@selector(retryDelayStateChanged:)
                name:kGTMSessionFetcherRetryDelayStartedNotification
              object:nil];
@@ -1827,6 +1852,10 @@ NSString *const kGTMGettysburgFileName = @"gettysburgaddress.txt";
 
   NSAssert(_fetchStopped <= _fetchStarted, @"fetch notification imbalance: starts=%d stops=%d",
            (int)_fetchStarted, (int)_fetchStopped);
+}
+
+- (void)fetchCompletionInvoked:(NSNotification *)note {
+  ++_fetchCompletionInvoked;
 }
 
 - (void)retryDelayStateChanged:(NSNotification *)note {

--- a/Source/UnitTests/GTMSessionFetcherServiceTest.m
+++ b/Source/UnitTests/GTMSessionFetcherServiceTest.m
@@ -296,10 +296,13 @@ static NSString *const kValidFileName = @"gettysburgaddress.txt";
   localhosts = [service.delayedFetchersByHost objectForKey:@"localhost"];
   XCTAssertEqual([localhosts count], (NSUInteger)1, @"hosts delayed");
 
+  XCTAssertNil(service.stoppedAllFetchersDate);
+
   [service stopAllFetchers];
 
   XCTAssertEqual([service.runningFetchersByHost count], (NSUInteger)0, @"hosts running");
   XCTAssertEqual([service.delayedFetchersByHost count], (NSUInteger)0, @"hosts delayed");
+  XCTAssertNotNil(service.stoppedAllFetchersDate);
 }
 
 - (void)testSessionReuse {


### PR DESCRIPTION
- Add a time barrier so stopAllFetchers works for queued callbacks.
- Track if a fetcher was created from a background session and fixup asserts checking internal state.
- Completed upload fetchers might not have a Content-Length.
- Mark unused variable to support NS_BLOCK_ASSERTIONS.
- Avoid deadlock by starting a delayed fetcher outside the fetcher service @synchronized(self) block.
- Add a notification when a fetcher's completion handler is invoked. This is primarily to support record-and-replay test scenarios.