### PR TITLE
GTMSessionUploadFetcher - Handle empty and non-existing files to upload (issue #140)

### DIFF
--- a/Source/GTMSessionUploadFetcher.m
+++ b/Source/GTMSessionUploadFetcher.m
@@ -1430,11 +1430,13 @@ NSString *const kGTMSessionFetcherUploadLocationObtainedNotification =
 
   // TODO
   // Maybe here we can check to see if the request had x goog content length set. (the file length one).
-  int64_t previousContentLength =
-      [[chunkFetcher.request valueForHTTPHeaderField:@"Content-Length"] longLongValue];
+  NSString *previousContentLengthValue =
+      [chunkFetcher.request valueForHTTPHeaderField:@"Content-Length"];
   // The Content-Length header may not be present if the chunk fetcher was recreated from
   // a background session.
-  BOOL hasKnownChunkSize = (previousContentLength > 0);
+  BOOL hasKnownChunkSize = (previousContentLengthValue != nil);
+  int64_t previousContentLength = [previousContentLengthValue longLongValue];
+
   BOOL needsQuery = (!hasKnownChunkSize && !isUploadStatusStopped);
 
   if (error || (needsQuery && !isQueryFetch)) {
@@ -1479,7 +1481,9 @@ NSString *const kGTMSessionFetcherUploadLocationObtainedNotification =
                             chunkFetcher, chunkFetcher.request.allHTTPHeaderFields,
                             responseHeaders);
 #endif
-    if (isUploadStatusStopped || (_currentOffset > _uploadFileLength && _uploadFileLength > 0)) {
+    if (isUploadStatusStopped ||
+        _uploadFileLength == 0 ||
+        (_currentOffset > _uploadFileLength && _uploadFileLength > 0)) {
       // This was the last chunk.
       if (error == nil && uploadStatus == kStatusCancelled) {
         // Report cancelled status as an error.

--- a/Source/UnitTests/GTMSessionFetcherChunkedUploadTest.m
+++ b/Source/UnitTests/GTMSessionFetcherChunkedUploadTest.m
@@ -981,14 +981,14 @@ static void TestProgressBlock(GTMSessionUploadFetcher *fetcher,
   NSArray *expectedURLStrings = @[ @"/gettysburgaddress.txt.upload" ];
   NSArray *expectedCommands = @[ @"upload, finalize" ];
   NSArray *expectedOffsets = @[ @0 ];
-  NSArray *expectedLengths = @[ @(kBigUploadDataLength) ];
+  NSArray *expectedLengths = @[ @0 ];
   XCTAssertEqualObjects(fnctr.uploadChunkRequestPaths, expectedURLStrings);
   XCTAssertEqualObjects(fnctr.uploadChunkCommands, expectedCommands);
   XCTAssertEqualObjects(fnctr.uploadChunkOffsets, expectedOffsets);
   XCTAssertEqualObjects(fnctr.uploadChunkLengths, expectedLengths);
 
-  XCTAssertEqual(fnctr.fetchStarted, 2);
-  XCTAssertEqual(fnctr.fetchStopped, 2);
+  XCTAssertEqual(fnctr.fetchStarted, 1);
+  XCTAssertEqual(fnctr.fetchStopped, 1);
   XCTAssertEqual(fnctr.uploadChunkFetchStarted, 1);
   XCTAssertEqual(fnctr.uploadChunkFetchStopped, 1);
   XCTAssertEqual(fnctr.retryDelayStarted, 0);


### PR DESCRIPTION
This is a fix for #140:
- empty files: return a server result (error or success depending on if the server accepts empty HTTP body for POST requests)
- unreachable file URL: complete with error