### PR TITLE
SwiftPM: Fix platform build warning

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -4,12 +4,6 @@ import PackageDescription
 
 let package = Package(
     name: "GTMSessionFetcher",
-    platforms: [
-        .macOS(.v10_10),
-        .iOS(.v8),
-        .tvOS(.v9),
-        .watchOS(.v2)
-    ],
     products: [
         .library(
             name: "GTMSessionFetcher",


### PR DESCRIPTION
The platform specifications cause build warnings in Xcode 12. They're not necessary since gtm-session-fetcher supports all versions supported by Xcode versions that support Swift Package Manager.

Details in firebase/firebase-ios-sdk#6449, https://forums.swift.org/t/minimum-ios-version-xcode-12-and-build-warnings/40224, and https://github.com/apple/swift-evolution/blob/master/proposals/0236-package-manager-platform-deployment-settings.md