### PR TITLE
Fix Test build due to MD5 deprecations.

### DIFF
--- a/Source/UnitTests/GTMSessionFetcherTestServer.m
+++ b/Source/UnitTests/GTMSessionFetcherTestServer.m
@@ -112,7 +112,12 @@ static NSString *const kEtag = @"GoodETag";
   NSData* data = [self dataUsingEncoding:NSUTF8StringEncoding];
 
   unsigned char MD5Digest[CC_MD5_DIGEST_LENGTH];
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wdeprecated-declarations"
+  // MD5 is deprecated in the iOS 13/OSX 10.15 headers, but is the explicit hash used for digest
+  // authentication, used here only for tests.
   CC_MD5(data.bytes, (CC_LONG)data.length, MD5Digest);
+#pragma clang diagnostic pop
   NSMutableString *MD5DigestString = [NSMutableString stringWithCapacity:2 * CC_MD5_DIGEST_LENGTH];
   for (int i = 0; i < CC_MD5_DIGEST_LENGTH; ++i) {
     [MD5DigestString appendFormat:@"%02x", (unsigned int)MD5Digest[i]];


### PR DESCRIPTION
In the iOS 13/Mac 10.15 SDK the CC_MD5() is officially deprecated, but is being used within tests (only) for a means of testing authentication mechanisms. Pending a more thorough review of whether this test should be rewritten, updating the test code to enable targeting the tests at iOS 13/Mac 10.15 targets.