### PR TITLE
Fix Swift Package Manager support

### DIFF
--- a/Source/SwiftPackage/GTMSessionFetcher/GTMGatherInputStream.h
+++ b/Source/SwiftPackage/GTMSessionFetcher/GTMGatherInputStream.h
@@ -1,0 +1,1 @@
+../../GTMGatherInputStream.h

--- a/Source/SwiftPackage/GTMSessionFetcher/GTMMIMEDocument.h
+++ b/Source/SwiftPackage/GTMSessionFetcher/GTMMIMEDocument.h
@@ -1,0 +1,1 @@
+../../GTMMIMEDocument.h

--- a/Source/SwiftPackage/GTMSessionFetcher/GTMReadMonitorInputStream.h
+++ b/Source/SwiftPackage/GTMSessionFetcher/GTMReadMonitorInputStream.h
@@ -1,0 +1,1 @@
+../../GTMReadMonitorInputStream.h

--- a/Source/SwiftPackage/GTMSessionFetcher/GTMSessionFetcher.h
+++ b/Source/SwiftPackage/GTMSessionFetcher/GTMSessionFetcher.h
@@ -1,0 +1,1 @@
+../../GTMSessionFetcher.h

--- a/Source/SwiftPackage/GTMSessionFetcher/GTMSessionFetcherLogging.h
+++ b/Source/SwiftPackage/GTMSessionFetcher/GTMSessionFetcherLogging.h
@@ -1,0 +1,1 @@
+../../GTMSessionFetcherLogging.h

--- a/Source/SwiftPackage/GTMSessionFetcher/GTMSessionFetcherService.h
+++ b/Source/SwiftPackage/GTMSessionFetcher/GTMSessionFetcherService.h
@@ -1,0 +1,1 @@
+../../GTMSessionFetcherService.h

--- a/Source/SwiftPackage/GTMSessionFetcher/GTMSessionUploadFetcher.h
+++ b/Source/SwiftPackage/GTMSessionFetcher/GTMSessionUploadFetcher.h
@@ -1,0 +1,1 @@
+../../GTMSessionUploadFetcher.h

--- a/Source/SwiftPackage/GTMSessionFetcherCore/GTMSessionFetcher.h
+++ b/Source/SwiftPackage/GTMSessionFetcherCore/GTMSessionFetcher.h
@@ -1,0 +1,1 @@
+../../GTMSessionFetcher.h

--- a/Source/SwiftPackage/GTMSessionFetcherCore/GTMSessionFetcherLogging.h
+++ b/Source/SwiftPackage/GTMSessionFetcherCore/GTMSessionFetcherLogging.h
@@ -1,0 +1,1 @@
+../../GTMSessionFetcherLogging.h

--- a/Source/SwiftPackage/GTMSessionFetcherCore/GTMSessionFetcherService.h
+++ b/Source/SwiftPackage/GTMSessionFetcherCore/GTMSessionFetcherService.h
@@ -1,0 +1,1 @@
+../../GTMSessionFetcherService.h

--- a/Source/SwiftPackage/GTMSessionFetcherCore/GTMSessionUploadFetcher.h
+++ b/Source/SwiftPackage/GTMSessionFetcherCore/GTMSessionUploadFetcher.h
@@ -1,0 +1,1 @@
+../../GTMSessionUploadFetcher.h

--- a/Source/SwiftPackage/GTMSessionFetcherFull/GTMGatherInputStream.h
+++ b/Source/SwiftPackage/GTMSessionFetcherFull/GTMGatherInputStream.h
@@ -1,0 +1,1 @@
+../../GTMGatherInputStream.h

--- a/Source/SwiftPackage/GTMSessionFetcherFull/GTMMIMEDocument.h
+++ b/Source/SwiftPackage/GTMSessionFetcherFull/GTMMIMEDocument.h
@@ -1,0 +1,1 @@
+../../GTMMIMEDocument.h

--- a/Source/SwiftPackage/GTMSessionFetcherFull/GTMReadMonitorInputStream.h
+++ b/Source/SwiftPackage/GTMSessionFetcherFull/GTMReadMonitorInputStream.h
@@ -1,0 +1,1 @@
+../../GTMReadMonitorInputStream.h

--- a/Source/SwiftPackage/GTMSessionFetcherLogView/GTMSessionFetcherLogViewController.h
+++ b/Source/SwiftPackage/GTMSessionFetcherLogView/GTMSessionFetcherLogViewController.h
@@ -1,0 +1,1 @@
+../../GTMSessionFetcherLogViewController.h

--- a/Source/SwiftPackage/module.modulemap
+++ b/Source/SwiftPackage/module.modulemap
@@ -1,23 +1,17 @@
 module GTMSessionFetcherCore {
-    header "../GTMSessionFetcher.h"
-    header "../GTMSessionFetcherLogging.h"
-    header "../GTMSessionFetcherService.h"
-    header "../GTMSessionUploadFetcher.h"
+    umbrella "GTMSessionFetcherCore"
 
     export *
 }
 
 module GTMSessionFetcherFull {
-    header "../GTMGatherInputStream.h"
-    header "../GTMGatherInputStream.h"
-    header "../GTMMIMEDocument.h"
-    header "../GTMReadMonitorInputStream.h"
+    umbrella "GTMSessionFetcherFull"
 
     export *
 }
 
 module GTMSessionFetcherLogView {
-    header "../GTMSessionFetcherLogViewController.h"
+    umbrella "GTMSessionFetcherLogView"
 
     export *
 }

--- a/Source/SwiftPackage/module.modulemap
+++ b/Source/SwiftPackage/module.modulemap
@@ -1,3 +1,9 @@
+module GTMSessionFetcher {
+    umbrella "GTMSessionFetcher"
+
+    export *
+}
+
 module GTMSessionFetcherCore {
     umbrella "GTMSessionFetcherCore"
 


### PR DESCRIPTION
Hi,

The current release installed via SPM cannot import headers as follows:

```objective-c
#import <GTMSessionFetcher/GTMSessionFetcher.h>
```

This PR creates umbrella directories to fix that.