### PR TITLE
Set the watchOS min to match the podspec.

### DIFF
--- a/Source/GTMSessionFetcherCore.xcodeproj/project.pbxproj
+++ b/Source/GTMSessionFetcherCore.xcodeproj/project.pbxproj
@@ -1161,6 +1161,7 @@
 					"-Widiomatic-parentheses",
 					"-Wimplicit-atomic-properties",
 				);
+				WATCHOS_DEPLOYMENT_TARGET = 2.0;
 			};
 			name = Debug;
 		};
@@ -1240,6 +1241,7 @@
 					"-Widiomatic-parentheses",
 					"-Wimplicit-atomic-properties",
 				);
+				WATCHOS_DEPLOYMENT_TARGET = 2.0;
 			};
 			name = Release;
 		};


### PR DESCRIPTION
Looks like it was floating so it was getting a value based on the Xcode used,
this atleast makes it like the other platforms and set to something explicit.