### PR TITLE
Fix crash for GTMSessionFetcherService: in case of NSURSession.delegate was swizzled

### DIFF
--- a/Source/GTMSessionFetcherCore.xcodeproj/project.pbxproj
+++ b/Source/GTMSessionFetcherCore.xcodeproj/project.pbxproj
@@ -81,6 +81,7 @@
 		4FEE143B1BB223DE002ACBF8 /* GTMSessionUploadFetcher.h in Headers */ = {isa = PBXBuildFile; fileRef = 4F6F7E8018D6B2CD00CA4B4C /* GTMSessionUploadFetcher.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		4FEE143C1BB223DE002ACBF8 /* GTMSessionUploadFetcher.m in Sources */ = {isa = PBXBuildFile; fileRef = 4F6F7E8118D6B2CD00CA4B4C /* GTMSessionUploadFetcher.m */; };
 		4FEE6531192D8451001B6234 /* MainStoryboard.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 4FEE6530192D8451001B6234 /* MainStoryboard.storyboard */; };
+		7C7EB0172180B44300E7CE2A /* GTMSessionFetcherURLSessionDelegateSwapTest.m in Sources */ = {isa = PBXBuildFile; fileRef = 7C7EB0162180B44300E7CE2A /* GTMSessionFetcherURLSessionDelegateSwapTest.m */; };
 		8E809F7218BC3AAE0040AE83 /* CoreGraphics.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 8E809F7118BC3AAE0040AE83 /* CoreGraphics.framework */; };
 		8EC5668E18AAFB1200E2C97D /* Foundation.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 4F5566B71862981000D6D62C /* Foundation.framework */; };
 		8EC5669218AAFB1200E2C97D /* UIKit.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 8EC5669118AAFB1200E2C97D /* UIKit.framework */; };
@@ -217,6 +218,7 @@
 		4FEE14271BB22328002ACBF8 /* GTMSessionFetcherIOS.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = GTMSessionFetcherIOS.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		4FEE142B1BB22328002ACBF8 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
 		4FEE6530192D8451001B6234 /* MainStoryboard.storyboard */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = file.storyboard; name = MainStoryboard.storyboard; path = TestApps/FetcheriOSTestApp/MainStoryboard.storyboard; sourceTree = SOURCE_ROOT; };
+		7C7EB0162180B44300E7CE2A /* GTMSessionFetcherURLSessionDelegateSwapTest.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; name = GTMSessionFetcherURLSessionDelegateSwapTest.m; path = UnitTests/GTMSessionFetcherURLSessionDelegateSwapTest.m; sourceTree = SOURCE_ROOT; };
 		8E809F7118BC3AAE0040AE83 /* CoreGraphics.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = CoreGraphics.framework; path = Platforms/iPhoneOS.platform/Developer/SDKs/iPhoneOS7.0.sdk/System/Library/Frameworks/CoreGraphics.framework; sourceTree = DEVELOPER_DIR; };
 		8EC5668D18AAFB1200E2C97D /* FetcheriOSTestApp.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = FetcheriOSTestApp.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		8EC5669118AAFB1200E2C97D /* UIKit.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = UIKit.framework; path = Library/Frameworks/UIKit.framework; sourceTree = DEVELOPER_DIR; };
@@ -419,6 +421,7 @@
 				4F63A7AA19831052004D4315 /* GTMSessionFetcherChunkedUploadTest.m */,
 				4F6F7EC518D6B60300CA4B4C /* GTMSessionFetcherServiceTest.m */,
 				4F6F7EC618D6B60300CA4B4C /* GTMSessionFetcherUtilityTest.m */,
+				7C7EB0162180B44300E7CE2A /* GTMSessionFetcherURLSessionDelegateSwapTest.m */,
 				4FBD7F78186523400048382E /* Data */,
 				4F5566FE1862A17A00D6D62C /* Server */,
 				4F5566D01862981000D6D62C /* Supporting Files */,
@@ -968,6 +971,7 @@
 				4F6F7ECE18D6B60300CA4B4C /* GTMSessionFetcherFetchingTest.m in Sources */,
 				4F6F7ED018D6B60300CA4B4C /* GTMSessionFetcherServiceTest.m in Sources */,
 				F46D93621D9D4DEB00590137 /* GTMSessionFetcherService.m in Sources */,
+				7C7EB0172180B44300E7CE2A /* GTMSessionFetcherURLSessionDelegateSwapTest.m in Sources */,
 				F46D93601D9D4DEB00590137 /* GTMSessionFetcher.m in Sources */,
 				F46D93631D9D4DEB00590137 /* GTMSessionUploadFetcher.m in Sources */,
 				4F63A7AC19831052004D4315 /* GTMSessionFetcherChunkedUploadTest.m in Sources */,

--- a/Source/GTMSessionFetcherCore.xcodeproj/project.pbxproj
+++ b/Source/GTMSessionFetcherCore.xcodeproj/project.pbxproj
@@ -81,6 +81,8 @@
 		4FEE143B1BB223DE002ACBF8 /* GTMSessionUploadFetcher.h in Headers */ = {isa = PBXBuildFile; fileRef = 4F6F7E8018D6B2CD00CA4B4C /* GTMSessionUploadFetcher.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		4FEE143C1BB223DE002ACBF8 /* GTMSessionUploadFetcher.m in Sources */ = {isa = PBXBuildFile; fileRef = 4F6F7E8118D6B2CD00CA4B4C /* GTMSessionUploadFetcher.m */; };
 		4FEE6531192D8451001B6234 /* MainStoryboard.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 4FEE6530192D8451001B6234 /* MainStoryboard.storyboard */; };
+		7C6F25E3218372DF003AC4F9 /* GTMSessionFetcherURLSessionDelegateSwapTest.m in Sources */ = {isa = PBXBuildFile; fileRef = 7C7EB0162180B44300E7CE2A /* GTMSessionFetcherURLSessionDelegateSwapTest.m */; };
+		7C6F25E4218372E4003AC4F9 /* GTMSessionFetcherURLSessionDelegateSwapTest.m in Sources */ = {isa = PBXBuildFile; fileRef = 7C7EB0162180B44300E7CE2A /* GTMSessionFetcherURLSessionDelegateSwapTest.m */; };
 		7C7EB0172180B44300E7CE2A /* GTMSessionFetcherURLSessionDelegateSwapTest.m in Sources */ = {isa = PBXBuildFile; fileRef = 7C7EB0162180B44300E7CE2A /* GTMSessionFetcherURLSessionDelegateSwapTest.m */; };
 		8E809F7218BC3AAE0040AE83 /* CoreGraphics.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 8E809F7118BC3AAE0040AE83 /* CoreGraphics.framework */; };
 		8EC5668E18AAFB1200E2C97D /* Foundation.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 4F5566B71862981000D6D62C /* Foundation.framework */; };
@@ -901,6 +903,7 @@
 				4F6F7ECF18D6B60300CA4B4C /* GTMSessionFetcherServiceTest.m in Sources */,
 				4FE52ABC18D7A37000C78136 /* GTMGatherInputStreamTest.m in Sources */,
 				F493FADE1D9C5B5900F6D5DC /* GTMSessionFetcherService.m in Sources */,
+				7C6F25E3218372DF003AC4F9 /* GTMSessionFetcherURLSessionDelegateSwapTest.m in Sources */,
 				F493FADC1D9C5B5900F6D5DC /* GTMSessionFetcher.m in Sources */,
 				F493FADF1D9C5B5900F6D5DC /* GTMSessionUploadFetcher.m in Sources */,
 				4F6F7EC718D6B60300CA4B4C /* GTMMIMEDocumentTest.m in Sources */,
@@ -1010,6 +1013,7 @@
 				F4A872291DA3EEF900D69E09 /* GTMSessionFetcherLogging.m in Sources */,
 				F4A8722E1DA3EF3900D69E09 /* GTMReadMonitorInputStreamTest.m in Sources */,
 				F4A872321DA3EF3900D69E09 /* GTMSessionFetcherServiceTest.m in Sources */,
+				7C6F25E4218372E4003AC4F9 /* GTMSessionFetcherURLSessionDelegateSwapTest.m in Sources */,
 				F4A872261DA3EEF900D69E09 /* GTMMIMEDocument.m in Sources */,
 				F4A872271DA3EEF900D69E09 /* GTMReadMonitorInputStream.m in Sources */,
 				F4A8722C1DA3EF3900D69E09 /* GTMGatherInputStreamTest.m in Sources */,

--- a/Source/GTMSessionFetcherService.m
+++ b/Source/GTMSessionFetcherService.m
@@ -374,17 +374,19 @@ NSString *const kGTMSessionFetcherServiceSessionKey
 }
 
 // Internal utility. Returns a fetcher's delegate if it's a dispatcher, or nil if the fetcher
-// is its own delegate and has no dispatcher.
+// is its either own delegate and has no dispatcher or swizzled alien.
 - (GTMSessionFetcherSessionDelegateDispatcher *)delegateDispatcherForFetcher:(GTMSessionFetcher *)fetcher {
   GTMSessionCheckNotSynchronized(self);
 
   NSURLSession *fetcherSession = fetcher.session;
   if (fetcherSession) {
     id<NSURLSessionDelegate> fetcherDelegate = fetcherSession.delegate;
-    BOOL hasDispatcher = (fetcherDelegate != nil && fetcherDelegate != fetcher);
-    if (hasDispatcher) {
+      BOOL maybeHasDispatcher = (fetcherDelegate != nil && fetcherDelegate != fetcher);
+      
       GTMSESSION_ASSERT_DEBUG([fetcherDelegate isKindOfClass:[GTMSessionFetcherSessionDelegateDispatcher class]],
                               @"Fetcher delegate class: %@", [fetcherDelegate class]);
+      
+    if (maybeHasDispatcher && [fetcherDelegate isKindOfClass:GTMSessionFetcherSessionDelegateDispatcher.class]) {
       return (GTMSessionFetcherSessionDelegateDispatcher *)fetcherDelegate;
     }
   }

--- a/Source/GTMSessionFetcherService.m
+++ b/Source/GTMSessionFetcherService.m
@@ -383,9 +383,6 @@ NSString *const kGTMSessionFetcherServiceSessionKey
     id<NSURLSessionDelegate> fetcherDelegate = fetcherSession.delegate;
     BOOL maybeHasDispatcher = (fetcherDelegate != nil && fetcherDelegate != fetcher);
       
-    GTMSESSION_ASSERT_DEBUG([fetcherDelegate isKindOfClass:[GTMSessionFetcherSessionDelegateDispatcher class]],
-                            @"Fetcher delegate class: %@", [fetcherDelegate class]);
-    
     if (maybeHasDispatcher && [fetcherDelegate isKindOfClass:GTMSessionFetcherSessionDelegateDispatcher.class]) {
       return (GTMSessionFetcherSessionDelegateDispatcher *)fetcherDelegate;
     }

--- a/Source/GTMSessionFetcherService.m
+++ b/Source/GTMSessionFetcherService.m
@@ -381,11 +381,11 @@ NSString *const kGTMSessionFetcherServiceSessionKey
   NSURLSession *fetcherSession = fetcher.session;
   if (fetcherSession) {
     id<NSURLSessionDelegate> fetcherDelegate = fetcherSession.delegate;
-      BOOL maybeHasDispatcher = (fetcherDelegate != nil && fetcherDelegate != fetcher);
+    BOOL maybeHasDispatcher = (fetcherDelegate != nil && fetcherDelegate != fetcher);
       
-      GTMSESSION_ASSERT_DEBUG([fetcherDelegate isKindOfClass:[GTMSessionFetcherSessionDelegateDispatcher class]],
-                              @"Fetcher delegate class: %@", [fetcherDelegate class]);
-      
+    GTMSESSION_ASSERT_DEBUG([fetcherDelegate isKindOfClass:[GTMSessionFetcherSessionDelegateDispatcher class]],
+                            @"Fetcher delegate class: %@", [fetcherDelegate class]);
+    
     if (maybeHasDispatcher && [fetcherDelegate isKindOfClass:GTMSessionFetcherSessionDelegateDispatcher.class]) {
       return (GTMSessionFetcherSessionDelegateDispatcher *)fetcherDelegate;
     }

--- a/Source/UnitTests/GTMSessionFetcherURLSessionDelegateSwapTest.m
+++ b/Source/UnitTests/GTMSessionFetcherURLSessionDelegateSwapTest.m
@@ -110,6 +110,8 @@
     }];
     
     [self waitForExpectations:@[swizzleDidActuallyHappenExpectaion] timeout:1];
+    
+    [fetcher stopFetching];
 }
 
 @end

--- a/Source/UnitTests/GTMSessionFetcherURLSessionDelegateSwapTest.m
+++ b/Source/UnitTests/GTMSessionFetcherURLSessionDelegateSwapTest.m
@@ -1,0 +1,115 @@
+//
+//  GTMSessionFetcherURLSessionDelegateSwapTest.m
+//  FetcheriOSTests
+//
+//  Created by Oleg Shanyuk on 24.10.18.
+//  Copyright © 2018 Oleg Shanyuk. All rights reserved.
+//
+
+#import <XCTest/XCTest.h>
+
+#import <objc/runtime.h>
+
+#import "GTMSessionFetcher.h"
+#import "GTMSessionFetcherService.h"
+
+
+@interface UrlSessionDelegateMock : NSObject<NSURLSessionDelegate, NSURLSessionTaskDelegate>
+
+// I'm totally dumb object, not like some trust kit or so... just an air in the nsobject ballon
+
+@property (nonatomic, nullable) XCTestExpectation *swizzledMethodsDidCallExpectation;
+
++ (instancetype)sharedObject;
++ (NSURLSession *)sessionWithConfiguration:(NSURLSessionConfiguration *)configuration delegate:(nullable id <NSURLSessionDelegate>)delegate delegateQueue:(nullable NSOperationQueue *)queue;
+
+@end
+
+@implementation UrlSessionDelegateMock
+
+@synthesize swizzledMethodsDidCallExpectation = _swizzledMethodDidCall;
+
++ (instancetype)sharedObject
+{
+    static dispatch_once_t onceToken;
+    static UrlSessionDelegateMock *object;
+    dispatch_once(&onceToken, ^{
+        object = [UrlSessionDelegateMock new];
+    });
+    
+    return object;
+}
+
+
++ (NSURLSession *)sessionWithConfiguration:(NSURLSessionConfiguration *)configuration delegate:(nullable id <NSURLSessionDelegate>)delegate delegateQueue:(nullable NSOperationQueue *)queue
+{
+    // THUS WE CALLING TO THE ORIGINAL's METHOD
+    
+    UrlSessionDelegateMock *sessionDelegateMonster = UrlSessionDelegateMock.sharedObject;
+    
+    [sessionDelegateMonster.swizzledMethodsDidCallExpectation fulfill];
+    
+    return [UrlSessionDelegateMock sessionWithConfiguration:configuration delegate:sessionDelegateMonster delegateQueue:queue];
+}
+
+@end
+
+
+
+@interface GTMSessionFetcherURLSessionDelegateSwapTest : XCTestCase<NSURLSessionDelegate>
+@property (nonatomic) GTMSessionFetcherService *fetcherService;
+
+@end
+
+@implementation GTMSessionFetcherURLSessionDelegateSwapTest {
+    Method originalMethod;
+    Method swizzledMethod;
+}
+
+@synthesize fetcherService = _fetcherService;
+
+- (void)setUp
+{
+    [super setUp];
+    
+    _fetcherService = [[GTMSessionFetcherService alloc] init];
+    
+    
+    /// SWIZZLE THINGz
+
+    SEL selector = @selector(sessionWithConfiguration:delegate:delegateQueue:);
+
+    originalMethod = class_getClassMethod(NSURLSession.class, selector);
+    swizzledMethod = class_getClassMethod(UrlSessionDelegateMock.class, selector);
+    
+    XCTAssert(originalMethod);
+    XCTAssert(swizzledMethod);
+    
+    method_exchangeImplementations(originalMethod, swizzledMethod);
+}
+
+- (void)tearDown
+{
+    // UNSWIZZLE THAT SH
+    method_exchangeImplementations(originalMethod, swizzledMethod);
+}
+
+- (void)testUrlSessionWithDelegate
+{
+    
+    // OK, I'm with swizzling error, and this part might need some improvements... anyway...
+    
+    GTMSessionFetcher *fetcher = [_fetcherService fetcherWithURLString:@"https://google.com"];
+    
+    XCTestExpectation *swizzleDidActuallyHappenExpectaion = [self expectationWithDescription:@"swizzle expected"];
+    
+    UrlSessionDelegateMock.sharedObject.swizzledMethodsDidCallExpectation = swizzleDidActuallyHappenExpectaion;
+    
+    [fetcher beginFetchWithCompletionHandler:^(NSData * _Nullable data, NSError * _Nullable error) {
+        NSLog(@"¯\\_(ツ)_/¯ can you help with that please?");
+    }];
+    
+    [self waitForExpectations:@[swizzleDidActuallyHappenExpectaion] timeout:1];
+}
+
+@end

--- a/Source/UnitTests/GTMSessionFetcherURLSessionDelegateSwapTest.m
+++ b/Source/UnitTests/GTMSessionFetcherURLSessionDelegateSwapTest.m
@@ -1,10 +1,17 @@
-//
-//  GTMSessionFetcherURLSessionDelegateSwapTest.m
-//  FetcheriOSTests
-//
-//  Created by Oleg Shanyuk on 24.10.18.
-//  Copyright © 2018 Oleg Shanyuk. All rights reserved.
-//
+/* Copyright 2014 Google Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 
 #import <XCTest/XCTest.h>
 


### PR DESCRIPTION
Well, basically, the topic.

I've met this problem when I've used [TrustKit](https://github.com/datatheorem/TrustKit), which wraps NSURLSessionDelegate with own implementation.

So, I've re-created a test case, which crashes without the fix.

Have a look please if it works for all occasions (at least, tests went fine with me).

Looking forward to your comments.