### PR TITLE
Added the 'nullable' attribute to the userEmail property of GTMFetcherAuthorizationProtocol.

### DIFF
--- a/Source/GTMSessionFetcher.h
+++ b/Source/GTMSessionFetcher.h
@@ -650,7 +650,7 @@ NSData * GTM_NULLABLE_TYPE GTMDataFromInputStream(NSInputStream *inputStream, NS
 
 - (BOOL)isAuthorizedRequest:(NSURLRequest *)request;
 
-@property(strong, readonly) NSString *userEmail;
+@property(strong, readonly, GTM_NULLABLE) NSString *userEmail;
 
 @optional
 


### PR DESCRIPTION
GTMOAuth2Authentication.h redefines the property in its concrete implementation as nullable. It also includes the comment: "User email and verified status; not used for authentication" which matches my expectations of the protocol (these user attributes might be useful, but are not required to authorize requests).