### PR TITLE
Make GTMSessionUploadFetcher's chunkSize property readonly.

### DIFF
--- a/Source/GTMSessionUploadFetcher.h
+++ b/Source/GTMSessionUploadFetcher.h
@@ -132,7 +132,7 @@ typedef void (^GTMSessionUploadFetcherCancellationHandler)(
 @property(atomic, strong, GTM_NULLABLE) NSFileHandle *uploadFileHandle;
 @property(atomic, copy, readonly, GTM_NULLABLE) GTMSessionUploadFetcherDataProvider uploadDataProvider;
 @property(atomic, copy) NSString *uploadMIMEType;
-@property(atomic, assign) int64_t chunkSize;
+@property(atomic, readonly, assign) int64_t chunkSize;
 @property(atomic, readonly, assign) int64_t currentOffset;
 // Reflects the original NSURLRequest's @c allowCellularAccess property.
 @property(atomic, readonly, assign) BOOL allowsCellularAccess;

--- a/Source/GTMSessionUploadFetcher.m
+++ b/Source/GTMSessionUploadFetcher.m
@@ -464,14 +464,6 @@ NSString *const kGTMSessionFetcherUploadLocationObtainedNotification =
   }
 }
 
-- (void)setChunkSize:(int64_t)chunkSize {
-  @synchronized(self) {
-    GTMSessionMonitorSynchronized(self);
-
-    _chunkSize = chunkSize;
-  }
-}
-
 - (int64_t)chunkSize {
   @synchronized(self) {
     GTMSessionMonitorSynchronized(self);


### PR DESCRIPTION
If a custom chunk size is desired, it should be set once at fetcher creation and not modified after.