### PR TITLE
Add unit test to verify behavior when cancelling a redirect.

### DIFF
--- a/Source/GTMSessionUploadFetcher.m
+++ b/Source/GTMSessionUploadFetcher.m
@@ -221,6 +221,7 @@ NSString *const kGTMSessionFetcherUploadLocationObtainedNotification =
   uploadFetcher.sessionUserInfo = metadata;
   uploadFetcher.useBackgroundSession = YES;
   uploadFetcher.currentOffset = currentOffset;
+  uploadFetcher.delegateCallbackQueue = uploadFetcher.callbackQueue;
   uploadFetcher.allowedInsecureSchemes = @[ @"http" ];  // Allowed on restored upload fetcher.
   return uploadFetcher;
 }


### PR DESCRIPTION
Tests already included accepting the redirect, but had never checked the behavior of the fetcher when the redirect block completion was called with a nil new request.