### PR TITLE
Fix flakey -testFetchToFile/testUnsuccessfulFetchToFile.

### DIFF
--- a/Source/GTMSessionFetcher.m
+++ b/Source/GTMSessionFetcher.m
@@ -2707,20 +2707,18 @@ totalBytesExpectedToWrite:(int64_t)totalBytesExpectedToWrite {
       // but totalBytesWritten > totalBytesExpectedToWrite, so setting to unkown in these cases.
       totalBytesExpectedToWrite = NSURLSessionTransferSizeUnknown;
     }
-    // We won't hold on to download progress block during the enqueue;
-    // it's ok to not send it if the upload finishes.
 
-    [self invokeOnCallbackQueueUnlessStopped:^{
-      GTMSessionFetcherDownloadProgressBlock progressBlock;
-      @synchronized(self) {
-        GTMSessionMonitorSynchronized(self);
+    GTMSessionFetcherDownloadProgressBlock progressBlock;
+    @synchronized(self) {
+      GTMSessionMonitorSynchronized(self);
 
-        progressBlock = self->_downloadProgressBlock;
-      }
-      if (progressBlock) {
+      progressBlock = self->_downloadProgressBlock;
+    }
+    if (progressBlock) {
+      [self invokeOnCallbackQueueUnlessStopped:^{
         progressBlock(bytesWritten, totalBytesWritten, totalBytesExpectedToWrite);
-      }
-    }];
+      }];
+    }
   }  // @synchronized(self)
 }
 


### PR DESCRIPTION
The download progress block was explicitly not being retained when dispatching to the callback queue, meaning the callback may or may not be called, depending on the dispatch behavior. This led to the test flaking, because it would not always update the total bytes written.