### PR TITLE
Remove special character ç to prevent downstream failures in python3 encoding/decoding

### DIFF
--- a/Source/GTMSessionFetcherLogging.m
+++ b/Source/GTMSessionFetcherLogging.m
@@ -226,7 +226,7 @@ static NSString *gLoggingProcessName = nil;
 }
 
 + (NSString *)htmlFileName {
-  return @"aperçu_http_log.html";
+  return @"apercu_http_log.html";
 }
 
 + (void)deleteLogDirectoriesOlderThanDate:(NSDate *)cutoffDate {


### PR DESCRIPTION
The character ç is causing downstream packages that use python3 to fail at the encoding/decoding step. Removing the character here seems like it would cause the lease side effects, and mitigate any issues that other users would have with a similar issue.