### PR TITLE
Move to Xcode 9.3 which also means a High Sierra image.

### DIFF
--- a/.travis.sh
+++ b/.travis.sh
@@ -36,7 +36,7 @@ case "${BUILD_MODE}" in
   tvOS)
     CMD_BUILDER+=(
         -scheme "tvOS Framework"
-        -destination "platform=tvOS Simulator,name=Apple TV 1080p,OS=latest"
+        -destination "platform=tvOS Simulator,name=Apple TV,OS=latest"
     )
     ;;
   watchOS)

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,5 @@
 language: objective-c
-osx_image: xcode8.3
+osx_image: xcode9.3
 env:
   - MODE=OSX CFG=Debug
   - MODE=OSX CFG=Release

--- a/Source/GTMMIMEDocument.m
+++ b/Source/GTMMIMEDocument.m
@@ -102,8 +102,9 @@ static void SearchDataForBytes(NSData *data, const void *targetBytes, NSUInteger
 }
 
 - (NSString *)description {
-  return [NSString stringWithFormat:@"%@ %p (headers %tu keys, body %tu bytes)",
-          [self class], self, _headers.count, _bodyData.length];
+  return [NSString stringWithFormat:@"%@ %p (headers %lu keys, body %lu bytes)",
+          [self class], self, (unsigned long)_headers.count,
+          (unsigned long)_bodyData.length];
 }
 
 - (BOOL)isEqual:(GTMMIMEDocumentPart *)other {
@@ -139,8 +140,8 @@ static void SearchDataForBytes(NSData *data, const void *targetBytes, NSUInteger
 }
 
 - (NSString *)description {
-  return [NSString stringWithFormat:@"%@ %p (%tu parts)",
-          [self class], self, _parts.count];
+  return [NSString stringWithFormat:@"%@ %p (%lu parts)",
+          [self class], self, (unsigned long)_parts.count];
 }
 
 #pragma mark - Joining Parts

--- a/Source/GTMSessionFetcher.m
+++ b/Source/GTMSessionFetcher.m
@@ -756,8 +756,8 @@ static GTMSessionFetcherTestBlock GTM_NULLABLE_TYPE gGlobalTestBlock;
   if (_downloadResumeData) {
     newSessionTask = [_session downloadTaskWithResumeData:_downloadResumeData];
     GTMSESSION_ASSERT_DEBUG_OR_LOG(newSessionTask,
-        @"Failed downloadTaskWithResumeData for %@, resume data %tu bytes",
-        _session, _downloadResumeData.length);
+        @"Failed downloadTaskWithResumeData for %@, resume data %lu bytes",
+        _session, (unsigned long)_downloadResumeData.length);
   } else if (_destinationFileURL && !isDataRequest) {
     newSessionTask = [_session downloadTaskWithRequest:fetchRequest];
     GTMSESSION_ASSERT_DEBUG_OR_LOG(newSessionTask, @"Failed downloadTaskWithRequest for %@, %@",
@@ -780,8 +780,8 @@ static GTMSessionFetcherTestBlock GTM_NULLABLE_TYPE gGlobalTestBlock;
       newSessionTask = [_session uploadTaskWithRequest:fetchRequest
                                             fromData:(NSData * GTM_NONNULL_TYPE)_bodyData];
       GTMSESSION_ASSERT_DEBUG_OR_LOG(newSessionTask,
-          @"Failed uploadTaskWithRequest for %@, %@, body data %tu bytes",
-          _session, fetchRequest, _bodyData.length);
+          @"Failed uploadTaskWithRequest for %@, %@, body data %lu bytes",
+          _session, fetchRequest, (unsigned long)_bodyData.length);
     }
     needsDataAccumulator = YES;
   } else {
@@ -4404,8 +4404,9 @@ NSString *GTMFetcherSystemVersionString(void) {
 // all clients to build with Xcode 9 or above.
       NSOperatingSystemVersion version = procInfo.operatingSystemVersion;
 #pragma clang diagnostic pop
-      versString = [NSString stringWithFormat:@"%zd.%zd.%zd",
-                    version.majorVersion, version.minorVersion, version.patchVersion];
+      versString = [NSString stringWithFormat:@"%ld.%ld.%ld",
+                    (long)version.majorVersion, (long)version.minorVersion,
+                    (long)version.patchVersion];
 #else
 #pragma unused(procInfo)
 #endif

--- a/Source/UnitTests/GTMSessionFetcherFetchingTest.m
+++ b/Source/UnitTests/GTMSessionFetcherFetchingTest.m
@@ -2584,7 +2584,7 @@ UIBackgroundTaskIdentifier gTaskID = 1000;
 - (void)endBackgroundTask:(UIBackgroundTaskIdentifier)taskID {
   @synchronized(self) {
     NSAssert(_identifierToTaskInfoMap[@(taskID)] != nil,
-             @"endBackgroundTask failed to find task: %tu", taskID);
+             @"endBackgroundTask failed to find task: %lu", (unsigned long)taskID);
 
     [_identifierToTaskInfoMap removeObjectForKey:@(taskID)];
   }
@@ -2630,7 +2630,8 @@ UIBackgroundTaskIdentifier gTaskID = 1000;
 @synthesize expirationHandler = _expirationHandler;
 
 - (NSString *)description {
-  return [NSString stringWithFormat:@"<task %tu \"%@\">", _taskIdentifier, _taskName];
+  return [NSString stringWithFormat:@"<task %lu \"%@\">",
+          (unsigned long)_taskIdentifier, _taskName];
 }
 
 @end
@@ -2736,7 +2737,8 @@ UIBackgroundTaskIdentifier gTaskID = 1000;
                            fetcher.comment ?: @"<no comment>",
                            fetcher.request.URL.absoluteString];
   if (fetcher.retryCount > 0) {
-    description = [description stringByAppendingFormat:@" retry %tu", fetcher.retryCount];
+    description = [description stringByAppendingFormat:@" retry %lu",
+                   (unsigned long)fetcher.retryCount];
   }
   return description;
 }

--- a/Source/UnitTests/GTMSessionFetcherServiceTest.m
+++ b/Source/UnitTests/GTMSessionFetcherServiceTest.m
@@ -472,7 +472,7 @@ static NSString *const kValidFileName = @"gettysburgaddress.txt";
   NSMutableIndexSet *overloadIndexes = [NSMutableIndexSet indexSet];
 
   for (NSUInteger index = 0; index < kNumberOfFetchersToCreate; index++) {
-    NSString *desc = [NSString stringWithFormat:@"Fetcher %tu", index];
+    NSString *desc = [NSString stringWithFormat:@"Fetcher %lu", (unsigned long)index];
     XCTestExpectation *expectation = [self expectationWithDescription:desc];
 
     dispatch_queue_t queue = queues[index % queues.count];
@@ -496,11 +496,11 @@ static NSString *const kValidFileName = @"gettysburgaddress.txt";
               dispatch_queue_get_label(queues[(index / 3) % queues.count]);
           const char *actualQueueLabel = dispatch_queue_get_label(DISPATCH_CURRENT_QUEUE_LABEL);
           XCTAssert(strcmp(actualQueueLabel, expectedQueueLabel) == 0,
-                    @"queue mismatch on index %tu: %s (expected %s)",
-                    index, actualQueueLabel, expectedQueueLabel);
+                    @"queue mismatch on index %lu: %s (expected %s)",
+                    (unsigned long)index, actualQueueLabel, expectedQueueLabel);
 
-          XCTAssertNotNil(fetchData, @"index %tu", index);
-          XCTAssertNil(fetchError, @"index %tu", index);
+          XCTAssertNotNil(fetchData, @"index %lu", (unsigned long)index);
+          XCTAssertNil(fetchError, @"index %lu", (unsigned long)index);
         }
       }];
     });

--- a/Source/UnitTests/GTMSessionFetcherUtilityTest.m
+++ b/Source/UnitTests/GTMSessionFetcherUtilityTest.m
@@ -140,10 +140,10 @@
 #pragma clang diagnostic pop
 #if TARGET_OS_IPHONE
   // iOS, tvOS, watchOS
-  NSString *versionStr = [NSString stringWithFormat:@"%zd.%zd",
-                          version.majorVersion, version.minorVersion];
+  NSString *versionStr = [NSString stringWithFormat:@"%ld.%ld",
+                          (long)version.majorVersion, (long)version.minorVersion];
   if (version.patchVersion > 0) {
-    versionStr = [versionStr stringByAppendingFormat:@".%zd", version.patchVersion];
+    versionStr = [versionStr stringByAppendingFormat:@".%ld", (long)version.patchVersion];
   }
   // The simulator result looks like:
   //   com.google.FetcheriOSTests/1.0 iPhone/9.3.1 hw/sim
@@ -160,8 +160,8 @@
 #else
   // macOS
   NSString *expected =
-      [NSString stringWithFormat:@"com.google.FetcherMacTests/1.0 MacOSX/%zd.%zd.%zd",
-       version.majorVersion, version.minorVersion, version.patchVersion];
+      [NSString stringWithFormat:@"com.google.FetcherMacTests/1.0 MacOSX/%ld.%ld.%ld",
+       (long)version.majorVersion, (long)version.minorVersion, (long)version.patchVersion];
   XCTAssertEqualObjects(result, expected);
 #endif
 }


### PR DESCRIPTION
Given the current level of flake/failure on travis, this likely will be
just as bad or worse. But moving forward for the newer compile warnings
and errors seems like a good thing.