### PR TITLE
Revert "Work around early iOS 13 betas still in use."

### DIFF
--- a/Source/GTMSessionFetcher.m
+++ b/Source/GTMSessionFetcher.m
@@ -665,18 +665,7 @@ static GTMSessionFetcherTestBlock GTM_NULLABLE_TYPE gGlobalTestBlock;
       _configuration.TLSMinimumSupportedProtocolVersion = tls_protocol_version_TLSv12;
 #elif GTM_SDK_SUPPORTS_TLSMINIMUMSUPPORTEDPROTOCOLVERSION
       if (@available(iOS 13, tvOS 13, watchOS 6, macOS 10.15, *)) {
-#if TARGET_OS_IOS
-        // Early seeds of iOS 13 don't actually support the selector and several
-        // months later, those seeds are still in use, so validate if the selector
-        // is supported.
-        if ([_configuration respondsToSelector:@selector(setTLSMinimumSupportedProtocolVersion:)]) {
-          _configuration.TLSMinimumSupportedProtocolVersion = tls_protocol_version_TLSv12;
-        } else {
-          _configuration.TLSMinimumSupportedProtocol = kTLSProtocol12;
-        }
-#else
         _configuration.TLSMinimumSupportedProtocolVersion = tls_protocol_version_TLSv12;
-#endif  // TARGET_OS_IOS
       } else {
         _configuration.TLSMinimumSupportedProtocol = kTLSProtocol12;
       }


### PR DESCRIPTION
This reverts commit 67d6e1ba577b4fe902d3ce6fd4374bf841e9b902.

Original PR was intended to be a short-term change due to a large-ish number of users still remaining on early iOS 13 public betas. Had planned to reevaluate that decision eventually, and have come to the conclusion we should no longer maintain the fix rather than retain the standard mechanism for checking for API support.