### PR TITLE
Check a service exists before marking created `NSURLSession` as shared.

### DIFF
--- a/Source/GTMSessionFetcher.m
+++ b/Source/GTMSessionFetcher.m
@@ -622,7 +622,7 @@ static GTMSessionFetcherTestBlock GTM_NULLABLE_TYPE gGlobalTestBlock;
 
   BOOL isRecreatingSession = (self.sessionIdentifier != nil) && (fetchRequest == nil);
 
-  self.canShareSession = !isRecreatingSession && !self.usingBackgroundSession;
+  self.canShareSession = (_service != nil) && !isRecreatingSession && !self.usingBackgroundSession;
 
   if (!self.session && self.canShareSession) {
     self.session = [_service sessionForFetcherCreation];


### PR DESCRIPTION
The fetcher only "shares" its `NSURLSession` when being created via a `GTMSessionFetcherService`. If no service is set, but an authorizer is provided and needs to request authorization before it can continue the fetch, when `canSharedSession == YES` the fetcher's `NSURLSession` is released but not invalidated, which can lead to a leak due to the session retaining its delegate (the fetcher) and itself.