### PR TITLE
Silence a performSelector-leaks warning.

### DIFF
--- a/Source/GTMReadMonitorInputStream.m
+++ b/Source/GTMReadMonitorInputStream.m
@@ -94,6 +94,8 @@
         // and invoke on the proper thread.
         SEL sel = @selector(invokeReadSelectorWithBuffer:);
         NSData *data = [NSData dataWithBytes:buffer length:(NSUInteger)numRead];
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Warc-performSelector-leaks"
         if (_runLoopModes) {
           [self performSelector:sel
                        onThread:_thread
@@ -106,6 +108,7 @@
                      withObject:data
                   waitUntilDone:NO];
         }
+#pragma clang diagnostic pop
       }
     }
   }


### PR DESCRIPTION
This closes https://github.com/google/gtm-session-fetcher/issues/76.