### PR TITLE
Default NSURLSession delegate methods to a background queue.

### DIFF
--- a/Source/GTMSessionFetcherService.m
+++ b/Source/GTMSessionFetcherService.m
@@ -141,7 +141,10 @@ NSString *const kGTMSessionFetcherServiceSessionKey
         [[GTMSessionFetcherSessionDelegateDispatcher alloc] initWithParentService:self
                                                            sessionDiscardInterval:_unusedSessionTimeout];
     _callbackQueue = dispatch_get_main_queue();
-    _delegateQueue = [NSOperationQueue mainQueue];
+
+    _delegateQueue = [[NSOperationQueue alloc] init];
+    _delegateQueue.maxConcurrentOperationCount = 1;
+    _delegateQueue.name = @"com.google.GTMSessionFetcher.NSURLSessionDelegateQueue";
 
     _sessionCreationSemaphore = dispatch_semaphore_create(1);
 


### PR DESCRIPTION
This should be transparent to client code; the fetcher delegate
methods/callbacks were already being called back on a separately specified
queue. Internally the fetcher supported using a background queue, and data
access was thread-safe, so this switches over the default and updates some
unit tests.