### PR TITLE
Update the defaulting for fetcher logging.

### DIFF
--- a/Source/GTMSessionFetcher.h
+++ b/Source/GTMSessionFetcher.h
@@ -265,6 +265,16 @@
 #import <UIKit/UIKit.h>
 #endif
 
+// By default it is stripped from non DEBUG builds. Developers can override
+// this in their project settings.
+#ifndef STRIP_GTM_FETCH_LOGGING
+  #if !DEBUG
+    #define STRIP_GTM_FETCH_LOGGING 1
+  #else
+    #define STRIP_GTM_FETCH_LOGGING 0
+  #endif
+#endif
+
 // Logs in debug builds.
 #ifndef GTMSESSION_LOG_DEBUG
   #if DEBUG

--- a/Source/GTMSessionFetcher.m
+++ b/Source/GTMSessionFetcher.m
@@ -21,6 +21,10 @@
 
 #import <sys/utsname.h>
 
+#ifndef STRIP_GTM_FETCH_LOGGING
+  #error GTMSessionFetcher headers should have defaulted this if it wasn't already defined.
+#endif
+
 GTM_ASSUME_NONNULL_BEGIN
 
 NSString *const kGTMSessionFetcherStartedNotification           = @"kGTMSessionFetcherStartedNotification";

--- a/Source/GTMSessionFetcherLogViewController.m
+++ b/Source/GTMSessionFetcherLogViewController.m
@@ -19,12 +19,16 @@
 
 #import "GTMSessionFetcherLogViewController.h"
 
-#if !STRIP_GTM_FETCH_LOGGING && !STRIP_GTM_SESSIONLOGVIEWCONTROLLER
-
 #import <objc/runtime.h>
 
 #import "GTMSessionFetcher.h"
 #import "GTMSessionFetcherLogging.h"
+
+#ifndef STRIP_GTM_FETCH_LOGGING
+  #error GTMSessionFetcher headers should have defaulted this if it wasn't already defined.
+#endif
+
+#if !STRIP_GTM_FETCH_LOGGING && !STRIP_GTM_SESSIONLOGVIEWCONTROLLER
 
 static NSString *const kHTTPLogsCell = @"kGTMHTTPLogsCell";
 

--- a/Source/GTMSessionFetcherLogging.m
+++ b/Source/GTMSessionFetcherLogging.m
@@ -17,12 +17,16 @@
 #error "This file requires ARC support."
 #endif
 
-#if !STRIP_GTM_FETCH_LOGGING
-
 #include <sys/stat.h>
 #include <unistd.h>
 
 #import "GTMSessionFetcherLogging.h"
+
+#ifndef STRIP_GTM_FETCH_LOGGING
+  #error GTMSessionFetcher headers should have defaulted this if it wasn't already defined.
+#endif
+
+#if !STRIP_GTM_FETCH_LOGGING
 
 // Sensitive credential strings are replaced in logs with _snip_
 //


### PR DESCRIPTION
Default to off in non DEBUG builds (not just iOS ones).