### PR TITLE
Cleanup iOS 8/macOS 10.10 version checking cruft.

### DIFF
--- a/Source/GTMSessionFetcher.m
+++ b/Source/GTMSessionFetcher.m
@@ -639,7 +639,7 @@ static GTMSessionFetcherTestBlock GTM_NULLABLE_TYPE gGlobalTestBlock;
         NSMapTable *sessionIdentifierToFetcherMap = [[self class] sessionIdentifierToFetcherMap];
         [sessionIdentifierToFetcherMap setObject:self forKey:self.sessionIdentifier];
 
-        if (@available(iOS 8.0, macOS 10.10, *)) {
+        if (@available(iOS 8.0, tvOS 9.0, watchOS 2.0, macOS 10.10, *)) {
           _configuration =
               [NSURLSessionConfiguration backgroundSessionConfigurationWithIdentifier:sessionIdentifier];
         } else {


### PR DESCRIPTION
A bunch of now-unnecessary #ifs were added at one point due to @available not being universally available. Clients are now assumed to be building with a version of Xcode that has @available, so cleaned up the pile of #ifs and replaced with some @available checks.

No functional changes.