### PR TITLE
Pass testBlock onto subordinate upload fetchers.

### DIFF
--- a/Source/GTMSessionUploadFetcher.m
+++ b/Source/GTMSessionUploadFetcher.m
@@ -1387,6 +1387,9 @@ NSString *const kGTMSessionFetcherUploadLocationObtainedNotification =
   chunkFetcher.allowLocalhostRequest = self.allowLocalhostRequest;
   chunkFetcher.allowInvalidServerCertificates = self.allowInvalidServerCertificates;
   chunkFetcher.useUploadTask = !isQueryFetch;
+#if !GTM_DISABLE_FETCHER_TEST_BLOCK
+  chunkFetcher.testBlock = self.testBlock;
+#endif  // GTM_DISABLE_FETCHER_TEST_BLOCK
 
   if (self.uploadFileURL && !isQueryFetch && self.useBackgroundSession) {
     [chunkFetcher createSessionIdentifierWithMetadata:[self uploadSessionIdentifierMetadata]];

--- a/Source/GTMSessionUploadFetcher.m
+++ b/Source/GTMSessionUploadFetcher.m
@@ -1389,7 +1389,7 @@ NSString *const kGTMSessionFetcherUploadLocationObtainedNotification =
   chunkFetcher.useUploadTask = !isQueryFetch;
 #if !GTM_DISABLE_FETCHER_TEST_BLOCK
   chunkFetcher.testBlock = self.testBlock;
-#endif  // GTM_DISABLE_FETCHER_TEST_BLOCK
+#endif  // !GTM_DISABLE_FETCHER_TEST_BLOCK
 
   if (self.uploadFileURL && !isQueryFetch && self.useBackgroundSession) {
     [chunkFetcher createSessionIdentifierWithMetadata:[self uploadSessionIdentifierMetadata]];


### PR DESCRIPTION
With testBlock specified, GTMSessionUploadFetcher's subordinate query and chunk fetchers attempt to hit the network. This change passes testBlock onto subordinates, allowing test callers to simulate various backend responses and network errors at query and chunk upload time.