### PR TITLE
Small tweaks

### DIFF
--- a/Source/GTMSessionFetcher.h
+++ b/Source/GTMSessionFetcher.h
@@ -347,13 +347,22 @@ extern NSString *const kGTMSessionFetcherCompletionInvokedNotification;
 extern NSString *const kGTMSessionFetcherCompletionDataKey;
 extern NSString *const kGTMSessionFetcherCompletionErrorKey;
 
-// Constants for NSErrors created by the fetcher.
+// Constants for NSErrors created by the fetcher (excluding server status errors,
+// and error objects originating in the OS.)
 extern NSString *const kGTMSessionFetcherErrorDomain;
 
 // The fetcher turns server error status values (3XX, 4XX, 5XX) into NSErrors
 // with domain kGTMSessionFetcherStatusDomain.
+//
+// Any server response body data accompanying the status error is added to the
+// userInfo dictionary with key kGTMSessionFetcherStatusDataKey.
 extern NSString *const kGTMSessionFetcherStatusDomain;
-extern NSString *const kGTMSessionFetcherStatusDataKey;  // data returned with a kGTMSessionFetcherStatusDomain error
+extern NSString *const kGTMSessionFetcherStatusDataKey;
+
+// When a fetch fails with an error, these keys are included in the error userInfo
+// dictionary if retries were attempted.
+extern NSString *const kGTMSessionFetcherNumberOfRetriesDoneKey;
+extern NSString *const kGTMSessionFetcherElapsedIntervalWithRetriesKey;
 
 // Background session support requires access to NSUserDefaults.
 // If [NSUserDefaults standardUserDefaults] doesn't yield the correct NSUserDefaults for your usage,
@@ -885,6 +894,7 @@ NSData *GTMDataFromInputStream(NSInputStream *inputStream, NSError **outError);
 // Local path to which the downloaded file will be moved.
 //
 // If a file already exists at the path, it will be overwritten.
+// Will create the enclosing folders if they are not present.
 @property(strong, GTM_NULLABLE) NSURL *destinationFileURL;
 
 // userData is retained solely for the convenience of the client.

--- a/Source/UnitTests/GTMSessionFetcherFetchingTest.m
+++ b/Source/UnitTests/GTMSessionFetcherFetchingTest.m
@@ -350,6 +350,11 @@ NSString *const kGTMGettysburgFileName = @"gettysburgaddress.txt";
       }
       XCTAssertNotNil(error);
       XCTAssertEqual(fetcher.statusCode, (NSInteger)0);
+
+      NSNumber *retriesDone = error.userInfo[kGTMSessionFetcherNumberOfRetriesDoneKey];
+      NSNumber *elapsedInterval = error.userInfo[kGTMSessionFetcherElapsedIntervalWithRetriesKey];
+      XCTAssertNil(retriesDone);
+      XCTAssertNil(elapsedInterval);
   }];
   XCTAssertTrue([fetcher waitForCompletionWithTimeout:_timeoutInterval], @"timed out");
   [self assertCallbacksReleasedForFetcher:fetcher];
@@ -912,6 +917,11 @@ NSString *const kGTMGettysburgFileName = @"gettysburgaddress.txt";
       XCTAssertNotNil(data, @"error data is expected");
       XCTAssertEqual(fetcher.statusCode, (NSInteger)503);
       XCTAssertEqual(fetcher.retryCount, (NSUInteger)3);
+
+      NSNumber *retriesDone = error.userInfo[kGTMSessionFetcherNumberOfRetriesDoneKey];
+      NSNumber *elapsedInterval = error.userInfo[kGTMSessionFetcherElapsedIntervalWithRetriesKey];
+      XCTAssertEqual(retriesDone.integerValue, 3);
+      XCTAssertGreaterThan(elapsedInterval.doubleValue, 0);
    }];
   XCTAssertTrue([fetcher waitForCompletionWithTimeout:_timeoutInterval], @"timed out");
   [self assertCallbacksReleasedForFetcher:fetcher];
@@ -931,6 +941,11 @@ NSString *const kGTMGettysburgFileName = @"gettysburgaddress.txt";
       XCTAssertNil(data, @"error data unexpected");
       XCTAssertEqual(fetcher.statusCode, (NSInteger)408, @"%@", error);
       XCTAssertEqual(fetcher.retryCount, (NSUInteger)1);
+
+      NSNumber *retriesDone = error.userInfo[kGTMSessionFetcherNumberOfRetriesDoneKey];
+      NSNumber *elapsedInterval = error.userInfo[kGTMSessionFetcherElapsedIntervalWithRetriesKey];
+      XCTAssertEqual(retriesDone.integerValue, 1);
+      XCTAssertGreaterThan(elapsedInterval.doubleValue, 0);
   }];
   XCTAssertTrue([fetcher waitForCompletionWithTimeout:_timeoutInterval], @"timed out");
   [self assertCallbacksReleasedForFetcher:fetcher];
@@ -946,6 +961,11 @@ NSString *const kGTMGettysburgFileName = @"gettysburgaddress.txt";
       XCTAssertNotNil(data);
       XCTAssertEqual(fetcher.statusCode, (NSInteger)503, @"%@", error);
       XCTAssertEqual(fetcher.retryCount, (NSUInteger)2);
+
+      NSNumber *retriesDone = error.userInfo[kGTMSessionFetcherNumberOfRetriesDoneKey];
+      NSNumber *elapsedInterval = error.userInfo[kGTMSessionFetcherElapsedIntervalWithRetriesKey];
+      XCTAssertEqual(retriesDone.integerValue, 2);
+      XCTAssertGreaterThan(elapsedInterval.doubleValue, 0);
   }];
   XCTAssertTrue([fetcher waitForCompletionWithTimeout:_timeoutInterval], @"timed out");
   [self assertCallbacksReleasedForFetcher:fetcher];
@@ -1393,7 +1413,10 @@ NSString *const kGTMGettysburgFileName = @"gettysburgaddress.txt";
   };
 
   [fetcher beginFetchWithCompletionHandler:^(NSData *data, NSError *error) {
-      XCTAssertEqualObjects(error, fakedResultError);
+      XCTAssertEqualObjects(error.domain, fakedResultError.domain);
+      XCTAssertEqual(error.code, fakedResultError.code);
+      XCTAssertEqualObjects(error.userInfo[kGTMSessionFetcherStatusDataKey],
+                            fakedResultError.userInfo[kGTMSessionFetcherStatusDataKey]);
       XCTAssertNil(data);
       XCTAssertEqual(fetcher.statusCode, fakedResultResponse.statusCode);
       XCTAssertEqualObjects(fetcher.responseHeaders[@"Alaskan"], @"Malamute");


### PR DESCRIPTION
- When moving a downloaded file from its temp folder, if it fails because the
  destination folders are not present, create them first and try again.
- Provide number of retries and elapsed time interval with retries in fetcher
  error userInfo. This should make apparent to developers when failed errors
  were actually retried by the fetcher.