### PR TITLE
Revert the delayed resuming of background fetchers

### DIFF
--- a/Source/GTMSessionFetcher.m
+++ b/Source/GTMSessionFetcher.m
@@ -18,6 +18,9 @@
 #endif
 
 #import "GTMSessionFetcher.h"
+#if TARGET_OS_OSX
+#import <AppKit/AppKit.h>
+#endif
 
 #import <sys/utsname.h>
 
@@ -247,16 +250,11 @@ static GTMSessionFetcherTestBlock GTM_NULLABLE_TYPE gGlobalTestBlock;
              name:UIApplicationDidFinishLaunchingNotification
            object:nil];
 #elif GTMSESSION_RECONNECT_BACKGROUND_SESSIONS_ON_LAUNCH && TARGET_OS_OSX
-  // Weakly link the application-did-finish-launching notification name, since command-line
-  // Mac clients may not link AppKit.
-  extern NSNotificationName NSApplicationDidFinishLaunchingNotification __attribute__((weak_import));
-  if (NSApplicationDidFinishLaunchingNotification != NULL) {
-    NSNotificationCenter *nc = [NSNotificationCenter defaultCenter];
-    [nc addObserver:self
-           selector:@selector(reconnectFetchersForBackgroundSessionsOnAppLaunch:)
-               name:NSApplicationDidFinishLaunchingNotification
-             object:nil];
-  }
+  NSNotificationCenter *nc = [NSNotificationCenter defaultCenter];
+  [nc addObserver:self
+         selector:@selector(reconnectFetchersForBackgroundSessionsOnAppLaunch:)
+             name:NSApplicationDidFinishLaunchingNotification
+           object:nil];
 #else
   [self fetchersForBackgroundSessions];
 #endif

--- a/Source/GTMSessionFetcher.m
+++ b/Source/GTMSessionFetcher.m
@@ -18,9 +18,6 @@
 #endif
 
 #import "GTMSessionFetcher.h"
-#if TARGET_OS_OSX
-#import <AppKit/AppKit.h>
-#endif
 
 #import <sys/utsname.h>
 
@@ -89,34 +86,6 @@ GTM_ASSUME_NONNULL_END
     #define GTM_TARGET_SUPPORTS_APP_TRANSPORT_SECURITY 1
   #endif
 #endif
-
-// When creating background sessions to perform out-of-process uploads and
-// downloads, on app launch any background sessions must be reconnected in
-// order to receive events that occurred while the app was not running.
-//
-// The fetcher will automatically attempt to recreate the sessions on app
-// start, but doing so reads from NSUserDefaults. This may have launch-time
-// performance impacts.
-//
-// To avoid launch performance impacts, on iPhone/iPad/Mac with iOS 13+ and
-// macOS 10.15+ the GTMSessionFetcher class will register for the app launch
-// notification and perform the reconnect then.
-//
-// Apps targeting older SDKs can opt into the new behavior by defining
-// GTMSESSION_RECONNECT_BACKGROUND_SESSIONS_ON_LAUNCH=1.
-//
-// Apps targeting new SDKs can force the old behavior by defining
-// GTMSESSION_RECONNECT_BACKGROUND_SESSIONS_ON_LAUNCH = 0.
-#ifndef GTMSESSION_RECONNECT_BACKGROUND_SESSIONS_ON_LAUNCH
-  // Default to the on-launch behavior
-  #if (TARGET_OS_OSX && defined(MAC_OS_X_VERSION_10_15) && MAC_OS_X_VERSION_MAX_ALLOWED >= MAC_OS_X_VERSION_10_15) \
-       || (TARGET_OS_IOS && defined(__IPHONE_13_0) && __IPHONE_OS_VERSION_MAX_ALLOWED >= __IPHONE_13_0)
-    #define GTMSESSION_RECONNECT_BACKGROUND_SESSIONS_ON_LAUNCH 1
-  #else
-    #define GTMSESSION_RECONNECT_BACKGROUND_SESSIONS_ON_LAUNCH 0
-  #endif
-#endif
-
 
 @interface GTMSessionFetcher ()
 
@@ -243,32 +212,9 @@ static GTMSessionFetcherTestBlock GTM_NULLABLE_TYPE gGlobalTestBlock;
 
 #if !GTMSESSION_UNIT_TESTING
 + (void)load {
-#if GTMSESSION_RECONNECT_BACKGROUND_SESSIONS_ON_LAUNCH && TARGET_OS_IPHONE
-  NSNotificationCenter *nc = [NSNotificationCenter defaultCenter];
-  [nc addObserver:self
-         selector:@selector(reconnectFetchersForBackgroundSessionsOnAppLaunch:)
-             name:UIApplicationDidFinishLaunchingNotification
-           object:nil];
-#elif GTMSESSION_RECONNECT_BACKGROUND_SESSIONS_ON_LAUNCH && TARGET_OS_OSX
-  NSNotificationCenter *nc = [NSNotificationCenter defaultCenter];
-  [nc addObserver:self
-         selector:@selector(reconnectFetchersForBackgroundSessionsOnAppLaunch:)
-             name:NSApplicationDidFinishLaunchingNotification
-           object:nil];
-#else
   [self fetchersForBackgroundSessions];
+}
 #endif
-}
-
-+ (void)reconnectFetchersForBackgroundSessionsOnAppLaunch:(NSNotification *)notification {
-  // Give all other app-did-launch handlers a chance to complete before
-  // reconnecting the fetchers. Not doing this may lead to reconnecting
-  // before the app delegate has a chance to run.
-  dispatch_async(dispatch_get_main_queue(), ^{
-    [self fetchersForBackgroundSessions];
-  });
-}
-#endif  // !GTMSESSION_UNIT_TESTING
 
 + (instancetype)fetcherWithRequest:(GTM_NULLABLE NSURLRequest *)request {
   return [[self alloc] initWithRequest:request configuration:nil];


### PR DESCRIPTION
Still seeing some reports of issues with command line tools that used the fetcher, so rolling this back so it can be revisited to make things safer.