### PR TITLE
Fix background task behavior with background sessions.

### DIFF
--- a/Source/GTMSessionFetcher.m
+++ b/Source/GTMSessionFetcher.m
@@ -551,8 +551,11 @@ static GTMSessionFetcherTestBlock GTM_NULLABLE_TYPE gGlobalTestBlock;
                            fetchRequest);
     }
 #endif
+    // If priorSessionIdentifier is allowed to stay nil, it will still create a background
+    // session.
+    priorSessionIdentifier = nil;
     [self setSessionIdentifierInternal:nil];
-    self.useBackgroundSession = NO;
+    self.usingBackgroundSession = NO;
   }
 
 #if GTM_ALLOW_INSECURE_REQUESTS
@@ -902,7 +905,7 @@ static GTMSessionFetcherTestBlock GTM_NULLABLE_TYPE gGlobalTestBlock;
 #if GTM_BACKGROUND_TASK_FETCHING
   id<GTMUIApplicationProtocol> app = [[self class] fetcherUIApplication];
   // Background tasks seem to interfere with out-of-process uploads and downloads.
-  if (app && !self.skipBackgroundTask && !self.useBackgroundSession) {
+  if (app && !self.skipBackgroundTask && !self.usingBackgroundSession) {
     // Tell UIApplication that we want to continue even when the app is in the
     // background.
 #if DEBUG

--- a/Source/GTMSessionFetcher.m
+++ b/Source/GTMSessionFetcher.m
@@ -551,8 +551,8 @@ static GTMSessionFetcherTestBlock GTM_NULLABLE_TYPE gGlobalTestBlock;
                            fetchRequest);
     }
 #endif
-    // If priorSessionIdentifier is allowed to stay nil, it will still create a background
-    // session.
+    // If priorSessionIdentifier is allowed to stay non-nil, a background session can
+    // still be created.
     priorSessionIdentifier = nil;
     [self setSessionIdentifierInternal:nil];
     self.usingBackgroundSession = NO;


### PR DESCRIPTION
Previously was checking `useBackgroundSession` for the active state, while that property is documented only as the client's expressed preference that the fetch use a background session. Even with `useBackgroundSession = NO`, if a `sessionIdentifer` is set before beginning the fetch than a background session will be used (and `usingBackgroundSession` will be `YES`. Because `useBackgroundSession` was being checked instead, a background task could be created but shouldn't have been.

This also fixes some issues with GTMSessionUploadFetcher instances and their chunk fetchers. For the initial fetch, `canFetchWithBackgroundSession` will return NO, but `useBackgroundSession` could be YES, leading to _not_ creating a background task identifier for the initial fetch, but because subsequent chunk fetchers are created without `useBackgroundSession == YES`, but relying on the `sessionIdentifier` being non-nil to use a background session, this would lead to creating background task IDs for the chunk fetchers.

Also fixed a potential issue if a fetch for a data: URL is created and `useBackgroundSession == YES`.