### PR TITLE
Fix up races in backgroundTask handing, add tests.

### DIFF
--- a/Source/GTMSessionFetcher.h
+++ b/Source/GTMSessionFetcher.h
@@ -664,6 +664,16 @@ NSData * GTM_NULLABLE_TYPE GTMDataFromInputStream(NSInputStream *inputStream, NS
 @end
 #endif  // GTM_FETCHER_AUTHORIZATION_PROTOCOL
 
+#if TARGET_OS_IPHONE
+// A protocol for an alternative target for messages from GTMSessionFetcher to UIApplication.
+// Set the target using +[GTMSessionFetcher setSubstituteUIApplication:]
+@protocol GTMUIApplicationProtocol <NSObject>
+- (UIBackgroundTaskIdentifier)beginBackgroundTaskWithName:(nullable NSString *)taskName
+                                        expirationHandler:(void(^ __nullable)(void))handler;
+- (void)endBackgroundTask:(UIBackgroundTaskIdentifier)identifier;
+@end
+#endif
+
 #pragma mark -
 
 // GTMSessionFetcher objects are used for async retrieval of an http get or post
@@ -1059,6 +1069,13 @@ NSData * GTM_NULLABLE_TYPE GTMDataFromInputStream(NSInputStream *inputStream, NS
 @property(copy, GTM_NULLABLE) GTMSessionFetcherTestBlock testBlock;
 
 + (void)setGlobalTestBlock:(GTM_NULLABLE GTMSessionFetcherTestBlock)block;
+
+#if TARGET_OS_IPHONE
+// For testing or to override UIApplication invocations, apps may specify an alternative
+// target for messages to UIApplication.
++ (void)setSubstituteUIApplication:(nullable id<GTMUIApplicationProtocol>)substituteUIApplication;
++ (nullable id<GTMUIApplicationProtocol>)substituteUIApplication;
+#endif  // TARGET_OS_IPHONE
 
 // Exposed for testing.
 + (GTMSessionCookieStorage *)staticCookieStorage;

--- a/Source/UnitTests/GTMSessionFetcherFetchingTest.h
+++ b/Source/UnitTests/GTMSessionFetcherFetchingTest.h
@@ -23,6 +23,8 @@
 #import "GTMSessionFetcherLogging.h"
 #import "GTMSessionUploadFetcher.h"
 
+GTM_ASSUME_NONNULL_BEGIN
+
 extern NSString *const kGTMGettysburgFileName;
 
 @interface GTMSessionFetcherBaseTest : XCTestCase {
@@ -75,6 +77,32 @@ extern NSString *const kGTMGettysburgFileName;
 
 @end
 
+#if TARGET_OS_IPHONE
+
+// A fake of UIApplication that posts notifications when a background task begins
+// and ends.
+@class SubstituteUIApplicationTaskInfo;
+
+typedef void (^SubstituteUIApplicationExpirationCallback)
+    (NSUInteger numberOfBackgroundTasksToExpire,
+     NSArray <SubstituteUIApplicationTaskInfo *> * _Nullable tasksFailingToExpire);
+
+@interface SubstituteUIApplication : NSObject<GTMUIApplicationProtocol>
+
+- (UIBackgroundTaskIdentifier)beginBackgroundTaskWithName:(nullable NSString *)taskName
+                                        expirationHandler:(nullable dispatch_block_t)handler;
+- (void)endBackgroundTask:(UIBackgroundTaskIdentifier)identifier;
+
+- (void)expireAllBackgroundTasksWithCallback:(SubstituteUIApplicationExpirationCallback)handler;
+
+@end
+
+extern NSString *const kSubUIAppBackgroundTaskBegan;
+extern NSString *const kSubUIAppBackgroundTaskEnded;
+
+#endif  // TARGET_OS_IPHONE
+
+
 @interface FetcherNotificationsCounter : NSObject
 @property(nonatomic) int fetchStarted;
 @property(nonatomic) int fetchStopped;
@@ -93,5 +121,10 @@ extern NSString *const kGTMGettysburgFileName;
 @property(nonatomic) NSMutableArray *fetchersStartedDescriptions; // of NSString
 @property(nonatomic) NSMutableArray *fetchersStoppedDescriptions; // of NSString
 
+@property(nonatomic) NSMutableArray *backgroundTasksStarted;  // of boxed UIBackgroundTaskIdentifier
+@property(nonatomic) NSMutableArray *backgroundTasksEnded;  // of boxed UIBackgroundTaskIdentifier
+
 @end
+
+GTM_ASSUME_NONNULL_END
 


### PR DESCRIPTION
- Fix race conditions that relied on self.backgroundTaskIdentifier remaining
  unchanged until the background expiration block is invoked, as a new
  background task will have already begun for retries.
- Add a fetcher method +setSubstituteUIApplication for injecting a UIApplication
  fake for testing.
- Add a protocol GTMUIApplicationProtocol for the fake application.
- Add a SubstituteUIApplication test class that posts notifications about bgTask
  begin and end invocations and lets us exercise task expiration.
- Stop deferring endBackgroundTask: calls from the fetcher.