### PR TITLE
Deprecate GTMSessionFetcher (and service's) `waitForCompletionWithTimeout:` methods.

### DIFF
--- a/Source/GTMSessionFetcher.h
+++ b/Source/GTMSessionFetcher.h
@@ -1138,6 +1138,8 @@ NSData * GTM_NULLABLE_TYPE GTMDataFromInputStream(NSInputStream *inputStream, NS
 // to a shared session.
 @property(atomic, strong, GTM_NULL_RESETTABLE) NSOperationQueue *sessionDelegateQueue;
 
+// DEPRECATED: Callers should use XCTestExpectation instead.
+//
 // Spin the run loop or sleep the thread, discarding events, until the fetch has completed.
 //
 // This is only for use in testing or in tools without a user interface.
@@ -1146,7 +1148,8 @@ NSData * GTM_NULLABLE_TYPE GTMDataFromInputStream(NSInputStream *inputStream, NS
 // sufficient reason for rejection from the app store.
 //
 // Returns NO if timed out.
-- (BOOL)waitForCompletionWithTimeout:(NSTimeInterval)timeoutInSeconds;
+- (BOOL)waitForCompletionWithTimeout:(NSTimeInterval)timeoutInSeconds
+    __deprecated_msg("Use XCTestExpectation instead");
 
 // Test block is optional for testing.
 //

--- a/Source/GTMSessionFetcherService.h
+++ b/Source/GTMSessionFetcherService.h
@@ -172,6 +172,8 @@ extern NSString *const kGTMSessionFetcherServiceSessionKey;
                                   fakedResponse:(NSHTTPURLResponse *)fakedResponse
                                      fakedError:(GTM_NULLABLE NSError *)fakedErrorOrNil;
 
+// DEPRECATED: Callers should use XCTestExpectation instead.
+//
 // Spin the run loop and discard events (or, if not on the main thread, just sleep the thread)
 // until all running and delayed fetchers have completed.
 //
@@ -181,7 +183,8 @@ extern NSString *const kGTMSessionFetcherServiceSessionKey;
 // sufficient reason for rejection from the app store.
 //
 // Returns NO if timed out.
-- (BOOL)waitForCompletionOfAllFetchersWithTimeout:(NSTimeInterval)timeoutInSeconds;
+- (BOOL)waitForCompletionOfAllFetchersWithTimeout:(NSTimeInterval)timeoutInSeconds
+    __deprecated_msg("Use XCTestExpectation instead");
 
 @end
 

--- a/Source/GTMSessionUploadFetcher.m
+++ b/Source/GTMSessionUploadFetcher.m
@@ -1974,6 +1974,8 @@ NSString *const kGTMSessionFetcherUploadLocationObtainedNotification =
   return [super isFetching];
 }
 
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wdeprecated-implementations"
 - (BOOL)waitForCompletionWithTimeout:(NSTimeInterval)timeoutInSeconds {
   NSDate *timeoutDate = [NSDate dateWithTimeIntervalSinceNow:timeoutInSeconds];
 
@@ -1999,6 +2001,7 @@ NSString *const kGTMSessionFetcherUploadLocationObtainedNotification =
   }
   return YES;
 }
+#pragma clang diagnostic pop
 
 @end
 


### PR DESCRIPTION
These methods are only for unit testing, but suffer from a race conditions and potential invalid access due to non-serialized access to instance variables.