### PR TITLE
Allow overridding the version in GTMFetcherApplicationIdentifier(...)

### DIFF
--- a/Source/GTMSessionFetcher.h
+++ b/Source/GTMSessionFetcher.h
@@ -590,6 +590,9 @@ NSString *GTMFetcherStandardUserAgentString(NSBundle * GTM_NULLABLE_TYPE bundle)
 // The bundle ID may be overridden as the base identifier string by
 // adding to the bundle's Info.plist a "GTMUserAgentID" key.
 //
+// The application version may be overridden by adding to the bundle's
+// Info.plist a "GTMUserAgentVersion" key.
+//
 // If no bundle ID or override is available, the process name preceded
 // by "proc_" is used.
 NSString *GTMFetcherApplicationIdentifier(NSBundle * GTM_NULLABLE_TYPE bundle);

--- a/Source/GTMSessionFetcher.m
+++ b/Source/GTMSessionFetcher.m
@@ -4593,9 +4593,12 @@ NSString *GTMFetcherApplicationIdentifier(NSBundle * GTM_NULLABLE_TYPE bundle) {
     identifier = GTMFetcherCleanedUserAgentString(identifier);
 
     // If there's a version number, append that
-    NSString *version = [bundle objectForInfoDictionaryKey:@"CFBundleShortVersionString"];
+    NSString *version = [bundle objectForInfoDictionaryKey:@"GTMUserAgentVersion"];
     if (version.length == 0) {
-      version = [bundle objectForInfoDictionaryKey:@"CFBundleVersion"];
+      version = [bundle objectForInfoDictionaryKey:@"CFBundleShortVersionString"];
+      if (version.length == 0) {
+        version = [bundle objectForInfoDictionaryKey:@"CFBundleVersion"];
+      }
     }
 
     // Clean up whitespace and special characters


### PR DESCRIPTION
The format of "CFBundleVersion" and "CFBundleShortVersionString" is
fixed according to [1] and [2] to a string composed of one to three
period-separated integers.

Some application have a version identifier that does not fit this
format (e.g. Chrome version number looks like "62.0.3202.70").

Allow those applications to save the real version to use by setting
the "GTMUserAgentVersion" property in the bundle's Info.plist. This
value will be used if defined instead of either "CFBundleVersion" or
"CFBundleShortVersionString".

[1]: https://developer.apple.com/documentation/bundleresources/information_property_list/cfbundleversion
[2]: https://developer.apple.com/documentation/bundleresources/information_property_list/cfbundleshortversionstring

Bug: https://crbug.com/827856