### PR TITLE
Resolve Xcode 12 minimum iOS version warnings

### DIFF
--- a/GTMSessionFetcher.podspec
+++ b/GTMSessionFetcher.podspec
@@ -17,7 +17,7 @@ Pod::Spec.new do |s|
   and uses operating-system settings on iOS and Mac OS X.
   DESC
 
-  s.ios.deployment_target = '7.0'
+  s.ios.deployment_target = '9.0'
   s.osx.deployment_target = '10.9'
   s.tvos.deployment_target = '9.0'
   s.watchos.deployment_target = '2.0'


### PR DESCRIPTION
Xcode 12 generates build warnings for iOS versions less than 9. More context at https://github.com/CocoaPods/CocoaPods/issues/9884.

I confirmed that the macos and tvos versions are still ok in Xcode 12.