### PR TITLE
Create new ifdef for reference to UIApplication.

### DIFF
--- a/Source/GTMSessionFetcher.h
+++ b/Source/GTMSessionFetcher.h
@@ -382,6 +382,13 @@
   #define GTM_BACKGROUND_TASK_FETCHING 1
 #endif
 
+// If GTM_BACKGROUND_TASK_FETCHING is enabled and GTMUIApplicationProtocol is not used,
+// GTM_BACKGROUND_UIAPPLICATION will allow defaulting to UIApplication. To avoid references to
+// UIApplication (e.g. for extensions), set GTM_BACKGROUND_UIAPPLICATION to 0.
+#if TARGET_OS_IPHONE && !TARGET_OS_WATCH && !defined(GTM_BACKGROUND_UIAPPLICATION)
+  #define GTM_BACKGROUND_UIAPPLICATION 1
+#endif
+
 #ifdef __cplusplus
 extern "C" {
 #endif

--- a/Source/GTMSessionFetcher.m
+++ b/Source/GTMSessionFetcher.m
@@ -819,11 +819,11 @@ static GTMSessionFetcherTestBlock GTM_NULLABLE_TYPE gGlobalTestBlock;
 #endif  // GTM_DISABLE_FETCHER_TEST_BLOCK
 
 #if GTM_BACKGROUND_TASK_FETCHING
+  id<GTMUIApplicationProtocol> app = [[self class] fetcherUIApplication];
   // Background tasks seem to interfere with out-of-process uploads and downloads.
-  if (!self.skipBackgroundTask && !self.useBackgroundSession) {
+  if (app && !self.skipBackgroundTask && !self.useBackgroundSession) {
     // Tell UIApplication that we want to continue even when the app is in the
     // background.
-    id<GTMUIApplicationProtocol> app = [[self class] fetcherUIApplication];
 #if DEBUG
     NSString *bgTaskName = [NSString stringWithFormat:@"%@-%@",
                             [self class], fetchRequest.URL.host];

--- a/Source/GTMSessionFetcher.m
+++ b/Source/GTMSessionFetcher.m
@@ -1944,9 +1944,9 @@ static GTM_NULLABLE_TYPE id<GTMUIApplicationProtocol> gSubstituteUIApp;
   id<GTMUIApplicationProtocol> app = gSubstituteUIApp;
   if (app) return app;
 
-  // Some projects use GTM_BACKGROUND_TASK_FETCHING to avoid compile-time references
+  // Some projects use GTM_BACKGROUND_UIAPPLICATION to avoid compile-time references
   // to UIApplication.
-#if GTM_BACKGROUND_TASK_FETCHING
+#if GTM_BACKGROUND_UIAPPLICATION
   return (id<GTMUIApplicationProtocol>) [UIApplication sharedApplication];
 #else
   return nil;


### PR DESCRIPTION
- Allows GTMSessionFetcherIOS to link to main application and extension with GTM_BACKGROUND_TASK_FETCHING enabled
- Allows APPLICATION_EXTENSION_API_ONLY to be set and let background tasks occur in main application