### PR TITLE
SwiftPM support for the 5.x versions.

### DIFF
--- a/Package@swift-5.1.swift
+++ b/Package@swift-5.1.swift
@@ -1,4 +1,4 @@
-// swift-tools-version:5.3
+// swift-tools-version:5.1
 // The swift-tools-version declares the minimum version of Swift required to build this package.
 import PackageDescription
 
@@ -26,18 +26,6 @@ let package = Package(
         .target(
             name: "GTMSessionFetcherCore",
             path: "Source",
-            exclude:[
-                "GTMSessionFetcherIOS",
-                "GTMSessionFetcherOSX",
-                "GTMSessionFetchertvOS",
-                "GTMSessionFetcherwatchOS",
-                "TestApps",
-                "UnitTests",
-                "GTMGatherInputStream.m",
-                "GTMMIMEDocument.m",
-                "GTMReadMonitorInputStream.m",
-                "GTMSessionFetcherLogViewController.m",
-            ],
             sources:[
                 "GTMSessionFetcher.h",
                 "GTMSessionFetcher.m",
@@ -54,19 +42,6 @@ let package = Package(
             name: "GTMSessionFetcherFull",
             dependencies: ["GTMSessionFetcherCore"],
             path: "Source",
-            exclude:[
-                "GTMSessionFetcherIOS",
-                "GTMSessionFetcherOSX",
-                "GTMSessionFetchertvOS",
-                "GTMSessionFetcherwatchOS",
-                "TestApps",
-                "UnitTests",
-                "GTMSessionFetcher.m",
-                "GTMSessionFetcherLogging.m",
-                "GTMSessionFetcherLogViewController.m",
-                "GTMSessionFetcherService.m",
-                "GTMSessionUploadFetcher.m",
-            ],
             sources: [
                 "GTMGatherInputStream.h",
                 "GTMGatherInputStream.m",
@@ -81,21 +56,6 @@ let package = Package(
             name: "GTMSessionFetcherLogView",
             dependencies: ["GTMSessionFetcherCore"],
             path: "Source",
-            exclude:[
-                "GTMSessionFetcherIOS",
-                "GTMSessionFetcherOSX",
-                "GTMSessionFetchertvOS",
-                "GTMSessionFetcherwatchOS",
-                "TestApps",
-                "UnitTests",
-                "GTMGatherInputStream.m",
-                "GTMMIMEDocument.m",
-                "GTMReadMonitorInputStream.m",
-                "GTMSessionFetcherService.m",
-                "GTMSessionFetcher.m",
-                "GTMSessionFetcherLogging.m",
-                "GTMSessionUploadFetcher.m",
-            ],
             sources: [
                 "GTMSessionFetcherLogViewController.h",
                 "GTMSessionFetcherLogViewController.m"
@@ -105,11 +65,8 @@ let package = Package(
         .testTarget(
             name: "GTMSessionFetcherCoreTests",
             dependencies: ["GTMSessionFetcherFull", "GTMSessionFetcherCore"],
-            path: "Source/UnitTests",
-            // Resources not working as of Swfit 5.3
-            // - https://forums.swift.org/t/5-3-resources-support-not-working-on-with-swift-test/40381
-            // - https://bugs.swift.org/browse/SR-13560
-            exclude: ["Data", "SupportingFiles"]
+            path: "Source/UnitTests"
+            // Resources hot wired in the source file themselves.
         )
     ]
 )

--- a/Package@swift-5.2.swift
+++ b/Package@swift-5.2.swift
@@ -1,4 +1,4 @@
-// swift-tools-version:5.3
+// swift-tools-version:5.2
 // The swift-tools-version declares the minimum version of Swift required to build this package.
 import PackageDescription
 
@@ -26,18 +26,6 @@ let package = Package(
         .target(
             name: "GTMSessionFetcherCore",
             path: "Source",
-            exclude:[
-                "GTMSessionFetcherIOS",
-                "GTMSessionFetcherOSX",
-                "GTMSessionFetchertvOS",
-                "GTMSessionFetcherwatchOS",
-                "TestApps",
-                "UnitTests",
-                "GTMGatherInputStream.m",
-                "GTMMIMEDocument.m",
-                "GTMReadMonitorInputStream.m",
-                "GTMSessionFetcherLogViewController.m",
-            ],
             sources:[
                 "GTMSessionFetcher.h",
                 "GTMSessionFetcher.m",
@@ -54,19 +42,6 @@ let package = Package(
             name: "GTMSessionFetcherFull",
             dependencies: ["GTMSessionFetcherCore"],
             path: "Source",
-            exclude:[
-                "GTMSessionFetcherIOS",
-                "GTMSessionFetcherOSX",
-                "GTMSessionFetchertvOS",
-                "GTMSessionFetcherwatchOS",
-                "TestApps",
-                "UnitTests",
-                "GTMSessionFetcher.m",
-                "GTMSessionFetcherLogging.m",
-                "GTMSessionFetcherLogViewController.m",
-                "GTMSessionFetcherService.m",
-                "GTMSessionUploadFetcher.m",
-            ],
             sources: [
                 "GTMGatherInputStream.h",
                 "GTMGatherInputStream.m",
@@ -81,21 +56,6 @@ let package = Package(
             name: "GTMSessionFetcherLogView",
             dependencies: ["GTMSessionFetcherCore"],
             path: "Source",
-            exclude:[
-                "GTMSessionFetcherIOS",
-                "GTMSessionFetcherOSX",
-                "GTMSessionFetchertvOS",
-                "GTMSessionFetcherwatchOS",
-                "TestApps",
-                "UnitTests",
-                "GTMGatherInputStream.m",
-                "GTMMIMEDocument.m",
-                "GTMReadMonitorInputStream.m",
-                "GTMSessionFetcherService.m",
-                "GTMSessionFetcher.m",
-                "GTMSessionFetcherLogging.m",
-                "GTMSessionUploadFetcher.m",
-            ],
             sources: [
                 "GTMSessionFetcherLogViewController.h",
                 "GTMSessionFetcherLogViewController.m"
@@ -105,11 +65,8 @@ let package = Package(
         .testTarget(
             name: "GTMSessionFetcherCoreTests",
             dependencies: ["GTMSessionFetcherFull", "GTMSessionFetcherCore"],
-            path: "Source/UnitTests",
-            // Resources not working as of Swfit 5.3
-            // - https://forums.swift.org/t/5-3-resources-support-not-working-on-with-swift-test/40381
-            // - https://bugs.swift.org/browse/SR-13560
-            exclude: ["Data", "SupportingFiles"]
+            path: "Source/UnitTests"
+            // Resources hot wired in the source file themselves.
         )
     ]
 )


### PR DESCRIPTION
Document the resources support that isn't working in SwiftPM 5.3, and create the
version specific files that will be needed to eventually use it.

Progress on #192