### PR TITLE
Support metrics collection. (#187)

### DIFF
--- a/Source/GTMSessionFetcher.h
+++ b/Source/GTMSessionFetcher.h
@@ -560,6 +560,9 @@ typedef void (^GTMSessionFetcherRetryBlock)(BOOL suggestedWillRetry,
                                             NSError * GTM_NULLABLE_TYPE error,
                                             GTMSessionFetcherRetryResponse response);
 
+API_AVAILABLE(ios(10.0), macosx(10.12), tvos(10.0), watchos(3.0))
+typedef void (^GTMSessionFetcherMetricsCollectionBlock)(NSURLSessionTaskMetrics *metrics);
+
 typedef void (^GTMSessionFetcherTestResponse)(NSHTTPURLResponse * GTM_NULLABLE_TYPE response,
                                               NSData * GTM_NULLABLE_TYPE data,
                                               NSError * GTM_NULLABLE_TYPE error);
@@ -995,6 +998,13 @@ NSData * GTM_NULLABLE_TYPE GTMDataFromInputStream(NSInputStream *inputStream, NS
 // fetch.
 // See comments at the top of this file.
 @property(atomic, copy, GTM_NULLABLE) GTMSessionFetcherRetryBlock retryBlock;
+
+// The optional block for collecting the metrics of the present session.
+//
+// This is called on the callback queue.
+@property(atomic, copy, GTM_NULLABLE)
+    GTMSessionFetcherMetricsCollectionBlock metricsCollectionBlock API_AVAILABLE(
+        ios(10.0), macosx(10.12), tvos(10.0), watchos(3.0));
 
 // Retry intervals must be strictly less than maxRetryInterval, else
 // they will be limited to maxRetryInterval and no further retries will

--- a/Source/GTMSessionFetcherService.h
+++ b/Source/GTMSessionFetcherService.h
@@ -63,6 +63,9 @@ extern NSString *const kGTMSessionFetcherServiceSessionKey;
 @property(atomic, assign) NSTimeInterval maxRetryInterval;
 @property(atomic, assign) NSTimeInterval minRetryInterval;
 @property(atomic, copy, GTM_NULLABLE) GTM_NSDictionaryOf(NSString *, id) *properties;
+@property(atomic, copy, GTM_NULLABLE)
+    GTMSessionFetcherMetricsCollectionBlock metricsCollectionBlock API_AVAILABLE(
+        ios(10.0), macosx(10.12), tvos(10.0), watchos(3.0));
 
 #if GTM_BACKGROUND_TASK_FETCHING
 @property(atomic, assign) BOOL skipBackgroundTask;

--- a/Source/GTMSessionFetcherService.m
+++ b/Source/GTMSessionFetcherService.m
@@ -121,6 +121,7 @@ NSString *const kGTMSessionFetcherServiceSessionKey
             retryBlock = _retryBlock,
             maxRetryInterval = _maxRetryInterval,
             minRetryInterval = _minRetryInterval,
+            metricsCollectionBlock = _metricsCollectionBlock,
             properties = _properties,
             unusedSessionTimeout = _unusedSessionTimeout,
             testBlock = _testBlock;
@@ -186,6 +187,9 @@ NSString *const kGTMSessionFetcherServiceSessionKey
   fetcher.retryBlock = self.retryBlock;
   fetcher.maxRetryInterval = self.maxRetryInterval;
   fetcher.minRetryInterval = self.minRetryInterval;
+  if (@available(iOS 10.0, macOS 10.12, tvOS 10.0, watchOS 3.0, *)) {
+    fetcher.metricsCollectionBlock = self.metricsCollectionBlock;
+  }
   fetcher.properties = self.properties;
   fetcher.service = self;
   if (self.cookieStorageMethod >= 0) {
@@ -1279,6 +1283,14 @@ didCompleteWithError:(NSError *)error {
   [fetcher URLSession:session
                  task:task
  didCompleteWithError:error];
+}
+
+- (void)URLSession:(NSURLSession *)session
+                          task:(NSURLSessionTask *)task
+    didFinishCollectingMetrics:(NSURLSessionTaskMetrics *)metrics
+    API_AVAILABLE(ios(10.0), macosx(10.12), tvos(10.0), watchos(3.0)) {
+  id<NSURLSessionTaskDelegate> fetcher = [self fetcherForTask:task];
+  [fetcher URLSession:session task:task didFinishCollectingMetrics:metrics];
 }
 
 // NSURLSessionDataDelegate protocol methods.

--- a/Source/UnitTests/GTMSessionFetcherServiceTest.m
+++ b/Source/UnitTests/GTMSessionFetcherServiceTest.m
@@ -820,4 +820,29 @@ static NSString *const kValidFileName = @"gettysburgaddress.txt";
   [session invalidateAndCancel];
 }
 
+- (void)testFetcherUsingMetricsCollectionBlockFromFetcherService API_AVAILABLE(ios(10.0),
+                                                                               macosx(10.12),
+                                                                               tvos(10.0),
+                                                                               watchos(3.0)) {
+  if (!_isServerRunning) return;
+
+  __block NSURLSessionTaskMetrics *collectedMetrics = nil;
+
+  GTMSessionFetcherService *service = [[GTMSessionFetcherService alloc] init];
+  service.metricsCollectionBlock = ^(NSURLSessionTaskMetrics *_Nonnull metrics) {
+    collectedMetrics = metrics;
+  };
+
+  NSURL *fetchURL = [_testServer localURLForFile:kValidFileName];
+  GTMSessionFetcher *fetcher = [service fetcherWithURL:fetchURL];
+  [fetcher beginFetchWithCompletionHandler:^(NSData *fetchData, NSError *fetchError) {
+    XCTAssertNotNil(fetchData);
+    XCTAssertNil(fetchError);
+  }];
+
+  [service waitForCompletionOfAllFetchersWithTimeout:10];
+
+  XCTAssertNotNil(collectedMetrics);
+}
+
 @end


### PR DESCRIPTION
This adds support to handle the
`-URLSession:task:didFinishCollectingMetrics:` delegate method in the
`NSURLSessionTaskDelegate protocol`. A new callback block type,
`GTMSessionFetcherMetricsCollectionBlock`, is also added.

This feature is enabled when compiled for iOS 10+, macOS 10.12+, Mac
Catalyst 13.0+, tvOS 10.0+, or watchOS 3.0+.

New test methods are added to cover this feature.

This commit also upgrades the iOS target SDK in the Xcode project file
to iOS 10.0.