### PR TITLE
Fix GTMSessionUploadFetcher hanging on retry.

### DIFF
--- a/Source/GTMSessionFetcher.m
+++ b/Source/GTMSessionFetcher.m
@@ -369,6 +369,14 @@ static GTMSessionFetcherTestBlock GTM_NULLABLE_TYPE gGlobalTestBlock;
   [self beginFetchMayDelay:YES mayAuthorize:YES];
 }
 
+// Begin fetching the URL for a retry fetch. The delegate and completion handler
+// are already provided, and do not need to be copied.
+- (void)beginFetchForRetry {
+  GTMSessionCheckNotSynchronized(self);
+
+  [self beginFetchMayDelay:YES mayAuthorize:YES];
+}
+
 - (GTMSessionFetcherCompletionHandler)completionHandlerWithTarget:(GTM_NULLABLE_TYPE id)target
                                                 didFinishSelector:(GTM_NULLABLE_TYPE SEL)finishedSelector {
   GTMSessionFetcherAssertValidSelector(target, finishedSelector, @encode(GTMSessionFetcher *),
@@ -1881,8 +1889,6 @@ NSData * GTM_NULLABLE_TYPE GTMDataFromInputStream(NSInputStream *inputStream, NS
 - (void)retryFetch {
   [self stopFetchReleasingCallbacks:NO];
 
-  GTMSessionFetcherCompletionHandler completionHandler;
-
   // A retry will need a configuration with a fresh session identifier.
   @synchronized(self) {
     GTMSessionMonitorSynchronized(self);
@@ -1897,11 +1903,9 @@ NSData * GTM_NULLABLE_TYPE GTMDataFromInputStream(NSInputStream *inputStream, NS
       // the service's old one has become invalid.
       _session = nil;
     }
-
-    completionHandler = _completionHandler;
   }  // @synchronized(self)
 
-  [self beginFetchWithCompletionHandler:completionHandler];
+  [self beginFetchForRetry];
 }
 
 - (BOOL)waitForCompletionWithTimeout:(NSTimeInterval)timeoutInSeconds {

--- a/Source/GTMSessionUploadFetcher.m
+++ b/Source/GTMSessionUploadFetcher.m
@@ -70,6 +70,7 @@ NSString *const kGTMSessionFetcherUploadLocationObtainedNotification =
              afterUserStopped:(BOOL)afterStopped
                         block:(void (^)(void))block;
 - (NSTimer *)retryTimer;
+- (void)beginFetchForRetry;
 
 @property(readwrite, strong) NSData *downloadedData;
 - (void)releaseCallbacks;
@@ -794,6 +795,19 @@ NSString *const kGTMSessionFetcherUploadLocationObtainedNotification =
 
     return _fetcherInFlight;
   }
+}
+
+- (void)beginFetchForRetry {
+  GTMSessionCheckNotSynchronized(self);
+
+  // Override the superclass to reset the initial body length and fetcher-in-flight,
+  // then call the superclass implementation.
+  [self setInitialBodyLength:[self bodyLength]];
+
+  GTMSESSION_ASSERT_DEBUG(self.fetcherInFlight == nil, @"unexpected fetcher in flight: %@",
+                          self.fetcherInFlight);
+  self.fetcherInFlight = self;
+  [super beginFetchForRetry];
 }
 
 - (void)beginFetchWithCompletionHandler:(GTMSessionFetcherCompletionHandler)handler {

--- a/Source/UnitTests/GTMSessionFetcherChunkedUploadTest.m
+++ b/Source/UnitTests/GTMSessionFetcherChunkedUploadTest.m
@@ -602,6 +602,80 @@ static void TestProgressBlock(GTMSessionUploadFetcher *fetcher,
   [self removeTemporaryFileURL:bigFileURL];
 }
 
+- (void)testBigFileURLSingleChunkedUploadFetchRetry {
+  // Like testBigFileURLSingleChunkedUploadFetch, but the initial request will fail
+  // with HTTP 503, triggering a retry.
+  FetcherNotificationsCounter *fnctr = [[FetcherNotificationsCounter alloc] init];
+
+  NSURL *bigFileURL = [self bigFileToUploadURLWithBaseName:NSStringFromSelector(_cmd)];
+
+  NSMutableURLRequest *request = [self validUploadFileRequest];
+
+  NSURL *originalURL = request.URL;
+  NSString *failureURL = [originalURL.absoluteString stringByAppendingString:@"?status=503"];
+  request.URL = [NSURL URLWithString:failureURL];
+
+  GTMSessionUploadFetcher *fetcher =
+      [GTMSessionUploadFetcher uploadFetcherWithRequest:request
+                                         uploadMIMEType:@"text/plain"
+                                              chunkSize:kGTMSessionUploadFetcherStandardChunkSize
+                                         fetcherService:_service];
+  fetcher.uploadFileURL = bigFileURL;
+  fetcher.useBackgroundSession = NO;
+  fetcher.allowLocalhostRequest = YES;
+
+  BOOL (^shouldRetryUpload)(GTMSessionUploadFetcher *, BOOL, NSError *) =
+      ^BOOL(GTMSessionUploadFetcher *fetcher, BOOL suggestedWillRetry, NSError *error) {
+        // Change this fetch's request to have the original, non-failure status URL.
+        // This will make the retry succeed.
+        NSMutableURLRequest *mutableRequest = [fetcher mutableRequestForTesting];
+        mutableRequest.URL = originalURL;
+        fetcher.uploadLocationURL = originalURL;
+
+        return suggestedWillRetry;  // do the retry fetch; it should succeed now
+      };
+
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Warc-retain-cycles"
+  fetcher.retryEnabled = YES;
+  fetcher.retryBlock = ^(BOOL suggestedWillRetry, NSError *error,
+                         GTMSessionFetcherRetryResponse response) {
+    BOOL shouldRetry = shouldRetryUpload(fetcher, suggestedWillRetry, error);
+    response(shouldRetry);
+  };
+#pragma clang diagnostic pop
+
+  XCTestExpectation *expectation = [self expectationWithDescription:@"fetched"];
+  [fetcher beginFetchWithCompletionHandler:^(NSData *data, NSError *error) {
+    XCTAssertEqualObjects(data, [self gettysburgAddress]);
+    XCTAssertNil(error);
+    XCTAssertEqual(fetcher.statusCode, (NSInteger)200);
+    [expectation fulfill];
+  }];
+  [self waitForExpectationsWithTimeout:_timeoutInterval handler:nil];
+  [self assertCallbacksReleasedForFetcher:fetcher];
+
+  // Check that we uploaded the expected chunks.
+  NSArray *expectedURLStrings = @[ @"/gettysburgaddress.txt.upload" ];
+  NSArray *expectedCommands = @[ @"upload, finalize" ];
+  NSArray *expectedOffsets = @[ @0 ];
+  NSArray *expectedLengths = @[ @(kBigUploadDataLength) ];
+  XCTAssertEqualObjects(fnctr.uploadChunkRequestPaths, expectedURLStrings);
+  XCTAssertEqualObjects(fnctr.uploadChunkCommands, expectedCommands);
+  XCTAssertEqualObjects(fnctr.uploadChunkOffsets, expectedOffsets);
+  XCTAssertEqualObjects(fnctr.uploadChunkLengths, expectedLengths);
+
+  XCTAssertEqual(fnctr.fetchStarted, 3);
+  XCTAssertEqual(fnctr.fetchStopped, 3);
+  XCTAssertEqual(fnctr.uploadChunkFetchStarted, 1);
+  XCTAssertEqual(fnctr.uploadChunkFetchStopped, 1);
+  XCTAssertEqual(fnctr.retryDelayStarted, 1);
+  XCTAssertEqual(fnctr.retryDelayStopped, 1);
+  XCTAssertEqual(fnctr.uploadLocationObtained, 1);
+
+  [self removeTemporaryFileURL:bigFileURL];
+}
+
 // This appears to be hang/fail when testing macOS with Xcode 8. The
 // waitForExpectationsWithTimeout runs longer than the 4 minutes, before dying.
 // And while it is running, something bad seems to happen as the machine can


### PR DESCRIPTION
Changes the retry flow to have retryFetch call the new method
beginFetchForRetry. The upload fetcher overrides this to do a little
bookkeeping, then call the superclass implementation. The superclass
implementation calls -beginFetchMayDelay:mayAuthorize:, avoiding the
need to re-pass the completion handler.

The problem was that if the upload fetcher's initial request failed and
attempted to retry, the retry mechanism was losing the client's original
completion handler. This was due to the retry starting in retryFetch,
which called beginFetchWithCompletionHandler: passing the
GTMSessionFetcher's completion handler back into itself. When using an
upload fetcher, beginFetchWithCompletionHandler: is overridden to store
the provided handler and call the superclass with a new completion
handler used to begin triggering the chunk uploads. When the retry
occured, this caused the completion handler originally passed to the
upload fetcher to be discarded, so the client never got called when the
upload completes or errors out.