### PR TITLE
Start addressing race condition/deadlock issue.

### DIFF
--- a/Source/GTMSessionFetcher.h
+++ b/Source/GTMSessionFetcher.h
@@ -86,7 +86,7 @@
 // be uploaded from a system temporary or cache directory.
 //
 // Background session transfers are slower, and should typically be used only
-// or very large downloads or uploads (hundreds of megabytes).
+// for very large downloads or uploads (hundreds of megabytes).
 //
 // When background sessions are used in iOS apps, the application delegate must
 // pass through the parameters from UIApplicationDelegate's
@@ -134,7 +134,7 @@
 // HTTP methods and headers:
 //
 // Alternative HTTP methods, like PUT, and custom headers can be specified by
-// creating the fetcher with an appropriate NSMutableURLRequest
+// creating the fetcher with an appropriate NSMutableURLRequest.
 //
 //
 // Caching:

--- a/Source/GTMSessionFetcherService.m
+++ b/Source/GTMSessionFetcherService.m
@@ -48,12 +48,11 @@ NSString *const kGTMSessionFetcherServiceSessionKey
 // The session for the tasks in this dispatcher's task-to-fetcher map.
 @property(atomic) NSURLSession *session;
 
-// This semaphore can block access to the session property while another fetcher is creating
-// a session.
-@property(atomic, readonly) dispatch_semaphore_t sessionCreationSemaphore;
-
 // The timer interval for invalidating a session that has no active tasks.
 @property(atomic) NSTimeInterval discardInterval;
+
+// The current discard timer.
+@property(atomic, readonly) NSTimer *discardTimer;
 
 
 - (instancetype)initWithParentService:(GTMSessionFetcherService *)parentService
@@ -80,6 +79,9 @@ NSString *const kGTMSessionFetcherServiceSessionKey
 
   // When this ivar is nil, the service will not reuse sessions.
   GTMSessionFetcherSessionDelegateDispatcher *_delegateDispatcher;
+
+  // Fetchers will wait on this if another fetcher is creating the shared NSURLSession.
+  dispatch_semaphore_t _sessionCreationSemaphore;
 
   dispatch_queue_t _callbackQueue;
   NSOperationQueue *_delegateQueue;
@@ -140,6 +142,8 @@ NSString *const kGTMSessionFetcherServiceSessionKey
                                                            sessionDiscardInterval:_unusedSessionTimeout];
     _callbackQueue = dispatch_get_main_queue();
     _delegateQueue = [NSOperationQueue mainQueue];
+
+    _sessionCreationSemaphore = dispatch_semaphore_create(1);
 
     // Starting with the SDKs for OS X 10.11/iOS 9, the service has a default useragent.
     // Apps can remove this and get the default system "CFNetwork" useragent by setting the
@@ -228,34 +232,32 @@ NSString *const kGTMSessionFetcherServiceSessionKey
 // waits on a semaphore, blocking other fetchers while the caller creates the
 // session if needed.
 - (NSURLSession *)sessionForFetcherCreation {
-  // Avoid waiting in the @synchronized section since that can deadlock.
-  dispatch_semaphore_t semaphore;
+  @synchronized(self) {
+    GTMSessionMonitorSynchronized(self);
+    if (!_delegateDispatcher) {
+      // This fetcher is creating a non-shared session, so skip the semaphore usage.
+      return nil;
+    }
+  }
+
+  // Wait if another fetcher is currently creating a session; avoid waiting
+  // inside the @synchronized block, as that can deadlock.
+  dispatch_semaphore_wait(_sessionCreationSemaphore, DISPATCH_TIME_FOREVER);
+
   @synchronized(self) {
     GTMSessionMonitorSynchronized(self);
 
+    // Before getting the NSURLSession for task creation, it is
+    // important to invalidate and nil out the session discard timer; otherwise
+    // the session can be invalidated between when it is returned to the
+    // fetcher, and when the fetcher attempts to create its NSURLSessionTask.
     [_delegateDispatcher startSessionUsage];
-
-    semaphore = _delegateDispatcher.sessionCreationSemaphore;
-    GTMSESSION_ASSERT_DEBUG(semaphore != nil || _delegateDispatcher == nil, @"Expected semaphore");
-  }
-  if (semaphore) {
-    // Wait if another fetcher is currently creating a session.
-    dispatch_semaphore_wait(semaphore, DISPATCH_TIME_FOREVER);
-  } else {
-    // This fetcher is creating a non-shared session, so skip the semaphore usage.
-    return self.session;
-  }
-
-  @synchronized(self) {
-    GTMSessionMonitorSynchronized(self);
 
     NSURLSession *session = _delegateDispatcher.session;
     if (session) {
-      GTMSESSION_ASSERT_DEBUG(semaphore == _delegateDispatcher.sessionCreationSemaphore,
-                              @"delegate dispatcher semaphore changed");
       // The calling fetcher will receive a preexisting session, so
       // we can allow other fetchers to create a session.
-      dispatch_semaphore_signal(semaphore);
+      dispatch_semaphore_signal(_sessionCreationSemaphore);
     } else {
       // No existing session was obtained, so the calling fetcher will create the session;
       // it *must* invoke fetcherDidCreateSession: to signal the dispatcher's semaphore after
@@ -401,7 +403,7 @@ NSString *const kGTMSessionFetcherServiceSessionKey
       delegateDispatcher.session = fetcherSession;
 
       // Allow other fetchers to request this session now.
-      dispatch_semaphore_signal(delegateDispatcher.sessionCreationSemaphore);
+      dispatch_semaphore_signal(_sessionCreationSemaphore);
     }
   }
 }
@@ -663,17 +665,51 @@ NSString *const kGTMSessionFetcherServiceSessionKey
 }
 
 - (void)resetSession {
+  GTMSessionCheckNotSynchronized(self);
+  dispatch_semaphore_wait(_sessionCreationSemaphore, DISPATCH_TIME_FOREVER);
+
+  @synchronized(self) {
+    GTMSessionMonitorSynchronized(self);
+    [self resetSessionInternal];
+  }
+
+  dispatch_semaphore_signal(_sessionCreationSemaphore);
+}
+
+- (void)resetSessionInternal {
+  GTMSessionCheckSynchronized(self);
+
+  // The old dispatchers may be retained as delegates of any ongoing sessions by those sessions.
+  if (_delegateDispatcher) {
+    [self abandonDispatcher];
+    _delegateDispatcher =
+        [[GTMSessionFetcherSessionDelegateDispatcher alloc] initWithParentService:self
+                                                           sessionDiscardInterval:_unusedSessionTimeout];
+  }
+}
+
+- (void)resetSessionForDispatcherDiscardTimer:(NSTimer *)timer {
+  GTMSessionCheckNotSynchronized(self);
+
+  dispatch_semaphore_wait(_sessionCreationSemaphore, DISPATCH_TIME_FOREVER);
   @synchronized(self) {
     GTMSessionMonitorSynchronized(self);
 
-    // The old dispatchers may be retained as delegates of any ongoing sessions by those sessions.
-    if (_delegateDispatcher) {
-      [self abandonDispatcher];
-      _delegateDispatcher =
-          [[GTMSessionFetcherSessionDelegateDispatcher alloc] initWithParentService:self
-                                                             sessionDiscardInterval:_unusedSessionTimeout];
+    if (_delegateDispatcher.discardTimer == timer) {
+      // If the delegate dispatcher's current discardTimer is the same object as the timer
+      // that fired, no fetcher has recently attempted to start using the session by calling
+      // startSessionUsage, which invalidates and nils out the timer.
+      [self resetSessionInternal];
+    } else {
+      // A fetcher has invalidated the timer between its triggering and now, potentially
+      // meaning a fetcher has requested access to the NSURLSession, and may be in the process
+      // of starting a new task. The dispatcher should not be abandoned, as this can lead
+      // to a race condition between calling -finishTasksAndInvalidate on the NSURLSession
+      // and the fetcher attempting to create a new task.
     }
   }
+
+  dispatch_semaphore_signal(_sessionCreationSemaphore);
 }
 
 - (NSTimeInterval)unusedSessionTimeout {
@@ -695,6 +731,7 @@ NSString *const kGTMSessionFetcherServiceSessionKey
 
 // This method should be called inside of @synchronized(self)
 - (void)abandonDispatcher {
+  GTMSessionCheckSynchronized(self);
   [_delegateDispatcher abandon];
 }
 
@@ -910,7 +947,6 @@ NSString *const kGTMSessionFetcherServiceSessionKey
 @implementation GTMSessionFetcherSessionDelegateDispatcher {
   __weak GTMSessionFetcherService *_parentService;
   NSURLSession *_session;
-  dispatch_semaphore_t _sessionCreationSemaphore;
 
   // The task map maps NSURLSessionTasks to GTMSessionFetchers
   NSMutableDictionary *_taskToFetcherMap;
@@ -920,8 +956,7 @@ NSString *const kGTMSessionFetcherServiceSessionKey
 }
 
 @synthesize discardInterval = _discardInterval,
-            session = _session,
-            sessionCreationSemaphore = _sessionCreationSemaphore;
+            session = _session;
 
 - (instancetype)init {
   [self doesNotRecognizeSelector:_cmd];
@@ -934,7 +969,6 @@ NSString *const kGTMSessionFetcherServiceSessionKey
   if (self) {
     _discardInterval = discardInterval;
     _parentService = parentService;
-    _sessionCreationSemaphore = dispatch_semaphore_create(1);
   }
   return self;
 }
@@ -946,8 +980,16 @@ NSString *const kGTMSessionFetcherServiceSessionKey
           _taskToFetcherMap.count > 0 ? _taskToFetcherMap : @"<no tasks>"];
 }
 
+- (NSTimer *)discardTimer {
+  GTMSessionCheckNotSynchronized(self);
+  @synchronized(self) {
+    return _discardTimer;
+  }
+}
+
 // This method should be called inside of a @synchronized(self) block.
 - (void)startDiscardTimer {
+  GTMSessionCheckSynchronized(self);
   [_discardTimer invalidate];
   _discardTimer = nil;
   if (_discardInterval > 0) {
@@ -963,6 +1005,7 @@ NSString *const kGTMSessionFetcherServiceSessionKey
 
 // This method should be called inside of a @synchronized(self) block.
 - (void)destroyDiscardTimer {
+  GTMSessionCheckSynchronized(self);
   [_discardTimer invalidate];
   _discardTimer = nil;
 }
@@ -977,24 +1020,23 @@ NSString *const kGTMSessionFetcherServiceSessionKey
       service = _parentService;
     }
   }
-  // Ask the service to abandon us. It will create a new delegate dispatcher
-  // which will have a distinct session.
+
+  // Inform the service that the discard timer has fired, and should check whether the
+  // service can abandon us. -resetSession cannot be called directly, as there is a
+  // race condition that must be guarded against with the NSURLSession being returned
+  // from sessionForFetcherCreation outside other locks. The service can take steps
+  // to prevent resetting the session if that has occurred.
   //
-  // Since finishing this session takes a while, it's better for the service to have a new
-  // delegate dispatcher while the tasks on this session's delegate dispatcher finish up.
-  //
-  // We want to call the service from outside of a @synchronized section.
-  [service resetSession];
+  // The service must be called from outside the @synchronized block.
+  [service resetSessionForDispatcherDiscardTimer:timer];
 }
 
 - (void)abandon {
-  dispatch_semaphore_wait(_sessionCreationSemaphore, DISPATCH_TIME_FOREVER);
   @synchronized(self) {
     GTMSessionMonitorSynchronized(self);
 
     [self destroySessionAndTimer];
   }
-  dispatch_semaphore_signal(_sessionCreationSemaphore);
 }
 
 - (void)startSessionUsage {
@@ -1007,6 +1049,7 @@ NSString *const kGTMSessionFetcherServiceSessionKey
 
 // This method should be called inside of a @synchronized(self) block.
 - (void)destroySessionAndTimer {
+  GTMSessionCheckSynchronized(self);
   [self destroyDiscardTimer];
 
   // Break any retain cycle from the session holding the delegate.


### PR DESCRIPTION
Address a race condition that could lead to crash, and fixes
synchronization/locking order to prevent a closely related deadlock.

The underlying race condition is in scheduling invalidation of shared
NSURLSessions after a period of inactivity, and the structure of the code
doing so.

NSURLSession creation is performed by the fetcher, and the resulting session is
passed back to the service (and through it to the delegate dispatcher). To
prevent multiple fetchers from simultaneously attempting to create a
NSURLSession, a semaphore is used. The order of
@synchronized/dispatch_semaphore_wait was not strictly observed, and the
discard timer firing at just the right time could cause a deadlock. This change
moves ownership of that semaphore from the delegate dispatcher to the session
fetcher service, and makes the order of @synchronized/dispatch_semaphore_wait
locking consistent, which will prevent the deadlock.

The other race condition issue relates to invalidation of shared NSURLSession
in the service/delegate dispatcher, versus how the fetcher creates
NSURLSessionTasks. When beginning a request (for a fetcher sharing its
NSURLSession), the fetcher asks the service for the shared session; if one
exists, it is returned. At that point, there is no locking preventing
invalidation of the NSURLSession, but the fetcher will attempt to create an
NSURLSessionTask with that NSURLSession; if the session is invalidated before
task creation, trying to create the task will fail or crash.

This change tweaks the timer-based reset of the session, taking advantage of
how the timer callback does not nil the timer pointer, whereas the
-startSessionUsage method called when starting a new fetch does. Before
resetting the session when the timer fires, the service locks the session
creation semaphore (to prevent fetchers from being provided the NSURLSession),
and checks if the timer pointer is still non-nil; if so, no fetch has begun
since the discard timer was started, and while the semaphore is locked the
NSURLSession can be safely invalidated (unless some other deadlock or delay
has prevented the fetcher from starting its task, which would probably be a
different bug).

This CL fixes the deadlock. And it alleviates the race condition between
NSURLSession invalidation vs NSURLSessionTask creation, although doesn't
entirely eliminate it; triggering it should now require an extremely long and
unusual delay between the fetcher receiving the session from
-sessionForFetcherCreation and creating its task, with other fetchers having
finished in the meantime, which for most cases should now be much harder, but
at least no worse. Fully eliminating the race may need to wait on refactoring
the service/fetcher interaction, moving session creation/maintenance and likely
task creation into the service.