### PR TITLE
Release fetcher's active background task while awaiting retry.

### DIFF
--- a/Source/GTMSessionFetcher.m
+++ b/Source/GTMSessionFetcher.m
@@ -3197,6 +3197,14 @@ didCompleteWithError:(NSError *)error {
   }
 
   [self destroyRetryTimer];
+  
+#if GTM_BACKGROUND_TASK_FETCHING
+  // Don't keep a background task active while awaiting retry, which can lead to the
+  // app exceeding the allotted time for keeping the background task open, causing the
+  // system to terminate the app. When the retry starts, a new background task will
+  // be created.
+  [self endBackgroundTask];
+#endif  // GTM_BACKGROUND_TASK_FETCHING
 
   @synchronized(self) {
     GTMSessionMonitorSynchronized(self);


### PR DESCRIPTION
When a fetch fails and attempts to retry, the background task was not being ended until the retry timer fires. In cases where the retry time may be large, the task may not complete for a long time, potentially holding the task open with the system beyond the alloted execution time leading to the app being terminated by the system.

Before starting the retry timer, the background task should be released.