### PR TITLE
Update GTMSessionFetcher.podspec

### DIFF
--- a/GTMSessionFetcher.podspec
+++ b/GTMSessionFetcher.podspec
@@ -1,7 +1,7 @@
 # This file specifies the Pod setup for GTMSessionFetcher. It enables developers 
 # to import GTMSessionFetcher via the CocoaPods dependency Manager.
 Pod::Spec.new do |s|
-  s.name        = 'GTMSessionFetcher'
+  s.name        = 'gtm-session-fetcher'
   s.version     = '1.1.0'
   s.authors     = 'Google Inc.'
   s.license     = { :type => 'Apache', :file => 'LICENSE' }


### PR DESCRIPTION
Maybe it would be a good idea to follow the naming convention for the other Google pods (like gtm-oauth2, gtm-http-fetcher).