### PR TITLE
Fix possible deadlock and clarify configuration support

### DIFF
--- a/Source/GTMSessionFetcher.h
+++ b/Source/GTMSessionFetcher.h
@@ -456,6 +456,8 @@ extern "C" {
 @class GTMSessionCookieStorage;
 @class GTMSessionFetcher;
 
+// The configuration block is for modifying the NSURLSessionConfiguration only.
+// DO NOT change any fetcher properties in the configuration block.
 typedef void (^GTMSessionFetcherConfigurationBlock)(GTMSessionFetcher *fetcher,
                                                     NSURLSessionConfiguration *configuration);
 typedef void (^GTMSessionFetcherSystemCompletionHandler)(void);
@@ -672,6 +674,11 @@ NSData *GTMDataFromInputStream(NSInputStream *inputStream, NSError **outError);
 // This is called synchronously, either on the thread that begins the fetch or, during a retry,
 // on the main thread. The configuration block may be called repeatedly if multiple fetchers are
 // created.
+//
+// The configuration block is for modifying the NSURLSessionConfiguration only.
+// DO NOT change any fetcher properties in the configuration block. Fetcher properties
+// may be set in the fetcher service prior to fetcher creation, or on the fetcher prior
+// to invoking beginFetch.
 @property(copy, GTM_NULLABLE) GTMSessionFetcherConfigurationBlock configurationBlock;
 
 // A session is created as needed by the fetcher.  A fetcher service object

--- a/Source/GTMSessionFetcher.m
+++ b/Source/GTMSessionFetcher.m
@@ -2066,6 +2066,8 @@ didReceiveChallenge:(NSURLAuthenticationChallenge *)challenge
   if (callbackQueue) {
     dispatch_group_async(_callbackGroup, callbackQueue, ^{
         if (!afterStopped) {
+          NSDate *serviceStoppedAllDate = [_service stoppedAllFetchersDate];
+
           @synchronized(self) {
             GTMSessionMonitorSynchronized(self);
 
@@ -2079,7 +2081,6 @@ didReceiveChallenge:(NSURLAuthenticationChallenge *)challenge
             // stopAllFetchers was invoked, so _userStoppedFetching wasn't set,
             // but the app still won't expect the callback to fire after
             // the service's stopAllFetchers was invoked.
-            NSDate *serviceStoppedAllDate = [_service stoppedAllFetchersDate];
             if (serviceStoppedAllDate
                 && [_initialBeginFetchDate compare:serviceStoppedAllDate] != NSOrderedDescending) {
               // stopAllFetchers was called after this fetcher began.
@@ -3022,6 +3023,7 @@ static NSMutableDictionary *gSystemCompletionHandlers = nil;
             sessionTask = _sessionTask,
             sessionUserInfo = _sessionUserInfo,
             taskDescription = _taskDescription,
+            taskPriority = _taskPriority,
             useBackgroundSession = _useBackgroundSession,
             canShareSession = _canShareSession,
             completionHandler = _completionHandler,


### PR DESCRIPTION
Move a call to the service from invokeOnCallbackQueue:afterUserStopped:block:
to outside of the @sync block, as that opens the window for a deadlock.
_service is immutable after fetcher creation, so does not need to be protected
by the @sync.

Add a comment clarifying that the configurationBlock is only for updating the
NSURLConfiguration, not for setting fetcher properties. Changing fetcher
properties in the config block can have unintended consequences for secondary
fetchers (like auth fetches and upload query or chunk fetches) which have been
set up before the config block is invoked.