### PR TITLE
Run clang-format --style=Google over all GTMSessionFetcher code.

### DIFF
--- a/Source/GTMGatherInputStream.h
+++ b/Source/GTMGatherInputStream.h
@@ -25,15 +25,15 @@
 #import <Foundation/Foundation.h>
 
 #ifndef GTM_NONNULL
-  #if defined(__has_attribute)
-    #if __has_attribute(nonnull)
-      #define GTM_NONNULL(x) __attribute__((nonnull x))
-    #else
-      #define GTM_NONNULL(x)
-    #endif
-  #else
-    #define GTM_NONNULL(x)
-  #endif
+#if defined(__has_attribute)
+#if __has_attribute(nonnull)
+#define GTM_NONNULL(x) __attribute__((nonnull x))
+#else
+#define GTM_NONNULL(x)
+#endif
+#else
+#define GTM_NONNULL(x)
+#endif
 #endif
 
 // Avoid multiple declaration of this class.

--- a/Source/GTMGatherInputStream.m
+++ b/Source/GTMGatherInputStream.m
@@ -20,9 +20,9 @@
 #import "GTMGatherInputStream.h"
 
 @implementation GTMGatherInputStream {
-  NSArray *_dataArray;  // NSDatas that should be "gathered" and streamed.
+  NSArray *_dataArray;     // NSDatas that should be "gathered" and streamed.
   NSUInteger _arrayIndex;  // Index in the array of the current NSData.
-  long long _dataOffset;  // Offset in the current NSData we are processing.
+  long long _dataOffset;   // Offset in the current NSData we are processing.
   NSStreamStatus _streamStatus;
   id<NSStreamDelegate> __weak _delegate;  // Stream delegate, defaults to self.
 }
@@ -108,7 +108,7 @@
     NSUInteger dataBytesLeft = dataLen - (NSUInteger)_dataOffset;
 
     NSUInteger bytesToCopy = MIN(bytesRemaining, dataBytesLeft);
-    NSRange range = NSMakeRange((NSUInteger) _dataOffset, bytesToCopy);
+    NSRange range = NSMakeRange((NSUInteger)_dataOffset, bytesToCopy);
 
     [data getBytes:(buffer + bytesRead) range:range];
 
@@ -168,7 +168,7 @@
   _arrayIndex = 0;
   _dataOffset = absoluteOffset;
   for (NSData *data in _dataArray) {
-    long long dataLen = (long long) data.length;
+    long long dataLen = (long long)data.length;
     if (dataLen > _dataOffset) {
       break;
     }

--- a/Source/GTMMIMEDocument.h
+++ b/Source/GTMMIMEDocument.h
@@ -23,42 +23,41 @@
 #import <Foundation/Foundation.h>
 
 #ifndef GTM_NONNULL
-  #if defined(__has_attribute)
-    #if __has_attribute(nonnull)
-      #define GTM_NONNULL(x) __attribute__((nonnull x))
-    #else
-      #define GTM_NONNULL(x)
-    #endif
-  #else
-    #define GTM_NONNULL(x)
-  #endif
+#if defined(__has_attribute)
+#if __has_attribute(nonnull)
+#define GTM_NONNULL(x) __attribute__((nonnull x))
+#else
+#define GTM_NONNULL(x)
+#endif
+#else
+#define GTM_NONNULL(x)
+#endif
 #endif
 
 #ifndef GTM_DECLARE_GENERICS
-  #if __has_feature(objc_generics)
-    #define GTM_DECLARE_GENERICS 1
-  #else
-    #define GTM_DECLARE_GENERICS 0
-  #endif
+#if __has_feature(objc_generics)
+#define GTM_DECLARE_GENERICS 1
+#else
+#define GTM_DECLARE_GENERICS 0
+#endif
 #endif
 
 #ifndef GTM_NSArrayOf
-  #if GTM_DECLARE_GENERICS
-    #define GTM_NSArrayOf(value) NSArray<value>
-    #define GTM_NSDictionaryOf(key, value) NSDictionary<key, value>
-  #else
-    #define GTM_NSArrayOf(value) NSArray
-    #define GTM_NSDictionaryOf(key, value) NSDictionary
-  #endif // GTM_DECLARE_GENERICS
+#if GTM_DECLARE_GENERICS
+#define GTM_NSArrayOf(value) NSArray<value>
+#define GTM_NSDictionaryOf(key, value) NSDictionary<key, value>
+#else
+#define GTM_NSArrayOf(value) NSArray
+#define GTM_NSDictionaryOf(key, value) NSDictionary
+#endif  // GTM_DECLARE_GENERICS
 #endif  // GTM_NSArrayOf
-
 
 // GTMMIMEDocumentPart represents a part of a MIME document.
 //
 // +[GTMMIMEDocument MIMEPartsWithBoundary:data:] returns an array of these.
 @interface GTMMIMEDocumentPart : NSObject
 
-@property(nonatomic, readonly) GTM_NSDictionaryOf(NSString *, NSString *) *headers;
+@property(nonatomic, readonly) GTM_NSDictionaryOf(NSString *, NSString *) * headers;
 @property(nonatomic, readonly) NSData *headerData;
 @property(nonatomic, readonly) NSData *body;
 @property(nonatomic, readonly) NSUInteger length;
@@ -83,7 +82,7 @@
 // The headers keys and values should be NSStrings.
 // Adding a part may cause the boundary string to change.
 - (void)addPartWithHeaders:(GTM_NSDictionaryOf(NSString *, NSString *) *)headers
-                      body:(NSData *)body GTM_NONNULL((1,2));
+                      body:(NSData *)body GTM_NONNULL((1, 2));
 
 // An inputstream that can be used to efficiently read the contents of the MIME document.
 //
@@ -140,9 +139,9 @@
                       foundOffset:(NSUInteger *)foundOffset;
 
 + (void)searchData:(NSData *)data
-       targetBytes:(const void *)targetBytes
-      targetLength:(NSUInteger)targetLength
-      foundOffsets:(GTM_NSArrayOf(NSNumber *) **)outFoundOffsets
- foundBlockNumbers:(GTM_NSArrayOf(NSNumber *) **)outFoundBlockNumbers;
+          targetBytes:(const void *)targetBytes
+         targetLength:(NSUInteger)targetLength
+         foundOffsets:(GTM_NSArrayOf(NSNumber *) **)outFoundOffsets
+    foundBlockNumbers:(GTM_NSArrayOf(NSNumber *) **)outFoundBlockNumbers;
 
 @end

--- a/Source/GTMMIMEDocument.m
+++ b/Source/GTMMIMEDocument.m
@@ -55,9 +55,7 @@ static void SearchDataForBytes(NSData *data, const void *targetBytes, NSUInteger
   NSData *_bodyData;
 }
 
-@synthesize headers = _headers,
-            headerData = _headerData,
-            body = _bodyData;
+@synthesize headers = _headers, headerData = _headerData, body = _bodyData;
 
 @dynamic length;
 
@@ -83,7 +81,7 @@ static void SearchDataForBytes(NSData *data, const void *targetBytes, NSUInteger
   // null values.
   NSData *headerData = self.headerData;
   return (FindBytes(bytes, length, headerData.bytes, headerData.length, NULL) == length ||
-          FindBytes(bytes, length, _bodyData.bytes,  _bodyData.length, NULL) == length);
+          FindBytes(bytes, length, _bodyData.bytes, _bodyData.length, NULL) == length);
 }
 
 - (NSData *)headerData {
@@ -102,16 +100,15 @@ static void SearchDataForBytes(NSData *data, const void *targetBytes, NSUInteger
 }
 
 - (NSString *)description {
-  return [NSString stringWithFormat:@"%@ %p (headers %lu keys, body %lu bytes)",
-          [self class], self, (unsigned long)_headers.count,
-          (unsigned long)_bodyData.length];
+  return [NSString stringWithFormat:@"%@ %p (headers %lu keys, body %lu bytes)", [self class], self,
+                                    (unsigned long)_headers.count, (unsigned long)_bodyData.length];
 }
 
 - (BOOL)isEqual:(GTMMIMEDocumentPart *)other {
   if (self == other) return YES;
   if (![other isKindOfClass:[GTMMIMEDocumentPart class]]) return NO;
-  return ((_bodyData == other->_bodyData || [_bodyData isEqual:other->_bodyData])
-          && (_headers == other->_headers || [_headers isEqual:other->_headers]));
+  return ((_bodyData == other->_bodyData || [_bodyData isEqual:other->_bodyData]) &&
+          (_headers == other->_headers || [_headers isEqual:other->_headers]));
 }
 
 - (NSUInteger)hash {
@@ -121,10 +118,10 @@ static void SearchDataForBytes(NSData *data, const void *targetBytes, NSUInteger
 @end
 
 @implementation GTMMIMEDocument {
-  NSMutableArray *_parts;         // Ordered array of GTMMIMEDocumentParts.
-  unsigned long long _length;     // Length in bytes of the document.
+  NSMutableArray *_parts;      // Ordered array of GTMMIMEDocumentParts.
+  unsigned long long _length;  // Length in bytes of the document.
   NSString *_boundary;
-  u_int32_t _randomSeed;          // For testing.
+  u_int32_t _randomSeed;  // For testing.
 }
 
 + (instancetype)MIMEDocument {
@@ -140,8 +137,8 @@ static void SearchDataForBytes(NSData *data, const void *targetBytes, NSUInteger
 }
 
 - (NSString *)description {
-  return [NSString stringWithFormat:@"%@ %p (%lu parts)",
-          [self class], self, (unsigned long)_parts.count];
+  return [NSString
+      stringWithFormat:@"%@ %p (%lu parts)", [self class], self, (unsigned long)_parts.count];
 }
 
 #pragma mark - Joining Parts
@@ -188,7 +185,6 @@ static void SearchDataForBytes(NSData *data, const void *targetBytes, NSUInteger
 
   const int maxTries = 10;  // Arbitrarily chosen maximum attempts.
   for (int tries = 0; tries < maxTries; ++tries) {
-
     NSData *data = [_boundary dataUsingEncoding:NSUTF8StringEncoding];
     const void *dataBytes = data.bytes;
     NSUInteger dataLen = data.length;
@@ -198,7 +194,7 @@ static void SearchDataForBytes(NSData *data, const void *targetBytes, NSUInteger
       if (didCollide) break;
     }
 
-    if (!didCollide) break; // We're fine, no more attempts needed.
+    if (!didCollide) break;  // We're fine, no more attempts needed.
 
     // Try again with a random number appended.
     _boundary = [NSString stringWithFormat:@"%@_%08x", kBaseBoundary, [self random]];
@@ -219,7 +215,6 @@ static void SearchDataForBytes(NSData *data, const void *targetBytes, NSUInteger
 - (void)generateDataArray:(NSMutableArray *)dataArray
                    length:(unsigned long long *)outLength
                  boundary:(NSString **)outBoundary {
-
   // The input stream is of the form:
   //   --boundary
   //    [part_1_headers]
@@ -252,7 +247,7 @@ static void SearchDataForBytes(NSData *data, const void *targetBytes, NSUInteger
   [dataArray addObject:endBoundaryData];
   length += endBoundaryData.length;
 
-  if (outLength)   *outLength = length;
+  if (outLength) *outLength = length;
   if (outBoundary) *outBoundary = boundary;
 }
 
@@ -260,9 +255,7 @@ static void SearchDataForBytes(NSData *data, const void *targetBytes, NSUInteger
                      length:(unsigned long long *)outLength
                    boundary:(NSString **)outBoundary {
   NSMutableArray *dataArray = outStream ? [NSMutableArray array] : nil;
-  [self generateDataArray:dataArray
-                   length:outLength
-                 boundary:outBoundary];
+  [self generateDataArray:dataArray length:outLength boundary:outBoundary];
 
   if (outStream) {
     Class streamClass = NSClassFromString(@"GTMGatherInputStream");
@@ -276,9 +269,7 @@ static void SearchDataForBytes(NSData *data, const void *targetBytes, NSUInteger
                       length:(unsigned long long *)outLength
                     boundary:(NSString **)outBoundary {
   NSMutableArray *dataArray = outDispatchData ? [NSMutableArray array] : nil;
-  [self generateDataArray:dataArray
-                   length:outLength
-                 boundary:outBoundary];
+  [self generateDataArray:dataArray length:outLength boundary:outBoundary];
 
   if (outDispatchData) {
     // Create an empty data accumulator.
@@ -290,9 +281,9 @@ static void SearchDataForBytes(NSData *data, const void *targetBytes, NSUInteger
       __block NSData *immutablePartData = [partData copy];
       dispatch_data_t newDataPart =
           dispatch_data_create(immutablePartData.bytes, immutablePartData.length, bgQueue, ^{
-        // We want the data retained until this block executes.
-        immutablePartData = nil;
-      });
+            // We want the data retained until this block executes.
+            immutablePartData = nil;
+          });
 
       if (dataAccumulator == nil) {
         // First part.
@@ -308,7 +299,7 @@ static void SearchDataForBytes(NSData *data, const void *targetBytes, NSUInteger
 
 + (NSData *)dataWithHeaders:(NSDictionary *)headers {
   // Generate the header data by coalescing the dictionary as lines of "key: value\r\n".
-  NSMutableString* headerString = [NSMutableString string];
+  NSMutableString *headerString = [NSMutableString string];
 
   // Sort the header keys so we have a deterministic order for unit testing.
   SEL sortSel = @selector(caseInsensitiveCompare:);
@@ -340,8 +331,7 @@ static void SearchDataForBytes(NSData *data, const void *targetBytes, NSUInteger
 
 #pragma mark - Separating Parts
 
-+ (NSArray *)MIMEPartsWithBoundary:(NSString *)boundary
-                              data:(NSData *)fullDocumentData {
++ (NSArray *)MIMEPartsWithBoundary:(NSString *)boundary data:(NSData *)fullDocumentData {
   // In MIME documents, the boundary is preceded by CRLF and two dashes, and followed
   // at the end by two dashes.
   NSData *boundaryData = [boundary dataUsingEncoding:NSUTF8StringEncoding];
@@ -367,9 +357,9 @@ static void SearchDataForBytes(NSData *data, const void *targetBytes, NSUInteger
   } else {
     // A no-op self invocation on fullDocumentData will keep it retained until the block is invoked.
     dispatch_queue_t bgQueue = dispatch_get_global_queue(DISPATCH_QUEUE_PRIORITY_DEFAULT, 0);
-    dataWrapper = dispatch_data_create(fullDocumentData.bytes,
-                                       fullDocumentData.length,
-                                       bgQueue, ^{ [fullDocumentData self]; });
+    dataWrapper = dispatch_data_create(fullDocumentData.bytes, fullDocumentData.length, bgQueue, ^{
+      [fullDocumentData self];
+    });
   }
   NSMutableArray *parts;
   NSInteger previousBoundaryOffset = -1;
@@ -394,15 +384,13 @@ static void SearchDataForBytes(NSData *data, const void *targetBytes, NSUInteger
       if (previousPartDataLength < 2) {
         // The preceding part was too short to be useful.
 #if DEBUG
-        NSLog(@"MIME part %ld has %ld bytes", (long)partCounter - 1,
-              (long)previousPartDataLength);
+        NSLog(@"MIME part %ld has %ld bytes", (long)partCounter - 1, (long)previousPartDataLength);
 #endif
       } else {
         if (!parts) parts = [NSMutableArray array];
 
-        dispatch_data_t partData =
-            dispatch_data_create_subrange(dataWrapper,
-                (size_t)previousPartDataStartOffset, (size_t)previousPartDataLength);
+        dispatch_data_t partData = dispatch_data_create_subrange(
+            dataWrapper, (size_t)previousPartDataStartOffset, (size_t)previousPartDataLength);
         // Scan the part data for the separator between headers and body. After the CRLF,
         // either the headers start immediately, or there's another CRLF and there are no headers.
         //
@@ -416,8 +404,8 @@ static void SearchDataForBytes(NSData *data, const void *targetBytes, NSUInteger
             dispatch_data_create_map(partData, &partDataBuffer, &partDataBufferSize);
         dispatch_data_t bodyData;
         NSDictionary *headers;
-        BOOL hasAnotherCRLF = (((char *)partDataBuffer)[0] == '\r'
-                               && ((char *)partDataBuffer)[1] == '\n');
+        BOOL hasAnotherCRLF =
+            (((char *)partDataBuffer)[0] == '\r' && ((char *)partDataBuffer)[1] == '\n');
         mappedPartData = nil;
 
         if (hasAnotherCRLF) {
@@ -442,12 +430,13 @@ static void SearchDataForBytes(NSData *data, const void *targetBytes, NSUInteger
                 dispatch_data_create_subrange(partData, 0, (size_t)headerSeparatorOffset);
             headers = [self headersWithData:(NSData *)headerData];
 
-            bodyData = dispatch_data_create_subrange(partData, (size_t)headerSeparatorOffset + 4,
+            bodyData = dispatch_data_create_subrange(
+                partData, (size_t)headerSeparatorOffset + 4,
                 (size_t)(previousPartDataLength - (headerSeparatorOffset + 4)));
 
             numberOfPartsWithHeaders++;
           }  // crlfOffsets.count == 0
-        }  // hasAnotherCRLF
+        }    // hasAnotherCRLF
         GTMMIMEDocumentPart *part = [GTMMIMEDocumentPart partWithHeaders:headers
                                                                     body:(NSData *)bodyData];
         [parts addObject:part];
@@ -461,10 +450,7 @@ static void SearchDataForBytes(NSData *data, const void *targetBytes, NSUInteger
     NSUInteger length = fullDocumentData.length;
     if (length > 20) {  // Reasonably long.
       NSMutableArray *foundCRLFs;
-      [self searchData:fullDocumentData
-           targetBytes:"\r\n"
-          targetLength:2
-          foundOffsets:&foundCRLFs];
+      [self searchData:fullDocumentData targetBytes:"\r\n" targetLength:2 foundOffsets:&foundCRLFs];
       if (foundCRLFs.count == 0) {
         // Parts were logged above (due to lacking header separators.)
         NSLog(@"Warning: MIME document lacks any headers (may have wrong line endings)");
@@ -490,15 +476,14 @@ static void SearchDataForBytes(NSData *data, const void *targetBytes, NSUInteger
   *outFoundOffsets = foundOffsets;
 }
 
-
 // This version of searchData: also returns the block numbers (0-based) where the
 // target was found, used for testing that the supplied dispatch_data buffer
 // has not been flattened.
 + (void)searchData:(NSData *)data
-       targetBytes:(const void *)targetBytes
-      targetLength:(NSUInteger)targetLength
-      foundOffsets:(GTM_NSArrayOf(NSNumber *) **)outFoundOffsets
- foundBlockNumbers:(GTM_NSArrayOf(NSNumber *) **)outFoundBlockNumbers {
+          targetBytes:(const void *)targetBytes
+         targetLength:(NSUInteger)targetLength
+         foundOffsets:(GTM_NSArrayOf(NSNumber *) **)outFoundOffsets
+    foundBlockNumbers:(GTM_NSArrayOf(NSNumber *) **)outFoundBlockNumbers {
   NSMutableArray *foundOffsets = [NSMutableArray array];
   NSMutableArray *foundBlockNumbers = [NSMutableArray array];
 
@@ -513,9 +498,7 @@ static void SearchDataForBytes(NSData *data, const void *targetBytes, NSUInteger
   __block NSInteger priorPartialMatchStartingBlockNumber = -1;
   __block NSInteger blockNumber = -1;
 
-  [data enumerateByteRangesUsingBlock:^(const void *bytes,
-                                        NSRange byteRange,
-                                        BOOL *stop) {
+  [data enumerateByteRangesUsingBlock:^(const void *bytes, NSRange byteRange, BOOL *stop) {
     // Search for the first character in the current range.
     const void *ptr = bytes;
     NSInteger remainingInCurrentRange = (NSInteger)byteRange.length;
@@ -524,9 +507,9 @@ static void SearchDataForBytes(NSData *data, const void *targetBytes, NSUInteger
     if (priorPartialMatchAmount > 0) {
       NSUInteger amountRemainingToBeMatched = targetLength - priorPartialMatchAmount;
       NSUInteger remainingFoundOffset;
-      NSUInteger amountMatched = FindBytes(targetBytes + priorPartialMatchAmount,
-                                           amountRemainingToBeMatched,
-                                           ptr, (NSUInteger)remainingInCurrentRange, &remainingFoundOffset);
+      NSUInteger amountMatched =
+          FindBytes(targetBytes + priorPartialMatchAmount, amountRemainingToBeMatched, ptr,
+                    (NSUInteger)remainingInCurrentRange, &remainingFoundOffset);
       if (amountMatched == 0 || remainingFoundOffset > 0) {
         // No match of the rest of the prior partial match in this range.
       } else if (amountMatched < amountRemainingToBeMatched) {
@@ -589,9 +572,9 @@ static void SearchDataForBytes(NSData *data, const void *targetBytes, NSUInteger
   NSCharacterSet *newlineCharacters = [NSCharacterSet newlineCharacterSet];
   NSString *key;
   NSString *value;
-  while ([scanner scanUpToString:@":" intoString:&key]
-         && [scanner scanString:@":" intoString:NULL]
-         && [scanner scanUpToCharactersFromSet:newlineCharacters intoString:&value]) {
+  while ([scanner scanUpToString:@":" intoString:&key] &&
+         [scanner scanString:@":" intoString:NULL] &&
+         [scanner scanUpToCharactersFromSet:newlineCharacters intoString:&value]) {
     [headers setObject:value forKey:key];
     // Discard the trailing newline.
     [scanner scanCharactersFromSet:newlineCharacters intoString:NULL];
@@ -605,8 +588,8 @@ static void SearchDataForBytes(NSData *data, const void *targetBytes, NSUInteger
 //
 // If the result is less than needleLen, then the beginning of the needle
 // was found at the end of the haystack.
-static NSUInteger FindBytes(const unsigned char* needle, NSUInteger needleLen,
-                            const unsigned char* haystack, NSUInteger haystackLen,
+static NSUInteger FindBytes(const unsigned char *needle, NSUInteger needleLen,
+                            const unsigned char *haystack, NSUInteger haystackLen,
                             NSUInteger *foundOffset) {
   const unsigned char *ptr = haystack;
   NSInteger remain = (NSInteger)haystackLen;

--- a/Source/GTMReadMonitorInputStream.h
+++ b/Source/GTMReadMonitorInputStream.h
@@ -16,17 +16,16 @@
 #import <Foundation/Foundation.h>
 
 #ifndef GTM_NONNULL
-  #if defined(__has_attribute)
-    #if __has_attribute(nonnull)
-      #define GTM_NONNULL(x) __attribute__((nonnull x))
-    #else
-      #define GTM_NONNULL(x)
-    #endif
-  #else
-    #define GTM_NONNULL(x)
-  #endif
+#if defined(__has_attribute)
+#if __has_attribute(nonnull)
+#define GTM_NONNULL(x) __attribute__((nonnull x))
+#else
+#define GTM_NONNULL(x)
 #endif
-
+#else
+#define GTM_NONNULL(x)
+#endif
+#endif
 
 @interface GTMReadMonitorInputStream : NSInputStream <NSStreamDelegate>
 

--- a/Source/GTMReadMonitorInputStream.m
+++ b/Source/GTMReadMonitorInputStream.m
@@ -20,12 +20,11 @@
 #import "GTMReadMonitorInputStream.h"
 
 @implementation GTMReadMonitorInputStream {
-  NSInputStream *_inputStream; // Encapsulated stream that does the work.
+  NSInputStream *_inputStream;  // Encapsulated stream that does the work.
 
-  NSThread *_thread;      // Thread in which this object was created.
-  NSArray *_runLoopModes; // Modes for calling callbacks, when necessary.
+  NSThread *_thread;       // Thread in which this object was created.
+  NSArray *_runLoopModes;  // Modes for calling callbacks, when necessary.
 }
-
 
 @synthesize readDelegate = _readDelegate;
 @synthesize readSelector = _readSelector;
@@ -38,7 +37,7 @@
   return [NSInputStream methodSignatureForSelector:selector];
 }
 
-+ (void)forwardInvocation:(NSInvocation*)invocation {
++ (void)forwardInvocation:(NSInvocation *)invocation {
   [invocation invokeWithTarget:[NSInputStream class]];
 }
 
@@ -46,11 +45,11 @@
   return [_inputStream respondsToSelector:selector];
 }
 
-- (NSMethodSignature*)methodSignatureForSelector:(SEL)selector {
+- (NSMethodSignature *)methodSignatureForSelector:(SEL)selector {
   return [_inputStream methodSignatureForSelector:selector];
 }
 
-- (void)forwardInvocation:(NSInvocation*)invocation {
+- (void)forwardInvocation:(NSInvocation *)invocation {
   [invocation invokeWithTarget:_inputStream];
 }
 
@@ -60,7 +59,7 @@
   return [[self alloc] initWithStream:input];
 }
 
-- (instancetype)initWithStream:(NSInputStream *)input  {
+- (instancetype)initWithStream:(NSInputStream *)input {
   self = [super init];
   if (self) {
     _inputStream = input;
@@ -103,10 +102,7 @@
                   waitUntilDone:NO
                           modes:_runLoopModes];
         } else {
-          [self performSelector:sel
-                       onThread:_thread
-                     withObject:data
-                  waitUntilDone:NO];
+          [self performSelector:sel onThread:_thread withObject:data waitUntilDone:NO];
         }
 #pragma clang diagnostic pop
       }

--- a/Source/GTMSessionFetcher.h
+++ b/Source/GTMSessionFetcher.h
@@ -258,7 +258,6 @@
 //    response(suggestedWillRetry);
 //  };
 
-
 #import <Foundation/Foundation.h>
 
 #if TARGET_OS_IPHONE
@@ -271,47 +270,57 @@
 // By default it is stripped from non DEBUG builds. Developers can override
 // this in their project settings.
 #ifndef STRIP_GTM_FETCH_LOGGING
-  #if !DEBUG
-    #define STRIP_GTM_FETCH_LOGGING 1
-  #else
-    #define STRIP_GTM_FETCH_LOGGING 0
-  #endif
+#if !DEBUG
+#define STRIP_GTM_FETCH_LOGGING 1
+#else
+#define STRIP_GTM_FETCH_LOGGING 0
+#endif
 #endif
 
 // Logs in debug builds.
 #ifndef GTMSESSION_LOG_DEBUG
-  #if DEBUG
-    #define GTMSESSION_LOG_DEBUG(...) NSLog(__VA_ARGS__)
-  #else
-    #define GTMSESSION_LOG_DEBUG(...) do { } while (0)
-  #endif
+#if DEBUG
+#define GTMSESSION_LOG_DEBUG(...) NSLog(__VA_ARGS__)
+#else
+#define GTMSESSION_LOG_DEBUG(...) \
+  do {                            \
+  } while (0)
+#endif
 #endif
 
 // Asserts in debug builds (or logs in debug builds if GTMSESSION_ASSERT_AS_LOG
 // or NS_BLOCK_ASSERTIONS are defined.)
 #ifndef GTMSESSION_ASSERT_DEBUG
-  #if DEBUG && !defined(NS_BLOCK_ASSERTIONS) && !GTMSESSION_ASSERT_AS_LOG
-    #undef GTMSESSION_ASSERT_AS_LOG
-    #define GTMSESSION_ASSERT_AS_LOG 1
-  #endif
+#if DEBUG && !defined(NS_BLOCK_ASSERTIONS) && !GTMSESSION_ASSERT_AS_LOG
+#undef GTMSESSION_ASSERT_AS_LOG
+#define GTMSESSION_ASSERT_AS_LOG 1
+#endif
 
-  #if DEBUG && !GTMSESSION_ASSERT_AS_LOG
-    #define GTMSESSION_ASSERT_DEBUG(...) NSAssert(__VA_ARGS__)
-  #elif DEBUG
-    #define GTMSESSION_ASSERT_DEBUG(pred, ...) if (!(pred)) { NSLog(__VA_ARGS__); }
-  #else
-    #define GTMSESSION_ASSERT_DEBUG(pred, ...) do { } while (0)
-  #endif
+#if DEBUG && !GTMSESSION_ASSERT_AS_LOG
+#define GTMSESSION_ASSERT_DEBUG(...) NSAssert(__VA_ARGS__)
+#elif DEBUG
+#define GTMSESSION_ASSERT_DEBUG(pred, ...) \
+  if (!(pred)) {                           \
+    NSLog(__VA_ARGS__);                    \
+  }
+#else
+#define GTMSESSION_ASSERT_DEBUG(pred, ...) \
+  do {                                     \
+  } while (0)
+#endif
 #endif
 
 // Asserts in debug builds, logs in release builds (or logs in debug builds if
 // GTMSESSION_ASSERT_AS_LOG is defined.)
 #ifndef GTMSESSION_ASSERT_DEBUG_OR_LOG
-  #if DEBUG && !GTMSESSION_ASSERT_AS_LOG
-    #define GTMSESSION_ASSERT_DEBUG_OR_LOG(...) NSAssert(__VA_ARGS__)
-  #else
-    #define GTMSESSION_ASSERT_DEBUG_OR_LOG(pred, ...) if (!(pred)) { NSLog(__VA_ARGS__); }
-  #endif
+#if DEBUG && !GTMSESSION_ASSERT_AS_LOG
+#define GTMSESSION_ASSERT_DEBUG_OR_LOG(...) NSAssert(__VA_ARGS__)
+#else
+#define GTMSESSION_ASSERT_DEBUG_OR_LOG(pred, ...) \
+  if (!(pred)) {                                  \
+    NSLog(__VA_ARGS__);                           \
+  }
+#endif
 #endif
 
 // Macro useful for examining messages from NSURLSession during debugging.
@@ -322,42 +331,42 @@
 #endif
 
 #ifndef GTM_NULLABLE
-  #if __has_feature(nullability)  // Available starting in Xcode 6.3
-    #define GTM_NULLABLE_TYPE __nullable
-    #define GTM_NONNULL_TYPE __nonnull
-    #define GTM_NULLABLE nullable
-    #define GTM_NONNULL_DECL nonnull  // GTM_NONNULL is used by GTMDefines.h
-    #define GTM_NULL_RESETTABLE null_resettable
+#if __has_feature(nullability)  // Available starting in Xcode 6.3
+#define GTM_NULLABLE_TYPE __nullable
+#define GTM_NONNULL_TYPE __nonnull
+#define GTM_NULLABLE nullable
+#define GTM_NONNULL_DECL nonnull  // GTM_NONNULL is used by GTMDefines.h
+#define GTM_NULL_RESETTABLE null_resettable
 
-    #define GTM_ASSUME_NONNULL_BEGIN NS_ASSUME_NONNULL_BEGIN
-    #define GTM_ASSUME_NONNULL_END NS_ASSUME_NONNULL_END
-  #else
-    #define GTM_NULLABLE_TYPE
-    #define GTM_NONNULL_TYPE
-    #define GTM_NULLABLE
-    #define GTM_NONNULL_DECL
-    #define GTM_NULL_RESETTABLE
-    #define GTM_ASSUME_NONNULL_BEGIN
-    #define GTM_ASSUME_NONNULL_END
-  #endif  // __has_feature(nullability)
+#define GTM_ASSUME_NONNULL_BEGIN NS_ASSUME_NONNULL_BEGIN
+#define GTM_ASSUME_NONNULL_END NS_ASSUME_NONNULL_END
+#else
+#define GTM_NULLABLE_TYPE
+#define GTM_NONNULL_TYPE
+#define GTM_NULLABLE
+#define GTM_NONNULL_DECL
+#define GTM_NULL_RESETTABLE
+#define GTM_ASSUME_NONNULL_BEGIN
+#define GTM_ASSUME_NONNULL_END
+#endif  // __has_feature(nullability)
 #endif  // GTM_NULLABLE
 
 #ifndef GTM_DECLARE_GENERICS
-  #if __has_feature(objc_generics)
-    #define GTM_DECLARE_GENERICS 1
-  #else
-    #define GTM_DECLARE_GENERICS 0
-  #endif
+#if __has_feature(objc_generics)
+#define GTM_DECLARE_GENERICS 1
+#else
+#define GTM_DECLARE_GENERICS 0
+#endif
 #endif
 
 #ifndef GTM_NSArrayOf
-  #if GTM_DECLARE_GENERICS
-    #define GTM_NSArrayOf(value) NSArray<value>
-    #define GTM_NSDictionaryOf(key, value) NSDictionary<key, value>
-  #else
-    #define GTM_NSArrayOf(value) NSArray
-    #define GTM_NSDictionaryOf(key, value) NSDictionary
-  #endif // __has_feature(objc_generics)
+#if GTM_DECLARE_GENERICS
+#define GTM_NSArrayOf(value) NSArray<value>
+#define GTM_NSDictionaryOf(key, value) NSDictionary<key, value>
+#else
+#define GTM_NSArrayOf(value) NSArray
+#define GTM_NSDictionaryOf(key, value) NSDictionary
+#endif  // __has_feature(objc_generics)
 #endif  // GTM_NSArrayOf
 
 // For iOS, the fetcher can declare itself a background task to allow fetches
@@ -370,49 +379,50 @@
 // GTM_BACKGROUND_TASK_FETCHING to 0, or alternatively may set the
 // skipBackgroundTask property to YES.
 #if TARGET_OS_IPHONE && !TARGET_OS_WATCH && !defined(GTM_BACKGROUND_TASK_FETCHING)
-  #define GTM_BACKGROUND_TASK_FETCHING 1
+#define GTM_BACKGROUND_TASK_FETCHING 1
 #endif
 
 #ifdef __cplusplus
 extern "C" {
 #endif
 
-#if (TARGET_OS_TV \
-     || TARGET_OS_WATCH \
-     || (!TARGET_OS_IPHONE && defined(MAC_OS_X_VERSION_10_11) && MAC_OS_X_VERSION_MAX_ALLOWED >= MAC_OS_X_VERSION_10_11) \
-     || (TARGET_OS_IPHONE && defined(__IPHONE_9_0) && __IPHONE_OS_VERSION_MAX_ALLOWED >= __IPHONE_9_0))
-  #ifndef GTM_USE_SESSION_FETCHER
-    #define GTM_USE_SESSION_FETCHER 1
-  #endif
+#if (TARGET_OS_TV || TARGET_OS_WATCH ||                          \
+     (!TARGET_OS_IPHONE && defined(MAC_OS_X_VERSION_10_11) &&    \
+      MAC_OS_X_VERSION_MAX_ALLOWED >= MAC_OS_X_VERSION_10_11) || \
+     (TARGET_OS_IPHONE && defined(__IPHONE_9_0) &&               \
+      __IPHONE_OS_VERSION_MAX_ALLOWED >= __IPHONE_9_0))
+#ifndef GTM_USE_SESSION_FETCHER
+#define GTM_USE_SESSION_FETCHER 1
+#endif
 #endif
 
 #if !defined(GTMBridgeFetcher)
-  // These bridge macros should be identical in GTMHTTPFetcher.h and GTMSessionFetcher.h
-  #if GTM_USE_SESSION_FETCHER
-  // Macros to new fetcher class.
-    #define GTMBridgeFetcher GTMSessionFetcher
-    #define GTMBridgeFetcherService GTMSessionFetcherService
-    #define GTMBridgeFetcherServiceProtocol GTMSessionFetcherServiceProtocol
-    #define GTMBridgeAssertValidSelector GTMSessionFetcherAssertValidSelector
-    #define GTMBridgeCookieStorage GTMSessionCookieStorage
-    #define GTMBridgeCleanedUserAgentString GTMFetcherCleanedUserAgentString
-    #define GTMBridgeSystemVersionString GTMFetcherSystemVersionString
-    #define GTMBridgeApplicationIdentifier GTMFetcherApplicationIdentifier
-    #define kGTMBridgeFetcherStatusDomain kGTMSessionFetcherStatusDomain
-    #define kGTMBridgeFetcherStatusBadRequest GTMSessionFetcherStatusBadRequest
-  #else
-    // Macros to old fetcher class.
-    #define GTMBridgeFetcher GTMHTTPFetcher
-    #define GTMBridgeFetcherService GTMHTTPFetcherService
-    #define GTMBridgeFetcherServiceProtocol GTMHTTPFetcherServiceProtocol
-    #define GTMBridgeAssertValidSelector GTMAssertSelectorNilOrImplementedWithArgs
-    #define GTMBridgeCookieStorage GTMCookieStorage
-    #define GTMBridgeCleanedUserAgentString GTMCleanedUserAgentString
-    #define GTMBridgeSystemVersionString GTMSystemVersionString
-    #define GTMBridgeApplicationIdentifier GTMApplicationIdentifier
-    #define kGTMBridgeFetcherStatusDomain kGTMHTTPFetcherStatusDomain
-    #define kGTMBridgeFetcherStatusBadRequest kGTMHTTPFetcherStatusBadRequest
-  #endif  // GTM_USE_SESSION_FETCHER
+// These bridge macros should be identical in GTMHTTPFetcher.h and GTMSessionFetcher.h
+#if GTM_USE_SESSION_FETCHER
+// Macros to new fetcher class.
+#define GTMBridgeFetcher GTMSessionFetcher
+#define GTMBridgeFetcherService GTMSessionFetcherService
+#define GTMBridgeFetcherServiceProtocol GTMSessionFetcherServiceProtocol
+#define GTMBridgeAssertValidSelector GTMSessionFetcherAssertValidSelector
+#define GTMBridgeCookieStorage GTMSessionCookieStorage
+#define GTMBridgeCleanedUserAgentString GTMFetcherCleanedUserAgentString
+#define GTMBridgeSystemVersionString GTMFetcherSystemVersionString
+#define GTMBridgeApplicationIdentifier GTMFetcherApplicationIdentifier
+#define kGTMBridgeFetcherStatusDomain kGTMSessionFetcherStatusDomain
+#define kGTMBridgeFetcherStatusBadRequest GTMSessionFetcherStatusBadRequest
+#else
+// Macros to old fetcher class.
+#define GTMBridgeFetcher GTMHTTPFetcher
+#define GTMBridgeFetcherService GTMHTTPFetcherService
+#define GTMBridgeFetcherServiceProtocol GTMHTTPFetcherServiceProtocol
+#define GTMBridgeAssertValidSelector GTMAssertSelectorNilOrImplementedWithArgs
+#define GTMBridgeCookieStorage GTMCookieStorage
+#define GTMBridgeCleanedUserAgentString GTMCleanedUserAgentString
+#define GTMBridgeSystemVersionString GTMSystemVersionString
+#define GTMBridgeApplicationIdentifier GTMApplicationIdentifier
+#define kGTMBridgeFetcherStatusDomain kGTMHTTPFetcherStatusDomain
+#define kGTMBridgeFetcherStatusBadRequest kGTMHTTPFetcherStatusBadRequest
+#endif  // GTM_USE_SESSION_FETCHER
 #endif
 
 // When creating background sessions to perform out-of-process uploads and
@@ -433,12 +443,12 @@ extern "C" {
 // Apps targeting new SDKs can force the old behavior by defining
 // GTMSESSION_RECONNECT_BACKGROUND_SESSIONS_ON_LAUNCH = 0.
 #ifndef GTMSESSION_RECONNECT_BACKGROUND_SESSIONS_ON_LAUNCH
-  // Default to the on-launch behavior for iOS 13+.
-  #if TARGET_OS_IOS && defined(__IPHONE_13_0) && __IPHONE_OS_VERSION_MAX_ALLOWED >= __IPHONE_13_0
-    #define GTMSESSION_RECONNECT_BACKGROUND_SESSIONS_ON_LAUNCH 1
-  #else
-    #define GTMSESSION_RECONNECT_BACKGROUND_SESSIONS_ON_LAUNCH 0
-  #endif
+// Default to the on-launch behavior for iOS 13+.
+#if TARGET_OS_IOS && defined(__IPHONE_13_0) && __IPHONE_OS_VERSION_MAX_ALLOWED >= __IPHONE_13_0
+#define GTMSESSION_RECONNECT_BACKGROUND_SESSIONS_ON_LAUNCH 1
+#else
+#define GTMSESSION_RECONNECT_BACKGROUND_SESSIONS_ON_LAUNCH 0
+#endif
 #endif
 
 GTM_ASSUME_NONNULL_BEGIN
@@ -523,24 +533,28 @@ extern "C" {
 typedef void (^GTMSessionFetcherConfigurationBlock)(GTMSessionFetcher *fetcher,
                                                     NSURLSessionConfiguration *configuration);
 typedef void (^GTMSessionFetcherSystemCompletionHandler)(void);
-typedef void (^GTMSessionFetcherCompletionHandler)(NSData * GTM_NULLABLE_TYPE data,
-                                                   NSError * GTM_NULLABLE_TYPE error);
+typedef void (^GTMSessionFetcherCompletionHandler)(NSData *GTM_NULLABLE_TYPE data,
+                                                   NSError *GTM_NULLABLE_TYPE error);
 typedef void (^GTMSessionFetcherBodyStreamProviderResponse)(NSInputStream *bodyStream);
-typedef void (^GTMSessionFetcherBodyStreamProvider)(GTMSessionFetcherBodyStreamProviderResponse response);
-typedef void (^GTMSessionFetcherDidReceiveResponseDispositionBlock)(NSURLSessionResponseDisposition disposition);
-typedef void (^GTMSessionFetcherDidReceiveResponseBlock)(NSURLResponse *response,
-                                                         GTMSessionFetcherDidReceiveResponseDispositionBlock dispositionBlock);
-typedef void (^GTMSessionFetcherChallengeDispositionBlock)(NSURLSessionAuthChallengeDisposition disposition,
-                                                           NSURLCredential * GTM_NULLABLE_TYPE credential);
-typedef void (^GTMSessionFetcherChallengeBlock)(GTMSessionFetcher *fetcher,
-                                                NSURLAuthenticationChallenge *challenge,
-                                                GTMSessionFetcherChallengeDispositionBlock dispositionBlock);
-typedef void (^GTMSessionFetcherWillRedirectResponse)(NSURLRequest * GTM_NULLABLE_TYPE redirectedRequest);
+typedef void (^GTMSessionFetcherBodyStreamProvider)(
+    GTMSessionFetcherBodyStreamProviderResponse response);
+typedef void (^GTMSessionFetcherDidReceiveResponseDispositionBlock)(
+    NSURLSessionResponseDisposition disposition);
+typedef void (^GTMSessionFetcherDidReceiveResponseBlock)(
+    NSURLResponse *response, GTMSessionFetcherDidReceiveResponseDispositionBlock dispositionBlock);
+typedef void (^GTMSessionFetcherChallengeDispositionBlock)(
+    NSURLSessionAuthChallengeDisposition disposition,
+    NSURLCredential *GTM_NULLABLE_TYPE credential);
+typedef void (^GTMSessionFetcherChallengeBlock)(
+    GTMSessionFetcher *fetcher, NSURLAuthenticationChallenge *challenge,
+    GTMSessionFetcherChallengeDispositionBlock dispositionBlock);
+typedef void (^GTMSessionFetcherWillRedirectResponse)(
+    NSURLRequest *GTM_NULLABLE_TYPE redirectedRequest);
 typedef void (^GTMSessionFetcherWillRedirectBlock)(NSHTTPURLResponse *redirectResponse,
                                                    NSURLRequest *redirectRequest,
                                                    GTMSessionFetcherWillRedirectResponse response);
-typedef void (^GTMSessionFetcherAccumulateDataBlock)(NSData * GTM_NULLABLE_TYPE buffer);
-typedef void (^GTMSessionFetcherSimulateByteTransferBlock)(NSData * GTM_NULLABLE_TYPE buffer,
+typedef void (^GTMSessionFetcherAccumulateDataBlock)(NSData *GTM_NULLABLE_TYPE buffer);
+typedef void (^GTMSessionFetcherSimulateByteTransferBlock)(NSData *GTM_NULLABLE_TYPE buffer,
                                                            int64_t bytesWritten,
                                                            int64_t totalBytesWritten,
                                                            int64_t totalBytesExpectedToWrite);
@@ -549,23 +563,24 @@ typedef void (^GTMSessionFetcherReceivedProgressBlock)(int64_t bytesWritten,
 typedef void (^GTMSessionFetcherDownloadProgressBlock)(int64_t bytesWritten,
                                                        int64_t totalBytesWritten,
                                                        int64_t totalBytesExpectedToWrite);
-typedef void (^GTMSessionFetcherSendProgressBlock)(int64_t bytesSent,
-                                                   int64_t totalBytesSent,
+typedef void (^GTMSessionFetcherSendProgressBlock)(int64_t bytesSent, int64_t totalBytesSent,
                                                    int64_t totalBytesExpectedToSend);
-typedef void (^GTMSessionFetcherWillCacheURLResponseResponse)(NSCachedURLResponse * GTM_NULLABLE_TYPE cachedResponse);
-typedef void (^GTMSessionFetcherWillCacheURLResponseBlock)(NSCachedURLResponse *proposedResponse,
-                                                           GTMSessionFetcherWillCacheURLResponseResponse responseBlock);
+typedef void (^GTMSessionFetcherWillCacheURLResponseResponse)(
+    NSCachedURLResponse *GTM_NULLABLE_TYPE cachedResponse);
+typedef void (^GTMSessionFetcherWillCacheURLResponseBlock)(
+    NSCachedURLResponse *proposedResponse,
+    GTMSessionFetcherWillCacheURLResponseResponse responseBlock);
 typedef void (^GTMSessionFetcherRetryResponse)(BOOL shouldRetry);
 typedef void (^GTMSessionFetcherRetryBlock)(BOOL suggestedWillRetry,
-                                            NSError * GTM_NULLABLE_TYPE error,
+                                            NSError *GTM_NULLABLE_TYPE error,
                                             GTMSessionFetcherRetryResponse response);
 
 API_AVAILABLE(ios(10.0), macosx(10.12), tvos(10.0), watchos(3.0))
 typedef void (^GTMSessionFetcherMetricsCollectionBlock)(NSURLSessionTaskMetrics *metrics);
 
-typedef void (^GTMSessionFetcherTestResponse)(NSHTTPURLResponse * GTM_NULLABLE_TYPE response,
-                                              NSData * GTM_NULLABLE_TYPE data,
-                                              NSError * GTM_NULLABLE_TYPE error);
+typedef void (^GTMSessionFetcherTestResponse)(NSHTTPURLResponse *GTM_NULLABLE_TYPE response,
+                                              NSData *GTM_NULLABLE_TYPE data,
+                                              NSError *GTM_NULLABLE_TYPE error);
 typedef void (^GTMSessionFetcherTestBlock)(GTMSessionFetcher *fetcherToTest,
                                            GTMSessionFetcherTestResponse testResponse);
 
@@ -581,7 +596,7 @@ void GTMSessionFetcherAssertValidSelector(id GTM_NULLABLE_TYPE obj, SEL GTM_NULL
 // Applications may use this as a starting point for their own user agent strings, perhaps
 // with additional sections appended.  Use GTMFetcherCleanedUserAgentString() below to
 // clean up any string being added to the user agent.
-NSString *GTMFetcherStandardUserAgentString(NSBundle * GTM_NULLABLE_TYPE bundle);
+NSString *GTMFetcherStandardUserAgentString(NSBundle *GTM_NULLABLE_TYPE bundle);
 
 // Make a generic name and version for the current application, like
 // com.example.MyApp/1.2.3 relying on the bundle identifier and the
@@ -595,7 +610,7 @@ NSString *GTMFetcherStandardUserAgentString(NSBundle * GTM_NULLABLE_TYPE bundle)
 //
 // If no bundle ID or override is available, the process name preceded
 // by "proc_" is used.
-NSString *GTMFetcherApplicationIdentifier(NSBundle * GTM_NULLABLE_TYPE bundle);
+NSString *GTMFetcherApplicationIdentifier(NSBundle *GTM_NULLABLE_TYPE bundle);
 
 // Make an identifier like "MacOSX/10.7.1" or "iPod_Touch/4.1 hw/iPod1_1"
 NSString *GTMFetcherSystemVersionString(void);
@@ -618,12 +633,11 @@ NSString *GTMFetcherCleanedUserAgentString(NSString *str);
 // queue before calling this function.
 //
 // Failure is indicated by a returned data value of nil.
-NSData * GTM_NULLABLE_TYPE GTMDataFromInputStream(NSInputStream *inputStream, NSError **outError);
+NSData *GTM_NULLABLE_TYPE GTMDataFromInputStream(NSInputStream *inputStream, NSError **outError);
 
 #ifdef __cplusplus
 }  // extern "C"
 #endif
-
 
 #if !GTM_USE_SESSION_FETCHER
 @protocol GTMHTTPFetcherServiceProtocol;
@@ -689,7 +703,7 @@ NSData * GTM_NULLABLE_TYPE GTMDataFromInputStream(NSInputStream *inputStream, NS
 @property(atomic, assign) BOOL shouldAuthorizeAllRequests;
 
 - (void)authorizeRequest:(GTM_NULLABLE NSMutableURLRequest *)request
-       completionHandler:(void (^)(NSError * GTM_NULLABLE_TYPE error))handler;
+       completionHandler:(void (^)(NSError *GTM_NULLABLE_TYPE error))handler;
 
 #if GTM_USE_SESSION_FETCHER
 @property(atomic, weak, GTM_NULLABLE) id<GTMSessionFetcherServiceProtocol> fetcherService;
@@ -707,7 +721,7 @@ NSData * GTM_NULLABLE_TYPE GTMDataFromInputStream(NSInputStream *inputStream, NS
 // Set the target using +[GTMSessionFetcher setSubstituteUIApplication:]
 @protocol GTMUIApplicationProtocol <NSObject>
 - (UIBackgroundTaskIdentifier)beginBackgroundTaskWithName:(nullable NSString *)taskName
-                                        expirationHandler:(void(^ __nullable)(void))handler;
+                                        expirationHandler:(void (^__nullable)(void))handler;
 - (void)endBackgroundTask:(UIBackgroundTaskIdentifier)identifier;
 @end
 #endif
@@ -803,7 +817,8 @@ NSData * GTM_NULLABLE_TYPE GTMDataFromInputStream(NSInputStream *inputStream, NS
 // Additional user-supplied data to encode into the session identifier. Since session identifier
 // length limits are unspecified, this should be kept small. Key names beginning with an underscore
 // are reserved for use by the fetcher.
-@property(atomic, strong, GTM_NULLABLE) GTM_NSDictionaryOf(NSString *, NSString *) *sessionUserInfo;
+@property(atomic, strong, GTM_NULLABLE) GTM_NSDictionaryOf(NSString *, NSString *) *
+    sessionUserInfo;
 
 // The human-readable description to be assigned to the task.
 @property(atomic, copy, GTM_NULLABLE) NSString *taskDescription;
@@ -873,7 +888,7 @@ NSData * GTM_NULLABLE_TYPE GTMDataFromInputStream(NSInputStream *inputStream, NS
 //
 // For builds with the iOS 9/OS X 10.11 and later SDKs, this property is required only when
 // the app specifies NSAppTransportSecurity/NSAllowsArbitraryLoads in the main bundle's Info.plist.
-@property(atomic, copy, GTM_NULLABLE) GTM_NSArrayOf(NSString *) *allowedInsecureSchemes;
+@property(atomic, copy, GTM_NULLABLE) GTM_NSArrayOf(NSString *) * allowedInsecureSchemes;
 
 // By default, the fetcher prohibits localhost requests unless this property is set,
 // or the GTM_ALLOW_INSECURE_REQUESTS build flag is set.
@@ -944,7 +959,8 @@ NSData * GTM_NULLABLE_TYPE GTMDataFromInputStream(NSInputStream *inputStream, NS
 // the session task response.
 //
 // This is called on the callback queue.
-@property(atomic, copy, GTM_NULLABLE) GTMSessionFetcherDidReceiveResponseBlock didReceiveResponseBlock;
+@property(atomic, copy, GTM_NULLABLE)
+    GTMSessionFetcherDidReceiveResponseBlock didReceiveResponseBlock;
 
 // The delegate's optional challenge block may be used to inspect or alter
 // the session task challenge.
@@ -995,7 +1011,8 @@ NSData * GTM_NULLABLE_TYPE GTMDataFromInputStream(NSInputStream *inputStream, NS
 // NSURLResponse. The user may prevent caching by passing nil to the block's response.
 //
 // This is called on the callback queue.
-@property(atomic, copy, GTM_NULLABLE) GTMSessionFetcherWillCacheURLResponseBlock willCacheURLResponseBlock;
+@property(atomic, copy, GTM_NULLABLE)
+    GTMSessionFetcherWillCacheURLResponseBlock willCacheURLResponseBlock;
 
 // Enable retrying; see comments at the top of this file.  Setting
 // retryEnabled=YES resets the min and max retry intervals.
@@ -1086,7 +1103,8 @@ NSData * GTM_NULLABLE_TYPE GTMDataFromInputStream(NSInputStream *inputStream, NS
 @property(atomic, readonly) NSInteger statusCode;
 
 // Return the http headers from the response.
-@property(atomic, strong, readonly, GTM_NULLABLE) GTM_NSDictionaryOf(NSString *, NSString *) *responseHeaders;
+@property(atomic, strong, readonly, GTM_NULLABLE) GTM_NSDictionaryOf(NSString *, NSString *) *
+    responseHeaders;
 
 // The response, once it's been received.
 @property(atomic, strong, readonly, GTM_NULLABLE) NSURLResponse *response;
@@ -1111,9 +1129,10 @@ NSData * GTM_NULLABLE_TYPE GTMDataFromInputStream(NSInputStream *inputStream, NS
 @property(atomic, strong, GTM_NULLABLE) id userData;
 
 // Stored property values are retained solely for the convenience of the client.
-@property(atomic, copy, GTM_NULLABLE) GTM_NSDictionaryOf(NSString *, id) *properties;
+@property(atomic, copy, GTM_NULLABLE) GTM_NSDictionaryOf(NSString *, id) * properties;
 
-- (void)setProperty:(GTM_NULLABLE id)obj forKey:(NSString *)key;  // Pass nil for obj to remove the property.
+- (void)setProperty:(GTM_NULLABLE id)obj
+             forKey:(NSString *)key;  // Pass nil for obj to remove the property.
 - (GTM_NULLABLE id)propertyForKey:(NSString *)key;
 
 - (void)addPropertiesFromDictionary:(GTM_NSDictionaryOf(NSString *, id) *)dict;
@@ -1221,7 +1240,7 @@ NSData * GTM_NULLABLE_TYPE GTMDataFromInputStream(NSInputStream *inputStream, NS
 - (void)appendLoggedStreamData:(NSData *)dataToAdd;
 - (void)clearLoggedStreamData;
 
-#endif // STRIP_GTM_FETCH_LOGGING
+#endif  // STRIP_GTM_FETCH_LOGGING
 
 @end
 
@@ -1283,41 +1302,40 @@ NSData * GTM_NULLABLE_TYPE GTMDataFromInputStream(NSInputStream *inputStream, NS
 // Only build the synchronization monitor code if NS_BLOCK_ASSERTIONS is not
 // defined or asserts are being logged instead.
 #if DEBUG && (!defined(NS_BLOCK_ASSERTIONS) || GTMSESSION_ASSERT_AS_LOG)
-  #define __GTMSessionMonitorSynchronizedVariableInner(varname, counter) \
-      varname ## counter
-  #define __GTMSessionMonitorSynchronizedVariable(varname, counter)  \
-      __GTMSessionMonitorSynchronizedVariableInner(varname, counter)
+#define __GTMSessionMonitorSynchronizedVariableInner(varname, counter) varname##counter
+#define __GTMSessionMonitorSynchronizedVariable(varname, counter) \
+  __GTMSessionMonitorSynchronizedVariableInner(varname, counter)
 
-  #define GTMSessionMonitorSynchronized(obj)                                     \
-      NS_VALID_UNTIL_END_OF_SCOPE id                                             \
-        __GTMSessionMonitorSynchronizedVariable(__monitor, __COUNTER__) =        \
-        [[GTMSessionSyncMonitorInternal alloc] initWithSynchronizationObject:obj \
-                                                    allowRecursive:NO            \
-                                                     functionName:__func__]
+#define GTMSessionMonitorSynchronized(obj)                                                         \
+  NS_VALID_UNTIL_END_OF_SCOPE id __GTMSessionMonitorSynchronizedVariable(__monitor, __COUNTER__) = \
+      [[GTMSessionSyncMonitorInternal alloc] initWithSynchronizationObject:obj                     \
+                                                            allowRecursive:NO                      \
+                                                              functionName:__func__]
 
-  #define GTMSessionMonitorRecursiveSynchronized(obj)                            \
-      NS_VALID_UNTIL_END_OF_SCOPE id                                             \
-        __GTMSessionMonitorSynchronizedVariable(__monitor, __COUNTER__) =        \
-        [[GTMSessionSyncMonitorInternal alloc] initWithSynchronizationObject:obj \
-                                                    allowRecursive:YES           \
-                                                     functionName:__func__]
+#define GTMSessionMonitorRecursiveSynchronized(obj)                                                \
+  NS_VALID_UNTIL_END_OF_SCOPE id __GTMSessionMonitorSynchronizedVariable(__monitor, __COUNTER__) = \
+      [[GTMSessionSyncMonitorInternal alloc] initWithSynchronizationObject:obj                     \
+                                                            allowRecursive:YES                     \
+                                                              functionName:__func__]
 
-  #define GTMSessionCheckSynchronized(obj) {                                           \
-      GTMSESSION_ASSERT_DEBUG(                                                         \
-          [GTMSessionSyncMonitorInternal functionsHoldingSynchronizationOnObject:obj], \
-          @"GTMSessionCheckSynchronized(" #obj ") failed: not sync'd"                  \
-          @" on " #obj " in %s. Call stack:\n%@",                                      \
-          __func__, [NSThread callStackSymbols]);                                      \
-      }
+#define GTMSessionCheckSynchronized(obj)                                             \
+  {                                                                                  \
+    GTMSESSION_ASSERT_DEBUG(                                                         \
+        [GTMSessionSyncMonitorInternal functionsHoldingSynchronizationOnObject:obj], \
+        @"GTMSessionCheckSynchronized(" #obj ") failed: not sync'd"                  \
+        @" on " #obj " in %s. Call stack:\n%@",                                      \
+        __func__, [NSThread callStackSymbols]);                                      \
+  }
 
-  #define GTMSessionCheckNotSynchronized(obj) {                                       \
-      GTMSESSION_ASSERT_DEBUG(                                                        \
-        ![GTMSessionSyncMonitorInternal functionsHoldingSynchronizationOnObject:obj], \
-        @"GTMSessionCheckNotSynchronized(" #obj ") failed: was sync'd"                \
-        @" on " #obj " in %s by %@. Call stack:\n%@", __func__,                       \
-        [GTMSessionSyncMonitorInternal functionsHoldingSynchronizationOnObject:obj],  \
-        [NSThread callStackSymbols]);                                                 \
-      }
+#define GTMSessionCheckNotSynchronized(obj)                                                    \
+  {                                                                                            \
+    GTMSESSION_ASSERT_DEBUG(                                                                   \
+        ![GTMSessionSyncMonitorInternal functionsHoldingSynchronizationOnObject:obj],          \
+        @"GTMSessionCheckNotSynchronized(" #obj ") failed: was sync'd"                         \
+        @" on " #obj " in %s by %@. Call stack:\n%@",                                          \
+        __func__, [GTMSessionSyncMonitorInternal functionsHoldingSynchronizationOnObject:obj], \
+        [NSThread callStackSymbols]);                                                          \
+  }
 
 // GTMSessionSyncMonitorInternal is a private class that keeps track of the
 // beginning and end of synchronized scopes.
@@ -1329,16 +1347,23 @@ NSData * GTM_NULLABLE_TYPE GTMDataFromInputStream(NSInputStream *inputStream, NS
                                allowRecursive:(BOOL)allowRecursive
                                  functionName:(const char *)functionName;
 // Return the names of the functions that hold sync on the object, or nil if none.
-+ (NSArray * GTM_NULLABLE_TYPE)functionsHoldingSynchronizationOnObject:(id)object;
++ (NSArray *GTM_NULLABLE_TYPE)functionsHoldingSynchronizationOnObject:(id)object;
 @end
 
 #else
-  #define GTMSessionMonitorSynchronized(obj) do { } while (0)
-  #define GTMSessionMonitorRecursiveSynchronized(obj) do { } while (0)
-  #define GTMSessionCheckSynchronized(obj) do { } while (0)
-  #define GTMSessionCheckNotSynchronized(obj) do { } while (0)
+#define GTMSessionMonitorSynchronized(obj) \
+  do {                                     \
+  } while (0)
+#define GTMSessionMonitorRecursiveSynchronized(obj) \
+  do {                                              \
+  } while (0)
+#define GTMSessionCheckSynchronized(obj) \
+  do {                                   \
+  } while (0)
+#define GTMSessionCheckNotSynchronized(obj) \
+  do {                                      \
+  } while (0)
 #endif  // !DEBUG
 #endif  // __OBJC__
-
 
 GTM_ASSUME_NONNULL_END

--- a/Source/GTMSessionFetcher.m
+++ b/Source/GTMSessionFetcher.m
@@ -27,32 +27,38 @@
 #import <sys/utsname.h>
 
 #ifndef STRIP_GTM_FETCH_LOGGING
-  #error GTMSessionFetcher headers should have defaulted this if it wasn't already defined.
+#error GTMSessionFetcher headers should have defaulted this if it wasn't already defined.
 #endif
 
 GTM_ASSUME_NONNULL_BEGIN
 
-NSString *const kGTMSessionFetcherStartedNotification           = @"kGTMSessionFetcherStartedNotification";
-NSString *const kGTMSessionFetcherStoppedNotification           = @"kGTMSessionFetcherStoppedNotification";
-NSString *const kGTMSessionFetcherRetryDelayStartedNotification = @"kGTMSessionFetcherRetryDelayStartedNotification";
-NSString *const kGTMSessionFetcherRetryDelayStoppedNotification = @"kGTMSessionFetcherRetryDelayStoppedNotification";
+NSString *const kGTMSessionFetcherStartedNotification = @"kGTMSessionFetcherStartedNotification";
+NSString *const kGTMSessionFetcherStoppedNotification = @"kGTMSessionFetcherStoppedNotification";
+NSString *const kGTMSessionFetcherRetryDelayStartedNotification =
+    @"kGTMSessionFetcherRetryDelayStartedNotification";
+NSString *const kGTMSessionFetcherRetryDelayStoppedNotification =
+    @"kGTMSessionFetcherRetryDelayStoppedNotification";
 
-NSString *const kGTMSessionFetcherCompletionInvokedNotification = @"kGTMSessionFetcherCompletionInvokedNotification";
+NSString *const kGTMSessionFetcherCompletionInvokedNotification =
+    @"kGTMSessionFetcherCompletionInvokedNotification";
 NSString *const kGTMSessionFetcherCompletionDataKey = @"data";
 NSString *const kGTMSessionFetcherCompletionErrorKey = @"error";
 
-NSString *const kGTMSessionFetcherErrorDomain       = @"com.google.GTMSessionFetcher";
-NSString *const kGTMSessionFetcherStatusDomain      = @"com.google.HTTPStatus";
-NSString *const kGTMSessionFetcherStatusDataKey     = @"data";  // data returned with a kGTMSessionFetcherStatusDomain error
+NSString *const kGTMSessionFetcherErrorDomain = @"com.google.GTMSessionFetcher";
+NSString *const kGTMSessionFetcherStatusDomain = @"com.google.HTTPStatus";
+NSString *const kGTMSessionFetcherStatusDataKey =
+    @"data";  // data returned with a kGTMSessionFetcherStatusDomain error
 NSString *const kGTMSessionFetcherStatusDataContentTypeKey = @"data_content_type";
 
-NSString *const kGTMSessionFetcherNumberOfRetriesDoneKey        = @"kGTMSessionFetcherNumberOfRetriesDoneKey";
-NSString *const kGTMSessionFetcherElapsedIntervalWithRetriesKey = @"kGTMSessionFetcherElapsedIntervalWithRetriesKey";
+NSString *const kGTMSessionFetcherNumberOfRetriesDoneKey =
+    @"kGTMSessionFetcherNumberOfRetriesDoneKey";
+NSString *const kGTMSessionFetcherElapsedIntervalWithRetriesKey =
+    @"kGTMSessionFetcherElapsedIntervalWithRetriesKey";
 
 static NSString *const kGTMSessionIdentifierPrefix = @"com.google.GTMSessionFetcher";
 static NSString *const kGTMSessionIdentifierDestinationFileURLMetadataKey = @"_destURL";
-static NSString *const kGTMSessionIdentifierBodyFileURLMetadataKey        = @"_bodyURL";
-static NSString *const kGTMSessionIdentifierClientReconnectMetadataKey    = @"_clientWillReconnect";
+static NSString *const kGTMSessionIdentifierBodyFileURLMetadataKey = @"_bodyURL";
+static NSString *const kGTMSessionIdentifierClientReconnectMetadataKey = @"_clientWillReconnect";
 
 // The default max retry interview is 10 minutes for uploads (POST/PUT/PATCH),
 // 1 minute for downloads.
@@ -65,10 +71,10 @@ static const int64_t kMaximumDownloadErrorDataLength = 20000;
 
 #ifdef GTMSESSION_PERSISTED_DESTINATION_KEY
 // Projects using unique class names should also define a unique persisted destination key.
-static NSString * const kGTMSessionFetcherPersistedDestinationKey =
+static NSString *const kGTMSessionFetcherPersistedDestinationKey =
     GTMSESSION_PERSISTED_DESTINATION_KEY;
 #else
-static NSString * const kGTMSessionFetcherPersistedDestinationKey =
+static NSString *const kGTMSessionFetcherPersistedDestinationKey =
     @"com.google.GTMSessionFetcher.downloads";
 #endif
 
@@ -85,24 +91,29 @@ GTM_ASSUME_NONNULL_END
 #endif
 
 #ifndef GTM_TARGET_SUPPORTS_APP_TRANSPORT_SECURITY
-  #if (TARGET_OS_TV \
-       || TARGET_OS_WATCH \
-       || (!TARGET_OS_IPHONE && defined(MAC_OS_X_VERSION_10_11) && MAC_OS_X_VERSION_MAX_ALLOWED >= MAC_OS_X_VERSION_10_11) \
-       || (TARGET_OS_IPHONE && defined(__IPHONE_9_0) && __IPHONE_OS_VERSION_MAX_ALLOWED >= __IPHONE_9_0))
-    #define GTM_TARGET_SUPPORTS_APP_TRANSPORT_SECURITY 1
-  #endif
+#if (TARGET_OS_TV || TARGET_OS_WATCH ||                          \
+     (!TARGET_OS_IPHONE && defined(MAC_OS_X_VERSION_10_11) &&    \
+      MAC_OS_X_VERSION_MAX_ALLOWED >= MAC_OS_X_VERSION_10_11) || \
+     (TARGET_OS_IPHONE && defined(__IPHONE_9_0) &&               \
+      __IPHONE_OS_VERSION_MAX_ALLOWED >= __IPHONE_9_0))
+#define GTM_TARGET_SUPPORTS_APP_TRANSPORT_SECURITY 1
+#endif
 #endif
 
-#if ((defined(TARGET_OS_MACCATALYST) && TARGET_OS_MACCATALYST) || \
+#if ((defined(TARGET_OS_MACCATALYST) && TARGET_OS_MACCATALYST) ||                                 \
      (TARGET_OS_OSX && defined(__MAC_10_15) && __MAC_OS_X_VERSION_MIN_REQUIRED >= __MAC_10_15) || \
-     (TARGET_OS_IOS && defined(__IPHONE_13_0) && __IPHONE_OS_VERSION_MIN_REQUIRED >= __IPHONE_13_0) || \
-     (TARGET_OS_WATCH && defined(__WATCHOS_6_0) && __WATCHOS_VERSION_MIN_REQUIRED >= __WATCHOS_6_0) || \
+     (TARGET_OS_IOS && defined(__IPHONE_13_0) &&                                                  \
+      __IPHONE_OS_VERSION_MIN_REQUIRED >= __IPHONE_13_0) ||                                       \
+     (TARGET_OS_WATCH && defined(__WATCHOS_6_0) &&                                                \
+      __WATCHOS_VERSION_MIN_REQUIRED >= __WATCHOS_6_0) ||                                         \
      (TARGET_OS_TV && defined(__TVOS_13_0) && __TVOS_VERSION_MIN_REQUIRED >= __TVOS_13_0))
 #define GTM_SDK_REQUIRES_TLSMINIMUMSUPPORTEDPROTOCOLVERSION 1
 #define GTM_SDK_SUPPORTS_TLSMINIMUMSUPPORTEDPROTOCOLVERSION 1
 #elif ((TARGET_OS_OSX && defined(__MAC_10_15) && __MAC_OS_X_VERSION_MAX_ALLOWED >= __MAC_10_15) || \
-       (TARGET_OS_IOS && defined(__IPHONE_13_0) && __IPHONE_OS_VERSION_MAX_ALLOWED >= __IPHONE_13_0) || \
-       (TARGET_OS_WATCH && defined(__WATCHOS_6_0) && __WATCHOS_VERSION_MAX_ALLOWED >= __WATCHOS_6_0) || \
+       (TARGET_OS_IOS && defined(__IPHONE_13_0) &&                                                 \
+        __IPHONE_OS_VERSION_MAX_ALLOWED >= __IPHONE_13_0) ||                                       \
+       (TARGET_OS_WATCH && defined(__WATCHOS_6_0) &&                                               \
+        __WATCHOS_VERSION_MAX_ALLOWED >= __WATCHOS_6_0) ||                                         \
        (TARGET_OS_TV && defined(__TVOS_13_0) && __TVOS_VERSION_MAX_ALLOWED >= __TVOS_13_0))
 #define GTM_SDK_REQUIRES_TLSMINIMUMSUPPORTEDPROTOCOLVERSION 0
 #define GTM_SDK_SUPPORTS_TLSMINIMUMSUPPORTEDPROTOCOLVERSION 1
@@ -111,10 +122,12 @@ GTM_ASSUME_NONNULL_END
 #define GTM_SDK_SUPPORTS_TLSMINIMUMSUPPORTEDPROTOCOLVERSION 0
 #endif
 
-#if ((defined(TARGET_OS_MACCATALYST) && TARGET_OS_MACCATALYST) || \
+#if ((defined(TARGET_OS_MACCATALYST) && TARGET_OS_MACCATALYST) ||                                 \
      (TARGET_OS_OSX && defined(__MAC_10_15) && __MAC_OS_X_VERSION_MIN_REQUIRED >= __MAC_10_15) || \
-     (TARGET_OS_IOS && defined(__IPHONE_13_0) && __IPHONE_OS_VERSION_MIN_REQUIRED >= __IPHONE_13_0) || \
-     (TARGET_OS_WATCH && defined(__WATCHOS_6_0) && __WATCHOS_VERSION_MIN_REQUIRED >= __WATCHOS_6_0) || \
+     (TARGET_OS_IOS && defined(__IPHONE_13_0) &&                                                  \
+      __IPHONE_OS_VERSION_MIN_REQUIRED >= __IPHONE_13_0) ||                                       \
+     (TARGET_OS_WATCH && defined(__WATCHOS_6_0) &&                                                \
+      __WATCHOS_VERSION_MIN_REQUIRED >= __WATCHOS_6_0) ||                                         \
      (TARGET_OS_TV && defined(__TVOS_13_0) && __TVOS_VERSION_MIN_REQUIRED >= __TVOS_13_0))
 #define GTM_SDK_REQUIRES_SECTRUSTEVALUATEWITHERROR 1
 #else
@@ -148,15 +161,14 @@ GTM_ASSUME_NONNULL_END
 GTM_ASSUME_NONNULL_BEGIN
 
 static NSTimeInterval InitialMinRetryInterval(void) {
-  return 1.0 + ((double)(arc4random_uniform(0x0FFFF)) / (double) 0x0FFFF);
+  return 1.0 + ((double)(arc4random_uniform(0x0FFFF)) / (double)0x0FFFF);
 }
 
-static BOOL IsLocalhost(NSString * GTM_NULLABLE_TYPE host) {
+static BOOL IsLocalhost(NSString *GTM_NULLABLE_TYPE host) {
   // We check if there's host, and then make the comparisons.
   if (host == nil) return NO;
-  return ([host caseInsensitiveCompare:@"localhost"] == NSOrderedSame
-          || [host isEqual:@"::1"]
-          || [host isEqual:@"127.0.0.1"]);
+  return ([host caseInsensitiveCompare:@"localhost"] == NSOrderedSame || [host isEqual:@"::1"] ||
+          [host isEqual:@"127.0.0.1"]);
 }
 
 static NSDictionary *GTM_NULLABLE_TYPE GTMErrorUserInfoForData(
@@ -178,9 +190,9 @@ static NSDictionary *GTM_NULLABLE_TYPE GTMErrorUserInfoForData(
 static GTMSessionFetcherTestBlock GTM_NULLABLE_TYPE gGlobalTestBlock;
 
 @implementation GTMSessionFetcher {
-  NSMutableURLRequest *_request; // after beginFetch, changed only in delegate callbacks
-  BOOL _useUploadTask;           // immutable after beginFetch
-  NSURL *_bodyFileURL;           // immutable after beginFetch
+  NSMutableURLRequest *_request;  // after beginFetch, changed only in delegate callbacks
+  BOOL _useUploadTask;            // immutable after beginFetch
+  NSURL *_bodyFileURL;            // immutable after beginFetch
   GTMSessionFetcherBodyStreamProvider _bodyStreamProvider;  // immutable after beginFetch
   NSURLSession *_session;
   BOOL _shouldInvalidateSession;  // immutable after beginFetch
@@ -197,17 +209,18 @@ static GTMSessionFetcherTestBlock GTM_NULLABLE_TYPE gGlobalTestBlock;
   NSString *_sessionIdentifierUUID;
   BOOL _userRequestedBackgroundSession;
   BOOL _usingBackgroundSession;
-  NSMutableData * GTM_NULLABLE_TYPE _downloadedData;
+  NSMutableData *GTM_NULLABLE_TYPE _downloadedData;
   NSError *_downloadFinishedError;
-  NSData *_downloadResumeData;  // immutable after construction
-  NSData * GTM_NULLABLE_TYPE _downloadTaskErrorData; // Data for when download task fails
+  NSData *_downloadResumeData;                       // immutable after construction
+  NSData *GTM_NULLABLE_TYPE _downloadTaskErrorData;  // Data for when download task fails
   NSURL *_destinationFileURL;
   int64_t _downloadedLength;
-  NSURLCredential *_credential;     // username & password
-  NSURLCredential *_proxyCredential; // credential supplied to proxy servers
-  BOOL _isStopNotificationNeeded;   // set when start notification has been sent
-  BOOL _isUsingTestBlock;  // set when a test block was provided (remains set when the block is released)
-  id _userData;                      // retained, if set by caller
+  NSURLCredential *_credential;       // username & password
+  NSURLCredential *_proxyCredential;  // credential supplied to proxy servers
+  BOOL _isStopNotificationNeeded;     // set when start notification has been sent
+  BOOL _isUsingTestBlock;  // set when a test block was provided (remains set when the block is
+                           // released)
+  id _userData;            // retained, if set by caller
   NSMutableDictionary *_properties;  // more data retained for caller
   dispatch_queue_t _callbackQueue;
   dispatch_group_t _callbackGroup;   // read-only after creation
@@ -216,24 +229,26 @@ static GTMSessionFetcherTestBlock GTM_NULLABLE_TYPE gGlobalTestBlock;
   id<GTMFetcherAuthorizationProtocol> _authorizer;  // immutable after beginFetch
 
   // The service object that created and monitors this fetcher, if any.
-  id<GTMSessionFetcherServiceProtocol> _service;  // immutable; set by the fetcher service upon creation
+  id<GTMSessionFetcherServiceProtocol>
+      _service;  // immutable; set by the fetcher service upon creation
   NSString *_serviceHost;
-  NSInteger _servicePriority;       // immutable after beginFetch
-  BOOL _hasStoppedFetching;         // counterpart to _initialBeginFetchDate
+  NSInteger _servicePriority;  // immutable after beginFetch
+  BOOL _hasStoppedFetching;    // counterpart to _initialBeginFetchDate
   BOOL _userStoppedFetching;
 
-  BOOL _isRetryEnabled;             // user wants auto-retry
+  BOOL _isRetryEnabled;  // user wants auto-retry
   NSTimer *_retryTimer;
   NSUInteger _retryCount;
-  NSTimeInterval _maxRetryInterval; // default 60 (download) or 600 (upload) seconds
-  NSTimeInterval _minRetryInterval; // random between 1 and 2 seconds
-  NSTimeInterval _retryFactor;      // default interval multiplier is 2
+  NSTimeInterval _maxRetryInterval;  // default 60 (download) or 600 (upload) seconds
+  NSTimeInterval _minRetryInterval;  // random between 1 and 2 seconds
+  NSTimeInterval _retryFactor;       // default interval multiplier is 2
   NSTimeInterval _lastRetryInterval;
-  NSDate *_initialBeginFetchDate;   // date that beginFetch was first invoked; immutable after initial beginFetch
-  NSDate *_initialRequestDate;      // date of first request to the target server (ignoring auth)
-  BOOL _hasAttemptedAuthRefresh;    // accessed only in shouldRetryNowForStatus:
+  NSDate *_initialBeginFetchDate;  // date that beginFetch was first invoked; immutable after
+                                   // initial beginFetch
+  NSDate *_initialRequestDate;     // date of first request to the target server (ignoring auth)
+  BOOL _hasAttemptedAuthRefresh;   // accessed only in shouldRetryNowForStatus:
 
-  NSString *_comment;               // comment for log
+  NSString *_comment;  // comment for log
   NSString *_log;
 #if !STRIP_GTM_FETCH_LOGGING
   NSMutableData *_loggedStreamData;
@@ -302,8 +317,9 @@ static GTMSessionFetcherTestBlock GTM_NULLABLE_TYPE gGlobalTestBlock;
     [fetcher setSessionIdentifier:sessionIdentifier];
     [sessionIdentifierToFetcherMap setObject:fetcher forKey:sessionIdentifier];
     fetcher->_wasCreatedFromBackgroundSession = YES;
-    [fetcher setCommentWithFormat:@"Resuming %@",
-     fetcher && fetcher->_sessionIdentifierUUID ? fetcher->_sessionIdentifierUUID : @"?"];
+    [fetcher setCommentWithFormat:@"Resuming %@", fetcher && fetcher->_sessionIdentifierUUID
+                                                      ? fetcher->_sessionIdentifierUUID
+                                                      : @"?"];
   }
   return fetcher;
 }
@@ -341,18 +357,17 @@ static GTMSessionFetcherTestBlock GTM_NULLABLE_TYPE gGlobalTestBlock;
   return YES;
 #endif  // GTM_TARGET_SUPPORTS_APP_TRANSPORT_SECURITY
 }
-#else  // GTM_ALLOW_INSECURE_REQUESTS
+#else   // GTM_ALLOW_INSECURE_REQUESTS
 + (BOOL)appAllowsInsecureRequests {
   return YES;
 }
 #endif  // !GTM_ALLOW_INSECURE_REQUESTS
 
-
 - (instancetype)init {
   return [self initWithRequest:nil configuration:nil];
 }
 
-- (instancetype)initWithRequest:(NSURLRequest *)request  {
+- (instancetype)initWithRequest:(NSURLRequest *)request {
   return [self initWithRequest:request configuration:nil];
 }
 
@@ -414,8 +429,8 @@ static GTMSessionFetcherTestBlock GTM_NULLABLE_TYPE gGlobalTestBlock;
 }
 
 - (void)dealloc {
-  GTMSESSION_ASSERT_DEBUG(!_isStopNotificationNeeded,
-                          @"unbalanced fetcher notification for %@", _request.URL);
+  GTMSESSION_ASSERT_DEBUG(!_isStopNotificationNeeded, @"unbalanced fetcher notification for %@",
+                          _request.URL);
   [self forgetSessionIdentifierForFetcherWithoutSyncCheck];
 
   // Note: if a session task or a retry timer was pending, then this instance
@@ -448,21 +463,22 @@ static GTMSessionFetcherTestBlock GTM_NULLABLE_TYPE gGlobalTestBlock;
 }
 
 - (GTMSessionFetcherCompletionHandler)completionHandlerWithTarget:(GTM_NULLABLE_TYPE id)target
-                                                didFinishSelector:(GTM_NULLABLE_TYPE SEL)finishedSelector {
+                                                didFinishSelector:
+                                                    (GTM_NULLABLE_TYPE SEL)finishedSelector {
   GTMSessionFetcherAssertValidSelector(target, finishedSelector, @encode(GTMSessionFetcher *),
                                        @encode(NSData *), @encode(NSError *), 0);
   GTMSessionFetcherCompletionHandler completionHandler = ^(NSData *data, NSError *error) {
-      if (target && finishedSelector) {
-        id selfArg = self;  // Placate ARC.
-        NSMethodSignature *sig = [target methodSignatureForSelector:finishedSelector];
-        NSInvocation *invocation = [NSInvocation invocationWithMethodSignature:sig];
-        [invocation setSelector:(SEL)finishedSelector];
-        [invocation setTarget:target];
-        [invocation setArgument:&selfArg atIndex:2];
-        [invocation setArgument:&data atIndex:3];
-        [invocation setArgument:&error atIndex:4];
-        [invocation invoke];
-      }
+    if (target && finishedSelector) {
+      id selfArg = self;  // Placate ARC.
+      NSMethodSignature *sig = [target methodSignatureForSelector:finishedSelector];
+      NSInvocation *invocation = [NSInvocation invocationWithMethodSignature:sig];
+      [invocation setSelector:(SEL)finishedSelector];
+      [invocation setTarget:target];
+      [invocation setArgument:&selfArg atIndex:2];
+      [invocation setArgument:&data atIndex:3];
+      [invocation setArgument:&error atIndex:4];
+      [invocation invoke];
+    }
   };
   return completionHandler;
 }
@@ -471,29 +487,26 @@ static GTMSessionFetcherTestBlock GTM_NULLABLE_TYPE gGlobalTestBlock;
              didFinishSelector:(GTM_NULLABLE_TYPE SEL)finishedSelector {
   GTMSessionCheckNotSynchronized(self);
 
-  GTMSessionFetcherCompletionHandler handler =  [self completionHandlerWithTarget:target
-                                                                didFinishSelector:finishedSelector];
+  GTMSessionFetcherCompletionHandler handler = [self completionHandlerWithTarget:target
+                                                               didFinishSelector:finishedSelector];
   [self beginFetchWithCompletionHandler:handler];
 }
 
-- (void)beginFetchMayDelay:(BOOL)mayDelay
-              mayAuthorize:(BOOL)mayAuthorize {
+- (void)beginFetchMayDelay:(BOOL)mayDelay mayAuthorize:(BOOL)mayAuthorize {
   // This is the internal entry point for re-starting fetches.
   GTMSessionCheckNotSynchronized(self);
 
-  NSMutableURLRequest *fetchRequest = _request;  // The request property is now externally immutable.
+  NSMutableURLRequest *fetchRequest =
+      _request;  // The request property is now externally immutable.
   NSURL *fetchRequestURL = fetchRequest.URL;
   NSString *priorSessionIdentifier = self.sessionIdentifier;
 
   // A utility block for creating error objects when we fail to start the fetch.
-  NSError *(^beginFailureError)(NSInteger) = ^(NSInteger code){
+  NSError * (^beginFailureError)(NSInteger) = ^(NSInteger code) {
     NSString *urlString = fetchRequestURL.absoluteString;
-    NSDictionary *userInfo = @{
-      NSURLErrorFailingURLStringErrorKey : (urlString ? urlString : @"(missing URL)")
-    };
-    return [NSError errorWithDomain:kGTMSessionFetcherErrorDomain
-                               code:code
-                           userInfo:userInfo];
+    NSDictionary *userInfo =
+        @{NSURLErrorFailingURLStringErrorKey : (urlString ? urlString : @"(missing URL)")};
+    return [NSError errorWithDomain:kGTMSessionFetcherErrorDomain code:code userInfo:userInfo];
   };
 
   // Catch delegate queue maxConcurrentOperationCount values other than 1, particularly
@@ -501,8 +514,7 @@ static GTMSessionFetcherTestBlock GTM_NULLABLE_TYPE gGlobalTestBlock;
   // of simultaneous or out-of-order delegate callbacks.
   GTMSESSION_ASSERT_DEBUG(_delegateQueue.maxConcurrentOperationCount == 1,
                           @"delegate queue %@ should support one concurrent operation, not %ld",
-                          _delegateQueue.name,
-                          (long)_delegateQueue.maxConcurrentOperationCount);
+                          _delegateQueue.name, (long)_delegateQueue.maxConcurrentOperationCount);
 
   if (!_initialBeginFetchDate) {
     // This ivar is set only here on the initial beginFetch so need not be synchronized.
@@ -536,8 +548,8 @@ static GTMSessionFetcherTestBlock GTM_NULLABLE_TYPE gGlobalTestBlock;
     if (![bodyFileURL checkResourceIsReachableAndReturnError:&fileCheckError]) {
       // This assert fires when the file being uploaded no longer exists once
       // the fetcher is ready to start the upload.
-      GTMSESSION_ASSERT_DEBUG_OR_LOG(0, @"Body file is unreachable: %@\n  %@",
-                                     bodyFileURL.path, fileCheckError);
+      GTMSESSION_ASSERT_DEBUG_OR_LOG(0, @"Body file is unreachable: %@\n  %@", bodyFileURL.path,
+                                     fileCheckError);
       [self failToBeginFetchWithError:fileCheckError];
       return;
     }
@@ -549,8 +561,7 @@ static GTMSessionFetcherTestBlock GTM_NULLABLE_TYPE gGlobalTestBlock;
     // NSURLSession does not support data URLs in background sessions.
 #if DEBUG
     if (priorSessionIdentifier || self.sessionIdentifier) {
-      GTMSESSION_LOG_DEBUG(@"Converting background to foreground session for %@",
-                           fetchRequest);
+      GTMSESSION_LOG_DEBUG(@"Converting background to foreground session for %@", fetchRequest);
     }
 #endif
     // If priorSessionIdentifier is allowed to stay non-nil, a background session can
@@ -563,9 +574,8 @@ static GTMSessionFetcherTestBlock GTM_NULLABLE_TYPE gGlobalTestBlock;
 #if GTM_ALLOW_INSECURE_REQUESTS
   BOOL shouldCheckSecurity = NO;
 #else
-  BOOL shouldCheckSecurity = (fetchRequestURL != nil
-                              && !isDataRequest
-                              && [[self class] appAllowsInsecureRequests]);
+  BOOL shouldCheckSecurity =
+      (fetchRequestURL != nil && !isDataRequest && [[self class] appAllowsInsecureRequests]);
 #endif
 
   if (shouldCheckSecurity) {
@@ -593,30 +603,36 @@ static GTMSessionFetcherTestBlock GTM_NULLABLE_TYPE gGlobalTestBlock;
       if (!allowRequest) {
         // Check for localhost requests.  Security checks only occur for non-https requests, so
         // this check won't happen for an https request to localhost.
-        BOOL isLocalhostRequest = (host.length == 0 && [fetchRequestURL isFileURL]) || IsLocalhost(host);
+        BOOL isLocalhostRequest =
+            (host.length == 0 && [fetchRequestURL isFileURL]) || IsLocalhost(host);
         if (isLocalhostRequest) {
           if (self.allowLocalhostRequest) {
             allowRequest = YES;
           } else {
-            GTMSESSION_ASSERT_DEBUG(NO, @"Fetch request for localhost but fetcher"
-                                        @" allowLocalhostRequest is not set: %@", fetchRequestURL);
+            GTMSESSION_ASSERT_DEBUG(NO,
+                                    @"Fetch request for localhost but fetcher"
+                                    @" allowLocalhostRequest is not set: %@",
+                                    fetchRequestURL);
           }
         } else {
-          GTMSESSION_ASSERT_DEBUG(NO, @"Insecure fetch request has a scheme (%@)"
-                                      @" not found in fetcher allowedInsecureSchemes (%@): %@",
-                                  requestScheme, _allowedInsecureSchemes ?: @" @[] ", fetchRequestURL);
+          GTMSESSION_ASSERT_DEBUG(NO,
+                                  @"Insecure fetch request has a scheme (%@)"
+                                  @" not found in fetcher allowedInsecureSchemes (%@): %@",
+                                  requestScheme, _allowedInsecureSchemes ?: @" @[] ",
+                                  fetchRequestURL);
         }
       }
 
       if (!allowRequest) {
 #if !DEBUG
-        NSLog(@"Insecure fetch disallowed for %@", fetchRequestURL.description ?: @"nil request URL");
+        NSLog(@"Insecure fetch disallowed for %@",
+              fetchRequestURL.description ?: @"nil request URL");
 #endif
         [self failToBeginFetchWithError:beginFailureError(GTMSessionFetcherErrorInsecureRequest)];
         return;
       }
     }  // !isSecure
-  }  // (requestURL != nil) && !isDataRequest
+  }    // (requestURL != nil) && !isDataRequest
 
   if (self.cookieStorage == nil) {
     self.cookieStorage = [[self class] staticCookieStorage];
@@ -645,11 +661,11 @@ static GTMSessionFetcherTestBlock GTM_NULLABLE_TYPE gGlobalTestBlock;
         [sessionIdentifierToFetcherMap setObject:self forKey:self.sessionIdentifier];
 
         if (@available(iOS 8.0, tvOS 9.0, watchOS 2.0, macOS 10.10, *)) {
-          _configuration =
-              [NSURLSessionConfiguration backgroundSessionConfigurationWithIdentifier:sessionIdentifier];
+          _configuration = [NSURLSessionConfiguration
+              backgroundSessionConfigurationWithIdentifier:sessionIdentifier];
         } else {
-#if ((!TARGET_OS_IPHONE && MAC_OS_X_VERSION_MIN_REQUIRED < MAC_OS_X_VERSION_10_10) \
-     || (TARGET_OS_IPHONE && __IPHONE_OS_VERSION_MIN_REQUIRED < __IPHONE_8_0))
+#if ((!TARGET_OS_IPHONE && MAC_OS_X_VERSION_MIN_REQUIRED < MAC_OS_X_VERSION_10_10) || \
+     (TARGET_OS_IPHONE && __IPHONE_OS_VERSION_MIN_REQUIRED < __IPHONE_8_0))
           // If building with support for iOS 7 or < macOS 10.10, allow using the older
           // -backgroundSessionConfiguration: method, otherwise leave it out to avoid deprecated
           // API warnings/errors.
@@ -762,8 +778,7 @@ static GTMSessionFetcherTestBlock GTM_NULLABLE_TYPE gGlobalTestBlock;
   if (effectiveHTTPMethod == nil) {
     effectiveHTTPMethod = fetchRequest.HTTPMethod;
   }
-  BOOL isEffectiveHTTPGet = (effectiveHTTPMethod == nil
-                             || [effectiveHTTPMethod isEqual:@"GET"]);
+  BOOL isEffectiveHTTPGet = (effectiveHTTPMethod == nil || [effectiveHTTPMethod isEqual:@"GET"]);
 
   BOOL needsUploadTask = (self.useUploadTask || self.bodyFileURL || self.bodyStreamProvider);
   if (_bodyData || self.bodyStreamProvider || fetchRequest.HTTPBodyStream) {
@@ -821,8 +836,8 @@ static GTMSessionFetcherTestBlock GTM_NULLABLE_TYPE gGlobalTestBlock;
   BOOL needsDataAccumulator = NO;
   if (_downloadResumeData) {
     newSessionTask = [_session downloadTaskWithResumeData:_downloadResumeData];
-    GTMSESSION_ASSERT_DEBUG_OR_LOG(newSessionTask,
-        @"Failed downloadTaskWithResumeData for %@, resume data %lu bytes",
+    GTMSESSION_ASSERT_DEBUG_OR_LOG(
+        newSessionTask, @"Failed downloadTaskWithResumeData for %@, resume data %lu bytes",
         _session, (unsigned long)_downloadResumeData.length);
   } else if (_destinationFileURL && !isDataRequest) {
     newSessionTask = [_session downloadTaskWithRequest:fetchRequest];
@@ -830,24 +845,23 @@ static GTMSessionFetcherTestBlock GTM_NULLABLE_TYPE gGlobalTestBlock;
                                    _session, fetchRequest);
   } else if (needsUploadTask) {
     if (bodyFileURL) {
-      newSessionTask = [_session uploadTaskWithRequest:fetchRequest
-                                              fromFile:bodyFileURL];
+      newSessionTask = [_session uploadTaskWithRequest:fetchRequest fromFile:bodyFileURL];
       GTMSESSION_ASSERT_DEBUG_OR_LOG(newSessionTask,
-                                     @"Failed uploadTaskWithRequest for %@, %@, file %@",
-                                     _session, fetchRequest, bodyFileURL.path);
+                                     @"Failed uploadTaskWithRequest for %@, %@, file %@", _session,
+                                     fetchRequest, bodyFileURL.path);
     } else if (self.bodyStreamProvider) {
       newSessionTask = [_session uploadTaskWithStreamedRequest:fetchRequest];
       GTMSESSION_ASSERT_DEBUG_OR_LOG(newSessionTask,
-                                     @"Failed uploadTaskWithStreamedRequest for %@, %@",
-                                     _session, fetchRequest);
+                                     @"Failed uploadTaskWithStreamedRequest for %@, %@", _session,
+                                     fetchRequest);
     } else {
-      GTMSESSION_ASSERT_DEBUG_OR_LOG(_bodyData != nil,
-                                     @"Upload task needs body data, %@", fetchRequest);
+      GTMSESSION_ASSERT_DEBUG_OR_LOG(_bodyData != nil, @"Upload task needs body data, %@",
+                                     fetchRequest);
       newSessionTask = [_session uploadTaskWithRequest:fetchRequest
-                                            fromData:(NSData * GTM_NONNULL_TYPE)_bodyData];
-      GTMSESSION_ASSERT_DEBUG_OR_LOG(newSessionTask,
-          @"Failed uploadTaskWithRequest for %@, %@, body data %lu bytes",
-          _session, fetchRequest, (unsigned long)_bodyData.length);
+                                              fromData:(NSData * GTM_NONNULL_TYPE) _bodyData];
+      GTMSESSION_ASSERT_DEBUG_OR_LOG(
+          newSessionTask, @"Failed uploadTaskWithRequest for %@, %@, body data %lu bytes", _session,
+          fetchRequest, (unsigned long)_bodyData.length);
     }
     needsDataAccumulator = YES;
   } else {
@@ -900,8 +914,8 @@ static GTMSessionFetcherTestBlock GTM_NULLABLE_TYPE gGlobalTestBlock;
     // Tell UIApplication that we want to continue even when the app is in the
     // background.
 #if DEBUG
-    NSString *bgTaskName = [NSString stringWithFormat:@"%@-%@",
-                            [self class], fetchRequest.URL.host];
+    NSString *bgTaskName =
+        [NSString stringWithFormat:@"%@-%@", [self class], fetchRequest.URL.host];
 #else
     NSString *bgTaskName = @"GTMSessionFetcher";
 #endif
@@ -911,22 +925,23 @@ static GTMSessionFetcherTestBlock GTM_NULLABLE_TYPE gGlobalTestBlock;
     // background).
     __block UIBackgroundTaskIdentifier guardedTaskID = UIBackgroundTaskInvalid;
     UIBackgroundTaskIdentifier returnedTaskID =
-        [app beginBackgroundTaskWithName:bgTaskName expirationHandler:^{
-      // Background task expiration callback - this block is always invoked by
-      // UIApplication on the main thread.
-      UIBackgroundTaskIdentifier localTaskID;
-      @synchronized(self) {
-        localTaskID = guardedTaskID;
-      }
-      if (localTaskID != UIBackgroundTaskInvalid) {
-        @synchronized(self) {
-          if (localTaskID == self.backgroundTaskIdentifier) {
-            self.backgroundTaskIdentifier = UIBackgroundTaskInvalid;
-          }
-        }
-        [app endBackgroundTask:localTaskID];
-      }
-    }];
+        [app beginBackgroundTaskWithName:bgTaskName
+                       expirationHandler:^{
+                         // Background task expiration callback - this block is always invoked by
+                         // UIApplication on the main thread.
+                         UIBackgroundTaskIdentifier localTaskID;
+                         @synchronized(self) {
+                           localTaskID = guardedTaskID;
+                         }
+                         if (localTaskID != UIBackgroundTaskInvalid) {
+                           @synchronized(self) {
+                             if (localTaskID == self.backgroundTaskIdentifier) {
+                               self.backgroundTaskIdentifier = UIBackgroundTaskInvalid;
+                             }
+                           }
+                           [app endBackgroundTask:localTaskID];
+                         }
+                       }];
     @synchronized(self) {
       guardedTaskID = returnedTaskID;
       self.backgroundTaskIdentifier = returnedTaskID;
@@ -968,7 +983,7 @@ static GTMSessionFetcherTestBlock GTM_NULLABLE_TYPE gGlobalTestBlock;
   }
 }
 
-NSData * GTM_NULLABLE_TYPE GTMDataFromInputStream(NSInputStream *inputStream, NSError **outError) {
+NSData *GTM_NULLABLE_TYPE GTMDataFromInputStream(NSInputStream *inputStream, NSError **outError) {
   NSMutableData *data = [NSMutableData data];
 
   [inputStream open];
@@ -1001,61 +1016,66 @@ NSData * GTM_NULLABLE_TYPE GTMDataFromInputStream(NSInputStream *inputStream, NS
   //
   // Callbacks will all occur on the callback queue.
   _testBlock(self, ^(NSURLResponse *response, NSData *responseData, NSError *error) {
-      // Callback from test block.
-      if (response == nil && responseData == nil && error == nil) {
-        // Assume the fetcher should execute rather than be tested.
-        self->_testBlock = nil;
-        self->_isUsingTestBlock = NO;
-        [self->_sessionTask resume];
-        return;
+    // Callback from test block.
+    if (response == nil && responseData == nil && error == nil) {
+      // Assume the fetcher should execute rather than be tested.
+      self->_testBlock = nil;
+      self->_isUsingTestBlock = NO;
+      [self->_sessionTask resume];
+      return;
+    }
+
+    GTMSessionFetcherBodyStreamProvider bodyStreamProvider = self.bodyStreamProvider;
+    if (bodyStreamProvider) {
+      bodyStreamProvider(^(NSInputStream *bodyStream) {
+        // Read from the input stream into an NSData buffer.  We'll drain the stream
+        // explicitly on a background queue.
+        [self
+            invokeOnCallbackQueue:dispatch_get_global_queue(DISPATCH_QUEUE_PRIORITY_HIGH, 0)
+                 afterUserStopped:NO
+                            block:^{
+                              NSError *streamError;
+                              NSData *streamedData =
+                                  GTMDataFromInputStream(bodyStream, &streamError);
+
+                              dispatch_async(dispatch_get_main_queue(), ^{
+                                // Continue callbacks on the main thread, since serial behavior
+                                // is more reliable for tests.
+                                [self
+                                    simulateDataCallbacksForTestBlockWithBodyData:streamedData
+                                                                         response:response
+                                                                     responseData:responseData
+                                                                            error:
+                                                                                (error
+                                                                                     ?: streamError)];
+                              });
+                            }];
+      });
+    } else {
+      // No input stream; use the supplied data or file URL.
+      NSURL *bodyFileURL = self.bodyFileURL;
+      if (bodyFileURL) {
+        NSError *readError;
+        self->_bodyData = [NSData dataWithContentsOfURL:bodyFileURL
+                                                options:NSDataReadingMappedIfSafe
+                                                  error:&readError];
+        error = readError;
       }
 
-      GTMSessionFetcherBodyStreamProvider bodyStreamProvider = self.bodyStreamProvider;
-      if (bodyStreamProvider) {
-        bodyStreamProvider(^(NSInputStream *bodyStream){
-          // Read from the input stream into an NSData buffer.  We'll drain the stream
-          // explicitly on a background queue.
-          [self invokeOnCallbackQueue:dispatch_get_global_queue(DISPATCH_QUEUE_PRIORITY_HIGH, 0)
-                     afterUserStopped:NO
-                                block:^{
-            NSError *streamError;
-            NSData *streamedData = GTMDataFromInputStream(bodyStream, &streamError);
+      // No stream provider.
 
-            dispatch_async(dispatch_get_main_queue(), ^{
-              // Continue callbacks on the main thread, since serial behavior
-              // is more reliable for tests.
-              [self simulateDataCallbacksForTestBlockWithBodyData:streamedData
-                                                         response:response
-                                                     responseData:responseData
-                                                            error:(error ?: streamError)];
-            });
-          }];
-        });
-      } else {
-        // No input stream; use the supplied data or file URL.
-        NSURL *bodyFileURL = self.bodyFileURL;
-        if (bodyFileURL) {
-          NSError *readError;
-          self->_bodyData = [NSData dataWithContentsOfURL:bodyFileURL
-                                            options:NSDataReadingMappedIfSafe
-                                              error:&readError];
-          error = readError;
-        }
-
-        // No stream provider.
-
-        // In real fetches, nothing happens until the run loop spins, so apps have leeway to
-        // set callbacks after they call beginFetch. We'll mirror that fetcher behavior by
-        // delaying callbacks here at least to the next spin of the run loop.  That keeps
-        // immediate, synchronous setting of callback blocks after beginFetch working in tests.
-        dispatch_async(dispatch_get_main_queue(), ^{
-          [self simulateDataCallbacksForTestBlockWithBodyData:self->_bodyData
-                                                     response:response
-                                                 responseData:responseData
-                                                        error:error];
-        });
-      }
-    });
+      // In real fetches, nothing happens until the run loop spins, so apps have leeway to
+      // set callbacks after they call beginFetch. We'll mirror that fetcher behavior by
+      // delaying callbacks here at least to the next spin of the run loop.  That keeps
+      // immediate, synchronous setting of callback blocks after beginFetch working in tests.
+      dispatch_async(dispatch_get_main_queue(), ^{
+        [self simulateDataCallbacksForTestBlockWithBodyData:self->_bodyData
+                                                   response:response
+                                               responseData:responseData
+                                                      error:error];
+      });
+    }
+  });
 }
 
 - (void)simulateByteTransferReportWithDataLength:(int64_t)totalDataLength
@@ -1069,12 +1089,12 @@ NSData * GTM_NULLABLE_TYPE GTMDataFromInputStream(NSInputStream *inputStream, NS
     sendReportSize = MIN(sendReportSize, bytesRemaining);
     totalSent += sendReportSize;
     [self invokeOnCallbackQueueUnlessStopped:^{
-        block(sendReportSize, totalSent, totalDataLength);
+      block(sendReportSize, totalSent, totalDataLength);
     }];
   }
 }
 
-- (void)simulateDataCallbacksForTestBlockWithBodyData:(NSData * GTM_NULLABLE_TYPE)bodyData
+- (void)simulateDataCallbacksForTestBlockWithBodyData:(NSData *GTM_NULLABLE_TYPE)bodyData
                                              response:(NSURLResponse *)response
                                          responseData:(NSData *)suppliedData
                                                 error:(NSError *)suppliedError {
@@ -1103,11 +1123,14 @@ NSData * GTM_NULLABLE_TYPE GTMDataFromInputStream(NSInputStream *inputStream, NS
     if (willRedirectBlock) {
       [self invokeOnCallbackUnsynchronizedQueueAfterUserStopped:YES
                                                           block:^{
-          willRedirectBlock((NSHTTPURLResponse *)response, self->_request,
-                             ^(NSURLRequest *redirectRequest) {
-              // For simulation, we'll assume the app will just continue.
-          });
-      }];
+                                                            willRedirectBlock(
+                                                                (NSHTTPURLResponse *)response,
+                                                                self->_request,
+                                                                ^(NSURLRequest *redirectRequest){
+                                                                    // For simulation, we'll assume
+                                                                    // the app will just continue.
+                                                                });
+                                                          }];
     }
 
     // If the fetcher has a challenge block, simulate a challenge.
@@ -1116,53 +1139,76 @@ NSData * GTM_NULLABLE_TYPE GTMDataFromInputStream(NSInputStream *inputStream, NS
     // fetches get challenged rather than always executing the supplied
     // challenge block.
     if (challengeBlock) {
-      [self invokeOnCallbackUnsynchronizedQueueAfterUserStopped:YES
-                                                          block:^{
-        NSURL *requestURL = self->_request.URL;
-        NSString *host = requestURL.host;
-        NSURLProtectionSpace *pspace =
-            [[NSURLProtectionSpace alloc] initWithHost:host
-                                                  port:requestURL.port.integerValue
-                                              protocol:requestURL.scheme
-                                                 realm:nil
-                                  authenticationMethod:NSURLAuthenticationMethodHTTPBasic];
-        id<NSURLAuthenticationChallengeSender> unusedSender =
-            (id<NSURLAuthenticationChallengeSender>)[NSNull null];
-        NSURLAuthenticationChallenge *challenge =
-            [[NSURLAuthenticationChallenge alloc] initWithProtectionSpace:pspace
-                                                       proposedCredential:nil
-                                                     previousFailureCount:0
-                                                          failureResponse:nil
-                                                                    error:nil
-                                                                   sender:unusedSender];
-        challengeBlock(self, challenge, ^(NSURLSessionAuthChallengeDisposition disposition,
-                                          NSURLCredential * GTM_NULLABLE_TYPE credential){
-          // We could change the responseData and responseError based on the disposition,
-          // but it's easier for apps to just supply the expected data and error
-          // directly to the test block. So this simulation ignores the disposition.
-        });
-      }];
+      [self
+          invokeOnCallbackUnsynchronizedQueueAfterUserStopped:YES
+                                                        block:^{
+                                                          NSURL *requestURL = self->_request.URL;
+                                                          NSString *host = requestURL.host;
+                                                          NSURLProtectionSpace *pspace = [[NSURLProtectionSpace
+                                                              alloc] initWithHost:host
+                                                                              port:requestURL.port
+                                                                                       .integerValue
+                                                                          protocol:requestURL.scheme
+                                                                             realm:nil
+                                                              authenticationMethod:
+                                                                  NSURLAuthenticationMethodHTTPBasic];
+                                                          id<NSURLAuthenticationChallengeSender>
+                                                              unusedSender =
+                                                                  (id<NSURLAuthenticationChallengeSender>)
+                                                                      [NSNull null];
+                                                          NSURLAuthenticationChallenge *challenge =
+                                                              [[NSURLAuthenticationChallenge alloc]
+                                                                  initWithProtectionSpace:pspace
+                                                                       proposedCredential:nil
+                                                                     previousFailureCount:0
+                                                                          failureResponse:nil
+                                                                                    error:nil
+                                                                                   sender:
+                                                                                       unusedSender];
+                                                          challengeBlock(
+                                                              self, challenge,
+                                                              ^(NSURLSessionAuthChallengeDisposition
+                                                                    disposition,
+                                                                NSURLCredential *GTM_NULLABLE_TYPE
+                                                                    credential){
+                                                                  // We could change the
+                                                                  // responseData and responseError
+                                                                  // based on the disposition,
+                                                                  // but it's easier for apps to
+                                                                  // just supply the expected data
+                                                                  // and error
+                                                                  // directly to the test block. So
+                                                                  // this simulation ignores the
+                                                                  // disposition.
+                                                              });
+                                                        }];
     }
 
     // Simulate receipt of an initial response.
     if (response && didReceiveResponseBlock) {
-      [self invokeOnCallbackUnsynchronizedQueueAfterUserStopped:YES
-                                                          block:^{
-          didReceiveResponseBlock(response, ^(NSURLSessionResponseDisposition desiredDisposition) {
-            // For simulation, we'll assume the disposition is to continue.
-          });
-      }];
+      [self
+          invokeOnCallbackUnsynchronizedQueueAfterUserStopped:YES
+                                                        block:^{
+                                                          didReceiveResponseBlock(
+                                                              response,
+                                                              ^(NSURLSessionResponseDisposition
+                                                                    desiredDisposition){
+                                                                  // For simulation, we'll assume
+                                                                  // the disposition is to continue.
+                                                              });
+                                                        }];
     }
 
     // Simulate reporting send progress.
     if (sendProgressBlock) {
       [self simulateByteTransferReportWithDataLength:(int64_t)bodyData.length
-                                               block:^(int64_t bytesSent,
-                                                       int64_t totalBytesSent,
+                                               block:^(int64_t bytesSent, int64_t totalBytesSent,
                                                        int64_t totalBytesExpectedToSend) {
-          // This is invoked on the callback queue unless stopped.
-          sendProgressBlock(bytesSent, totalBytesSent, totalBytesExpectedToSend);
-      }];
+                                                 // This is invoked on the callback queue unless
+                                                 // stopped.
+                                                 sendProgressBlock(bytesSent, totalBytesSent,
+                                                                   totalBytesExpectedToSend);
+                                               }];
     }
 
     if (destinationFileURL) {
@@ -1172,16 +1218,16 @@ NSData * GTM_NULLABLE_TYPE GTMDataFromInputStream(NSInputStream *inputStream, NS
                                                  block:^(int64_t bytesDownloaded,
                                                          int64_t totalBytesDownloaded,
                                                          int64_t totalBytesExpectedToDownload) {
-            // This is invoked on the callback queue unless stopped.
-            downloadProgressBlock(bytesDownloaded, totalBytesDownloaded,
-                                  totalBytesExpectedToDownload);
-        }];
+                                                   // This is invoked on the callback queue unless
+                                                   // stopped.
+                                                   downloadProgressBlock(
+                                                       bytesDownloaded, totalBytesDownloaded,
+                                                       totalBytesExpectedToDownload);
+                                                 }];
       }
 
       NSError *writeError;
-      [responseData writeToURL:destinationFileURL
-                       options:NSDataWritingAtomic
-                         error:&writeError];
+      [responseData writeToURL:destinationFileURL options:NSDataWritingAtomic error:&writeError];
       if (writeError) {
         // Tell the test code that writing failed.
         responseError = writeError;
@@ -1190,19 +1236,18 @@ NSData * GTM_NULLABLE_TYPE GTMDataFromInputStream(NSInputStream *inputStream, NS
       // Simulate download to NSData progress.
       if ((accumulateDataBlock || receivedProgressBlock) && responseData) {
         [self simulateByteTransferWithData:responseData
-                                     block:^(NSData *data,
-                                             int64_t bytesReceived,
+                                     block:^(NSData *data, int64_t bytesReceived,
                                              int64_t totalBytesReceived,
                                              int64_t totalBytesExpectedToReceive) {
-          // This is invoked on the callback queue unless stopped.
-          if (accumulateDataBlock) {
-            accumulateDataBlock(data);
-          }
+                                       // This is invoked on the callback queue unless stopped.
+                                       if (accumulateDataBlock) {
+                                         accumulateDataBlock(data);
+                                       }
 
-          if (receivedProgressBlock) {
-            receivedProgressBlock(bytesReceived, totalBytesReceived);
-          }
-        }];
+                                       if (receivedProgressBlock) {
+                                         receivedProgressBlock(bytesReceived, totalBytesReceived);
+                                       }
+                                     }];
       }
 
       if (!accumulateDataBlock) {
@@ -1213,14 +1258,18 @@ NSData * GTM_NULLABLE_TYPE GTMDataFromInputStream(NSInputStream *inputStream, NS
         // Simulate letting the client inspect and alter the cached response.
         NSData *cachedData = responseData ?: [[NSData alloc] init];  // Always have non-nil data.
         NSCachedURLResponse *cachedResponse =
-            [[NSCachedURLResponse alloc] initWithResponse:response
-                                                     data:cachedData];
+            [[NSCachedURLResponse alloc] initWithResponse:response data:cachedData];
         [self invokeOnCallbackUnsynchronizedQueueAfterUserStopped:YES
                                                             block:^{
-            willCacheURLResponseBlock(cachedResponse, ^(NSCachedURLResponse *responseToCache){
-                // The app may provide an alternative response, or nil to defeat caching.
-            });
-        }];
+                                                              willCacheURLResponseBlock(
+                                                                  cachedResponse,
+                                                                  ^(NSCachedURLResponse
+                                                                        *responseToCache){
+                                                                      // The app may provide an
+                                                                      // alternative response, or
+                                                                      // nil to defeat caching.
+                                                                  });
+                                                            }];
       }
     }
     _response = response;
@@ -1238,8 +1287,8 @@ NSData * GTM_NULLABLE_TYPE GTMDataFromInputStream(NSInputStream *inputStream, NS
                               error:responseError
                    forceAssumeRetry:NO
                            response:^(BOOL shouldRetry) {
-          [self finishWithError:responseError shouldRetry:shouldRetry];
-      }];
+                             [self finishWithError:responseError shouldRetry:shouldRetry];
+                           }];
     }
   }];
 }
@@ -1250,7 +1299,7 @@ NSData * GTM_NULLABLE_TYPE GTMDataFromInputStream(NSInputStream *inputStream, NS
   // "chunkCount" chunks and then passes each chunk along with a progress update to transferBlock.
   // This function can be used with accumulateDataBlock or receivedProgressBlock.
 
-  NSUInteger chunkCount = MAX(self.testBlockAccumulateDataChunkCount, (NSUInteger) 1);
+  NSUInteger chunkCount = MAX(self.testBlockAccumulateDataChunkCount, (NSUInteger)1);
   NSUInteger totalDataLength = responseData.length;
   NSUInteger sendDataSize = totalDataLength / chunkCount + 1;
   NSUInteger totalSent = 0;
@@ -1260,10 +1309,7 @@ NSData * GTM_NULLABLE_TYPE GTMDataFromInputStream(NSInputStream *inputStream, NS
     NSData *chunkData = [responseData subdataWithRange:NSMakeRange(totalSent, sendDataSize)];
     totalSent += sendDataSize;
     [self invokeOnCallbackQueueUnlessStopped:^{
-      transferBlock(chunkData,
-                    (int64_t)sendDataSize,
-                    (int64_t)totalSent,
-                    (int64_t)totalDataLength);
+      transferBlock(chunkData, (int64_t)sendDataSize, (int64_t)totalSent, (int64_t)totalDataLength);
     }];
   }
 }
@@ -1286,7 +1332,7 @@ NSData * GTM_NULLABLE_TYPE GTMDataFromInputStream(NSInputStream *inputStream, NS
   }  // @synchronized(self)
 }
 
-- (NSURLSessionTask * GTM_NULLABLE_TYPE)sessionTask {
+- (NSURLSessionTask *GTM_NULLABLE_TYPE)sessionTask {
   @synchronized(self) {
     GTMSessionMonitorSynchronized(self);
 
@@ -1318,14 +1364,12 @@ NSData * GTM_NULLABLE_TYPE GTMDataFromInputStream(NSInputStream *inputStream, NS
   if ([oldBackgroundSessions containsObject:_sessionIdentifier]) {
     return;
   }
-  NSMutableArray *newBackgroundSessions =
-      [NSMutableArray arrayWithArray:oldBackgroundSessions];
+  NSMutableArray *newBackgroundSessions = [NSMutableArray arrayWithArray:oldBackgroundSessions];
   [newBackgroundSessions addObject:sessionIdentifier];
   GTM_LOG_BACKGROUND_SESSION(@"Add to background sessions: %@", newBackgroundSessions);
 
   NSUserDefaults *userDefaults = [[self class] fetcherUserDefaults];
-  [userDefaults setObject:newBackgroundSessions
-                   forKey:kGTMSessionFetcherPersistedDestinationKey];
+  [userDefaults setObject:newBackgroundSessions forKey:kGTMSessionFetcherPersistedDestinationKey];
   [userDefaults synchronize];
 }
 
@@ -1337,8 +1381,7 @@ NSData * GTM_NULLABLE_TYPE GTMDataFromInputStream(NSInputStream *inputStream, NS
   if (!oldBackgroundSessions) {
     return;
   }
-  NSMutableArray *newBackgroundSessions =
-      [NSMutableArray arrayWithArray:oldBackgroundSessions];
+  NSMutableArray *newBackgroundSessions = [NSMutableArray arrayWithArray:oldBackgroundSessions];
   NSUInteger sessionIndex = [newBackgroundSessions indexOfObject:sessionIdentifier];
   if (sessionIndex == NSNotFound) {
     return;
@@ -1350,8 +1393,7 @@ NSData * GTM_NULLABLE_TYPE GTMDataFromInputStream(NSInputStream *inputStream, NS
   if (newBackgroundSessions.count == 0) {
     [userDefaults removeObjectForKey:kGTMSessionFetcherPersistedDestinationKey];
   } else {
-    [userDefaults setObject:newBackgroundSessions
-                     forKey:kGTMSessionFetcherPersistedDestinationKey];
+    [userDefaults setObject:newBackgroundSessions forKey:kGTMSessionFetcherPersistedDestinationKey];
   }
   [userDefaults synchronize];
 }
@@ -1387,14 +1429,14 @@ NSData * GTM_NULLABLE_TYPE GTMDataFromInputStream(NSInputStream *inputStream, NS
     GTMSessionFetcher *fetcher = [sessionIdentifierToFetcherMap objectForKey:sessionIdentifier];
     if (!fetcher) {
       fetcher = [self fetcherWithSessionIdentifier:sessionIdentifier];
-      GTMSESSION_ASSERT_DEBUG(fetcher != nil,
-                              @"Unexpected invalid session identifier: %@", sessionIdentifier);
+      GTMSESSION_ASSERT_DEBUG(fetcher != nil, @"Unexpected invalid session identifier: %@",
+                              sessionIdentifier);
       if (!fetcher.clientWillReconnectBackgroundSession) {
         [fetcher beginFetchWithCompletionHandler:nil];
       }
     }
-    GTM_LOG_BACKGROUND_SESSION(@"%@ restoring session %@ by creating fetcher %@ %p",
-                               [self class], sessionIdentifier, fetcher, fetcher);
+    GTM_LOG_BACKGROUND_SESSION(@"%@ restoring session %@ by creating fetcher %@ %p", [self class],
+                               sessionIdentifier, fetcher, fetcher);
     if (fetcher != nil) {
       [fetchers addObject:fetcher];
     }
@@ -1405,18 +1447,19 @@ NSData * GTM_NULLABLE_TYPE GTMDataFromInputStream(NSInputStream *inputStream, NS
 #if TARGET_OS_IPHONE && !TARGET_OS_WATCH
 + (void)application:(UIApplication *)application
     handleEventsForBackgroundURLSession:(NSString *)identifier
-                      completionHandler:(GTMSessionFetcherSystemCompletionHandler)completionHandler {
+                      completionHandler:
+                          (GTMSessionFetcherSystemCompletionHandler)completionHandler {
   GTMSessionFetcher *fetcher = [self fetcherWithSessionIdentifier:identifier];
   if (fetcher != nil) {
     fetcher.systemCompletionHandler = completionHandler;
   } else {
-    GTM_LOG_BACKGROUND_SESSION(@"%@ did not create background session identifier: %@",
-                               [self class], identifier);
+    GTM_LOG_BACKGROUND_SESSION(@"%@ did not create background session identifier: %@", [self class],
+                               identifier);
   }
 }
 #endif
 
-- (NSString * GTM_NULLABLE_TYPE)sessionIdentifier {
+- (NSString *GTM_NULLABLE_TYPE)sessionIdentifier {
   @synchronized(self) {
     GTMSessionMonitorSynchronized(self);
 
@@ -1448,7 +1491,7 @@ NSData * GTM_NULLABLE_TYPE GTMDataFromInputStream(NSInputStream *inputStream, NS
   }  // @synchronized(self)
 }
 
-- (NSDictionary * GTM_NULLABLE_TYPE)sessionUserInfo {
+- (NSDictionary *GTM_NULLABLE_TYPE)sessionUserInfo {
   @synchronized(self) {
     GTMSessionMonitorSynchronized(self);
 
@@ -1457,7 +1500,7 @@ NSData * GTM_NULLABLE_TYPE GTMDataFromInputStream(NSInputStream *inputStream, NS
       // re-using the userInfo dictionary later and accidentally including the internal keys.
       NSMutableDictionary *metadata = [[self sessionIdentifierMetadataUnsynchronized] mutableCopy];
       NSSet *keysToRemove = [metadata keysOfEntriesPassingTest:^BOOL(id key, id obj, BOOL *stop) {
-          return [key hasPrefix:@"_"];
+        return [key hasPrefix:@"_"];
       }];
       [metadata removeObjectsForKeys:[keysToRemove allObjects]];
       if (metadata.count > 0) {
@@ -1468,7 +1511,7 @@ NSData * GTM_NULLABLE_TYPE GTMDataFromInputStream(NSInputStream *inputStream, NS
   }  // @synchronized(self)
 }
 
-- (void)setSessionUserInfo:(NSDictionary * GTM_NULLABLE_TYPE)dictionary {
+- (void)setSessionUserInfo:(NSDictionary *GTM_NULLABLE_TYPE)dictionary {
   @synchronized(self) {
     GTMSessionMonitorSynchronized(self);
 
@@ -1516,7 +1559,7 @@ NSData * GTM_NULLABLE_TYPE GTMDataFromInputStream(NSInputStream *inputStream, NS
   }
 }
 
-- (NSDictionary * GTM_NULLABLE_TYPE)sessionIdentifierMetadata {
+- (NSDictionary *GTM_NULLABLE_TYPE)sessionIdentifierMetadata {
   @synchronized(self) {
     GTMSessionMonitorSynchronized(self);
 
@@ -1524,7 +1567,7 @@ NSData * GTM_NULLABLE_TYPE GTMDataFromInputStream(NSInputStream *inputStream, NS
   }
 }
 
-- (NSDictionary * GTM_NULLABLE_TYPE)sessionIdentifierMetadataUnsynchronized {
+- (NSDictionary *GTM_NULLABLE_TYPE)sessionIdentifierMetadataUnsynchronized {
   GTMSessionCheckSynchronized(self);
 
   // Session Identifier format: "com.google.<ClassName>_<UUID>_<Metadata in JSON format>
@@ -1543,18 +1586,18 @@ NSData * GTM_NULLABLE_TYPE GTMDataFromInputStream(NSInputStream *inputStream, NS
     _sessionIdentifierUUID = uuid;
     NSData *metadataData = [metadataString dataUsingEncoding:NSUTF8StringEncoding];
     NSError *error;
-    NSDictionary *metadataDict =
-      [NSJSONSerialization JSONObjectWithData:metadataData
-                                      options:0
-                                        error:&error];
-    GTM_LOG_BACKGROUND_SESSION(@"User Info from session identifier: %@ %@",
-                               metadataDict, error ? error : @"");
+    NSDictionary *metadataDict = [NSJSONSerialization JSONObjectWithData:metadataData
+                                                                 options:0
+                                                                   error:&error];
+    GTM_LOG_BACKGROUND_SESSION(@"User Info from session identifier: %@ %@", metadataDict,
+                               error ? error : @"");
     return metadataDict;
   }
   return nil;
 }
 
-- (NSString *)createSessionIdentifierWithMetadata:(NSDictionary * GTM_NULLABLE_TYPE)metadataToInclude {
+- (NSString *)createSessionIdentifierWithMetadata:
+    (NSDictionary *GTM_NULLABLE_TYPE)metadataToInclude {
   NSString *result;
   @synchronized(self) {
     GTMSessionMonitorSynchronized(self);
@@ -1563,10 +1606,10 @@ NSData * GTM_NULLABLE_TYPE GTMDataFromInputStream(NSInputStream *inputStream, NS
     GTMSESSION_ASSERT_DEBUG(!_sessionIdentifier, @"Session identifier already created");
     _sessionIdentifierUUID = [[NSUUID UUID] UUIDString];
     _sessionIdentifier =
-      [NSString stringWithFormat:@"%@_%@", kGTMSessionIdentifierPrefix, _sessionIdentifierUUID];
+        [NSString stringWithFormat:@"%@_%@", kGTMSessionIdentifierPrefix, _sessionIdentifierUUID];
     // Start with user-supplied keys so they cannot accidentally override the fetcher's keys.
-    NSMutableDictionary *metadataDict =
-        [NSMutableDictionary dictionaryWithDictionary:(NSDictionary * GTM_NONNULL_TYPE)_sessionUserInfo];
+    NSMutableDictionary *metadataDict = [NSMutableDictionary
+        dictionaryWithDictionary:(NSDictionary * GTM_NONNULL_TYPE) _sessionUserInfo];
 
     if (metadataToInclude) {
       [metadataDict addEntriesFromDictionary:(NSDictionary *)metadataToInclude];
@@ -1584,8 +1627,7 @@ NSData * GTM_NULLABLE_TYPE GTMDataFromInputStream(NSInputStream *inputStream, NS
       if (metadataData.length > 0) {
         NSString *metadataString = [[NSString alloc] initWithData:metadataData
                                                          encoding:NSUTF8StringEncoding];
-        _sessionIdentifier =
-          [_sessionIdentifier stringByAppendingFormat:@"_%@", metadataString];
+        _sessionIdentifier = [_sessionIdentifier stringByAppendingFormat:@"_%@", metadataString];
       }
     }
     _didCreateSessionIdentifier = YES;
@@ -1607,8 +1649,7 @@ NSData * GTM_NULLABLE_TYPE GTMDataFromInputStream(NSInputStream *inputStream, NS
                             userInfo:nil];
   }
 
-  [self invokeFetchCallbacksOnCallbackQueueWithData:nil
-                                              error:error];
+  [self invokeFetchCallbacksOnCallbackQueueWithData:nil error:error];
   [self releaseCallbacks];
 
   [_service fetcherDidStop:self];
@@ -1645,7 +1686,7 @@ NSData * GTM_NULLABLE_TYPE GTMDataFromInputStream(NSInputStream *inputStream, NS
   }
 }
 
-#endif // GTM_BACKGROUND_TASK_FETCHING
+#endif  // GTM_BACKGROUND_TASK_FETCHING
 
 - (void)authorizeRequest {
   GTMSessionCheckNotSynchronized(self);
@@ -1655,22 +1696,19 @@ NSData * GTM_NULLABLE_TYPE GTMDataFromInputStream(NSInputStream *inputStream, NS
   if ([authorizer respondsToSelector:asyncAuthSel]) {
     SEL callbackSel = @selector(authorizer:request:finishedWithError:);
     NSMutableURLRequest *mutableRequest = [self.request mutableCopy];
-    [authorizer authorizeRequest:mutableRequest
-                        delegate:self
-               didFinishSelector:callbackSel];
+    [authorizer authorizeRequest:mutableRequest delegate:self didFinishSelector:callbackSel];
   } else {
     GTMSESSION_ASSERT_DEBUG(authorizer == nil, @"invalid authorizer for fetch");
 
     // No authorizing possible, and authorizing happens only after any delay;
     // just begin fetching
-    [self beginFetchMayDelay:NO
-                mayAuthorize:NO];
+    [self beginFetchMayDelay:NO mayAuthorize:NO];
   }
 }
 
 - (void)authorizer:(id<GTMFetcherAuthorizationProtocol>)auth
-           request:(NSMutableURLRequest *)authorizedRequest
- finishedWithError:(NSError *)error {
+              request:(NSMutableURLRequest *)authorizedRequest
+    finishedWithError:(NSError *)error {
   GTMSessionCheckNotSynchronized(self);
 
   if (error != nil) {
@@ -1680,11 +1718,9 @@ NSData * GTM_NULLABLE_TYPE GTMDataFromInputStream(NSInputStream *inputStream, NS
     @synchronized(self) {
       _request = authorizedRequest;
     }
-    [self beginFetchMayDelay:NO
-                mayAuthorize:NO];
+    [self beginFetchMayDelay:NO mayAuthorize:NO];
   }
 }
-
 
 - (BOOL)canFetchWithBackgroundSession {
   // Subclasses may override.
@@ -1710,7 +1746,7 @@ NSData * GTM_NULLABLE_TYPE GTMDataFromInputStream(NSInputStream *inputStream, NS
   return hasBegun && !_hasStoppedFetching;
 }
 
-- (NSURLResponse * GTM_NULLABLE_TYPE)response {
+- (NSURLResponse *GTM_NULLABLE_TYPE)response {
   @synchronized(self) {
     GTMSessionMonitorSynchronized(self);
 
@@ -1719,7 +1755,7 @@ NSData * GTM_NULLABLE_TYPE GTMDataFromInputStream(NSInputStream *inputStream, NS
   }  // @synchronized(self)
 }
 
-- (NSURLResponse * GTM_NULLABLE_TYPE)responseUnsynchronized {
+- (NSURLResponse *GTM_NULLABLE_TYPE)responseUnsynchronized {
   GTMSessionCheckSynchronized(self);
 
   NSURLResponse *response = _sessionTask.response;
@@ -1752,7 +1788,7 @@ NSData * GTM_NULLABLE_TYPE GTMDataFromInputStream(NSInputStream *inputStream, NS
   return statusCode;
 }
 
-- (NSDictionary * GTM_NULLABLE_TYPE)responseHeaders {
+- (NSDictionary *GTM_NULLABLE_TYPE)responseHeaders {
   GTMSessionCheckNotSynchronized(self);
 
   NSURLResponse *response = self.response;
@@ -1763,7 +1799,7 @@ NSData * GTM_NULLABLE_TYPE GTMDataFromInputStream(NSInputStream *inputStream, NS
   return nil;
 }
 
-- (NSDictionary * GTM_NULLABLE_TYPE)responseHeadersUnsynchronized {
+- (NSDictionary *GTM_NULLABLE_TYPE)responseHeadersUnsynchronized {
   GTMSessionCheckSynchronized(self);
 
   NSURLResponse *response = [self responseUnsynchronized];
@@ -1882,8 +1918,8 @@ NSData * GTM_NULLABLE_TYPE GTMDataFromInputStream(NSInputStream *inputStream, NS
       if ([oldTask state] != NSURLSessionTaskStateCompleted) {
         // For download tasks, when the fetch is stopped, we may provide resume data that can
         // be used to create a new session.
-        BOOL mayResume = (_resumeDataBlock
-                          && [oldTask respondsToSelector:@selector(cancelByProducingResumeData:)]);
+        BOOL mayResume = (_resumeDataBlock &&
+                          [oldTask respondsToSelector:@selector(cancelByProducingResumeData:)]);
         if (!mayResume) {
           [oldTask cancel];
           // A side effect of stopping the task is that URLSession:task:didCompleteWithError:
@@ -1896,12 +1932,12 @@ NSData * GTM_NULLABLE_TYPE GTMDataFromInputStream(NSInputStream *inputStream, NS
           dispatch_queue_t callbackQueue = _callbackQueue;
           dispatch_group_enter(_callbackGroup);
           [(NSURLSessionDownloadTask *)oldTask cancelByProducingResumeData:^(NSData *resumeData) {
-              [self invokeOnCallbackQueue:callbackQueue
-                         afterUserStopped:YES
-                                    block:^{
-                  resumeBlock(resumeData);
-                  dispatch_group_leave(self->_callbackGroup);
-              }];
+            [self invokeOnCallbackQueue:callbackQueue
+                       afterUserStopped:YES
+                                  block:^{
+                                    resumeBlock(resumeData);
+                                    dispatch_group_leave(self->_callbackGroup);
+                                  }];
           }];
         }
         hasCanceledTask = YES;
@@ -2010,9 +2046,9 @@ NSData * GTM_NULLABLE_TYPE GTMDataFromInputStream(NSInputStream *inputStream, NS
 
   NSDate *giveUpDate = [NSDate dateWithTimeIntervalSinceNow:timeoutInSeconds];
 
-  BOOL shouldSpinRunLoop = ([NSThread isMainThread] &&
-                            (!self.callbackQueue
-                             || self.callbackQueue == dispatch_get_main_queue()));
+  BOOL shouldSpinRunLoop =
+      ([NSThread isMainThread] &&
+       (!self.callbackQueue || self.callbackQueue == dispatch_get_main_queue()));
   BOOL expired = NO;
 
   // Loop until the callbacks have been called and released, and until
@@ -2020,19 +2056,20 @@ NSData * GTM_NULLABLE_TYPE GTMDataFromInputStream(NSInputStream *inputStream, NS
   // in flight, or until the timeout has expired.
   int64_t delta = (int64_t)(100 * NSEC_PER_MSEC);  // 100 ms
   while (1) {
-    BOOL isTaskInProgress = (holdSelf->_sessionTask
-                             && [_sessionTask state] != NSURLSessionTaskStateCompleted);
+    BOOL isTaskInProgress =
+        (holdSelf->_sessionTask && [_sessionTask state] != NSURLSessionTaskStateCompleted);
     BOOL needsToCallCompletion = (_completionHandler != nil);
-    BOOL isCallbackInProgress = (_callbackGroup
-        && dispatch_group_wait(_callbackGroup, dispatch_time(DISPATCH_TIME_NOW, delta)));
+    BOOL isCallbackInProgress =
+        (_callbackGroup &&
+         dispatch_group_wait(_callbackGroup, dispatch_time(DISPATCH_TIME_NOW, delta)));
 
     if (!isTaskInProgress && !needsToCallCompletion && !isCallbackInProgress) break;
 
     expired = ([giveUpDate timeIntervalSinceNow] < 0);
     if (expired) {
       GTMSESSION_LOG_DEBUG(@"GTMSessionFetcher waitForCompletionWithTimeout:%0.1f expired -- "
-                           @"%@%@%@", timeoutInSeconds,
-                           isTaskInProgress ? @"taskInProgress " : @"",
+                           @"%@%@%@",
+                           timeoutInSeconds, isTaskInProgress ? @"taskInProgress " : @"",
                            needsToCallCompletion ? @"needsToCallCompletion " : @"",
                            isCallbackInProgress ? @"isCallbackInProgress" : @"");
       break;
@@ -2094,7 +2131,7 @@ static GTM_NULLABLE_TYPE id<GTMUIApplicationProtocol> gSubstituteUIApp;
   }
   return app;
 }
-#endif //  GTM_BACKGROUND_TASK_FETCHING
+#endif  //  GTM_BACKGROUND_TASK_FETCHING
 
 #pragma mark NSURLSession Delegate Methods
 
@@ -2104,13 +2141,14 @@ static GTM_NULLABLE_TYPE id<GTMUIApplicationProtocol> gSubstituteUIApp;
 // redirect.
 
 - (void)URLSession:(NSURLSession *)session
-              task:(NSURLSessionTask *)task
-willPerformHTTPRedirection:(NSHTTPURLResponse *)redirectResponse
-        newRequest:(NSURLRequest *)redirectRequest
- completionHandler:(void (^)(NSURLRequest * GTM_NULLABLE_TYPE))handler {
+                          task:(NSURLSessionTask *)task
+    willPerformHTTPRedirection:(NSHTTPURLResponse *)redirectResponse
+                    newRequest:(NSURLRequest *)redirectRequest
+             completionHandler:(void (^)(NSURLRequest *GTM_NULLABLE_TYPE))handler {
   [self setSessionTask:task];
-  GTM_LOG_SESSION_DELEGATE(@"%@ %p URLSession:%@ task:%@ willPerformHTTPRedirection:%@ newRequest:%@",
-                           [self class], self, session, task, redirectResponse, redirectRequest);
+  GTM_LOG_SESSION_DELEGATE(
+      @"%@ %p URLSession:%@ task:%@ willPerformHTTPRedirection:%@ newRequest:%@", [self class],
+      self, session, task, redirectResponse, redirectRequest);
 
   if ([self userStoppedFetching]) {
     handler(nil);
@@ -2134,7 +2172,7 @@ willPerformHTTPRedirection:(NSHTTPURLResponse *)redirectResponse
 
     redirectRequest = newRequest;
 
-      // Log the response we just received
+    // Log the response we just received
     [self setResponse:redirectResponse];
     [self logNowWithError:nil];
 
@@ -2144,14 +2182,16 @@ willPerformHTTPRedirection:(NSHTTPURLResponse *)redirectResponse
         GTMSessionMonitorSynchronized(self);
         [self invokeOnCallbackQueueAfterUserStopped:YES
                                               block:^{
-            willRedirectBlock(redirectResponse, redirectRequest, ^(NSURLRequest *clientRequest) {
+                                                willRedirectBlock(
+                                                    redirectResponse, redirectRequest,
+                                                    ^(NSURLRequest *clientRequest) {
+                                                      // Update the request for future logging.
+                                                      [self updateMutableRequest:[clientRequest
+                                                                                     mutableCopy]];
 
-                // Update the request for future logging.
-                [self updateMutableRequest:[clientRequest mutableCopy]];
-
-                handler(clientRequest);
-            });
-        }];
+                                                      handler(clientRequest);
+                                                    });
+                                              }];
       }  // @synchronized(self)
       return;
     }
@@ -2164,38 +2204,38 @@ willPerformHTTPRedirection:(NSHTTPURLResponse *)redirectResponse
 }
 
 - (void)URLSession:(NSURLSession *)session
-          dataTask:(NSURLSessionDataTask *)dataTask
-didReceiveResponse:(NSURLResponse *)response
- completionHandler:(void (^)(NSURLSessionResponseDisposition disposition))handler {
+              dataTask:(NSURLSessionDataTask *)dataTask
+    didReceiveResponse:(NSURLResponse *)response
+     completionHandler:(void (^)(NSURLSessionResponseDisposition disposition))handler {
   [self setSessionTask:dataTask];
-  GTM_LOG_SESSION_DELEGATE(@"%@ %p URLSession:%@ dataTask:%@ didReceiveResponse:%@",
-                           [self class], self, session, dataTask, response);
+  GTM_LOG_SESSION_DELEGATE(@"%@ %p URLSession:%@ dataTask:%@ didReceiveResponse:%@", [self class],
+                           self, session, dataTask, response);
   void (^accumulateAndFinish)(NSURLSessionResponseDisposition) =
       ^(NSURLSessionResponseDisposition dispositionValue) {
-      // This method is called when the server has determined that it
-      // has enough information to create the NSURLResponse
-      // it can be called multiple times, for example in the case of a
-      // redirect, so each time we reset the data.
-      @synchronized(self) {
-        GTMSessionMonitorSynchronized(self);
+        // This method is called when the server has determined that it
+        // has enough information to create the NSURLResponse
+        // it can be called multiple times, for example in the case of a
+        // redirect, so each time we reset the data.
+        @synchronized(self) {
+          GTMSessionMonitorSynchronized(self);
 
-        BOOL hadPreviousData = self->_downloadedLength > 0;
+          BOOL hadPreviousData = self->_downloadedLength > 0;
 
-        [self->_downloadedData setLength:0];
-        self->_downloadedLength = 0;
+          [self->_downloadedData setLength:0];
+          self->_downloadedLength = 0;
 
-        if (hadPreviousData && (dispositionValue != NSURLSessionResponseCancel)) {
-          // Tell the accumulate block to discard prior data.
-          GTMSessionFetcherAccumulateDataBlock accumulateBlock = self->_accumulateDataBlock;
-          if (accumulateBlock) {
-            [self invokeOnCallbackQueueUnlessStopped:^{
+          if (hadPreviousData && (dispositionValue != NSURLSessionResponseCancel)) {
+            // Tell the accumulate block to discard prior data.
+            GTMSessionFetcherAccumulateDataBlock accumulateBlock = self->_accumulateDataBlock;
+            if (accumulateBlock) {
+              [self invokeOnCallbackQueueUnlessStopped:^{
                 accumulateBlock(nil);
-            }];
+              }];
+            }
           }
-        }
-      }  // @synchronized(self)
-      handler(dispositionValue);
-  };
+        }  // @synchronized(self)
+        handler(dispositionValue);
+      };
 
   GTMSessionFetcherDidReceiveResponseBlock receivedResponseBlock;
   @synchronized(self) {
@@ -2207,10 +2247,12 @@ didReceiveResponse:(NSURLResponse *)response
       // for this delegate method even if the user has stopped the fetcher.
       [self invokeOnCallbackQueueAfterUserStopped:YES
                                             block:^{
-        receivedResponseBlock(response, ^(NSURLSessionResponseDisposition desiredDisposition) {
-          accumulateAndFinish(desiredDisposition);
-        });
-      }];
+                                              receivedResponseBlock(
+                                                  response, ^(NSURLSessionResponseDisposition
+                                                                  desiredDisposition) {
+                                                    accumulateAndFinish(desiredDisposition);
+                                                  });
+                                            }];
     }
   }  // @synchronized(self)
 
@@ -2220,22 +2262,21 @@ didReceiveResponse:(NSURLResponse *)response
 }
 
 - (void)URLSession:(NSURLSession *)session
-          dataTask:(NSURLSessionDataTask *)dataTask
-didBecomeDownloadTask:(NSURLSessionDownloadTask *)downloadTask {
+                 dataTask:(NSURLSessionDataTask *)dataTask
+    didBecomeDownloadTask:(NSURLSessionDownloadTask *)downloadTask {
   GTM_LOG_SESSION_DELEGATE(@"%@ %p URLSession:%@ dataTask:%@ didBecomeDownloadTask:%@",
                            [self class], self, session, dataTask, downloadTask);
   [self setSessionTask:downloadTask];
 }
 
-
 - (void)URLSession:(NSURLSession *)session
-              task:(NSURLSessionTask *)task
-didReceiveChallenge:(NSURLAuthenticationChallenge *)challenge
- completionHandler:(void (^)(NSURLSessionAuthChallengeDisposition disposition,
-                             NSURLCredential * GTM_NULLABLE_TYPE credential))handler {
+                   task:(NSURLSessionTask *)task
+    didReceiveChallenge:(NSURLAuthenticationChallenge *)challenge
+      completionHandler:(void (^)(NSURLSessionAuthChallengeDisposition disposition,
+                                  NSURLCredential *GTM_NULLABLE_TYPE credential))handler {
   [self setSessionTask:task];
-  GTM_LOG_SESSION_DELEGATE(@"%@ %p URLSession:%@ task:%@ didReceiveChallenge:%@",
-                           [self class], self, session, task, challenge);
+  GTM_LOG_SESSION_DELEGATE(@"%@ %p URLSession:%@ task:%@ didReceiveChallenge:%@", [self class],
+                           self, session, task, challenge);
 
   GTMSessionFetcherChallengeBlock challengeBlock = self.challengeBlock;
   if (challengeBlock) {
@@ -2248,19 +2289,18 @@ didReceiveChallenge:(NSURLAuthenticationChallenge *)challenge
 
       [self invokeOnCallbackQueueAfterUserStopped:YES
                                             block:^{
-        challengeBlock(self, challenge, handler);
-      }];
+                                              challengeBlock(self, challenge, handler);
+                                            }];
     }
   } else {
     // No challenge block was provided by the client.
-    [self respondToChallenge:challenge
-           completionHandler:handler];
+    [self respondToChallenge:challenge completionHandler:handler];
   }
 }
 
 - (void)respondToChallenge:(NSURLAuthenticationChallenge *)challenge
          completionHandler:(void (^)(NSURLSessionAuthChallengeDisposition disposition,
-                                     NSURLCredential * GTM_NULLABLE_TYPE credential))handler {
+                                     NSURLCredential *GTM_NULLABLE_TYPE credential))handler {
   @synchronized(self) {
     GTMSessionMonitorSynchronized(self);
 
@@ -2279,12 +2319,13 @@ didReceiveChallenge:(NSURLAuthenticationChallenge *)challenge
           handler(NSURLSessionAuthChallengePerformDefaultHandling, nil);
         } else {
           // Server trust information is available.
-          void (^callback)(SecTrustRef, BOOL) = ^(SecTrustRef trustRef, BOOL allow){
+          void (^callback)(SecTrustRef, BOOL) = ^(SecTrustRef trustRef, BOOL allow) {
             if (allow) {
               NSURLCredential *trustCredential = [NSURLCredential credentialForTrust:trustRef];
               handler(NSURLSessionAuthChallengeUseCredential, trustCredential);
             } else {
-              GTMSESSION_LOG_DEBUG(@"Cancelling authentication challenge for %@", self->_request.URL);
+              GTMSESSION_LOG_DEBUG(@"Cancelling authentication challenge for %@",
+                                   self->_request.URL);
               handler(NSURLSessionAuthChallengeCancelAuthenticationChallenge, nil);
             }
           };
@@ -2354,7 +2395,7 @@ didReceiveChallenge:(NSURLAuthenticationChallenge *)challenge
       (redirectScheme.length != originalScheme.length ||
        [redirectScheme caseInsensitiveCompare:originalScheme] != NSOrderedSame)) {
     NSURLComponents *components =
-        [NSURLComponents componentsWithURL:(NSURL * _Nonnull)redirectRequestURL
+        [NSURLComponents componentsWithURL:(NSURL *_Nonnull)redirectRequestURL
                    resolvingAgainstBaseURL:NO];
     components.scheme = originalScheme;
     return components.URL;
@@ -2390,7 +2431,7 @@ didReceiveChallenge:(NSURLAuthenticationChallenge *)challenge
   // single thread at a time, so we'll stick with using SecTrustEvaluate on a background
   // thread.
   dispatch_queue_t evaluateBackgroundQueue =
-    dispatch_get_global_queue(DISPATCH_QUEUE_PRIORITY_DEFAULT, 0);
+      dispatch_get_global_queue(DISPATCH_QUEUE_PRIORITY_DEFAULT, 0);
   dispatch_async(evaluateBackgroundQueue, ^{
     // It looks like the implementation of SecTrustEvaluate() on Mac grabs a global lock,
     // so it may be redundant for us to also lock, but it's easy to synchronize here
@@ -2398,7 +2439,7 @@ didReceiveChallenge:(NSURLAuthenticationChallenge *)challenge
     BOOL shouldAllow;
 #if GTM_SDK_REQUIRES_SECTRUSTEVALUATEWITHERROR
     CFErrorRef errorRef = NULL;
-    @synchronized ([GTMSessionFetcher class]) {
+    @synchronized([GTMSessionFetcher class]) {
       GTMSessionMonitorSynchronized([GTMSessionFetcher class]);
 
       // SecTrustEvaluateWithError handles both the "proceed" and "unspecified" cases,
@@ -2407,8 +2448,8 @@ didReceiveChallenge:(NSURLAuthenticationChallenge *)challenge
     }
 
     if (errorRef) {
-      GTMSESSION_LOG_DEBUG(@"Error %d evaluating trust for %@",
-                           (int)CFErrorGetCode(errorRef), request);
+      GTMSESSION_LOG_DEBUG(@"Error %d evaluating trust for %@", (int)CFErrorGetCode(errorRef),
+                           request);
       CFRelease(errorRef);
     }
 #else
@@ -2444,24 +2485,19 @@ didReceiveChallenge:(NSURLAuthenticationChallenge *)challenge
 }
 
 - (void)invokeOnCallbackQueueUnlessStopped:(void (^)(void))block {
-  [self invokeOnCallbackQueueAfterUserStopped:NO
-                                        block:block];
+  [self invokeOnCallbackQueueAfterUserStopped:NO block:block];
 }
 
-- (void)invokeOnCallbackQueueAfterUserStopped:(BOOL)afterStopped
-                                        block:(void (^)(void))block {
+- (void)invokeOnCallbackQueueAfterUserStopped:(BOOL)afterStopped block:(void (^)(void))block {
   GTMSessionCheckSynchronized(self);
 
-  [self invokeOnCallbackUnsynchronizedQueueAfterUserStopped:afterStopped
-                                                      block:block];
+  [self invokeOnCallbackUnsynchronizedQueueAfterUserStopped:afterStopped block:block];
 }
 
 - (void)invokeOnCallbackUnsynchronizedQueueAfterUserStopped:(BOOL)afterStopped
                                                       block:(void (^)(void))block {
   // testBlock simulation code may not be synchronizing when this is invoked.
-  [self invokeOnCallbackQueue:_callbackQueue
-             afterUserStopped:afterStopped
-                        block:block];
+  [self invokeOnCallbackQueue:_callbackQueue afterUserStopped:afterStopped block:block];
 }
 
 - (void)invokeOnCallbackQueue:(dispatch_queue_t)callbackQueue
@@ -2469,30 +2505,30 @@ didReceiveChallenge:(NSURLAuthenticationChallenge *)challenge
                         block:(void (^)(void))block {
   if (callbackQueue) {
     dispatch_group_async(_callbackGroup, callbackQueue, ^{
-        if (!afterStopped) {
-          NSDate *serviceStoppedAllDate = [self->_service stoppedAllFetchersDate];
+      if (!afterStopped) {
+        NSDate *serviceStoppedAllDate = [self->_service stoppedAllFetchersDate];
 
-          @synchronized(self) {
-            GTMSessionMonitorSynchronized(self);
+        @synchronized(self) {
+          GTMSessionMonitorSynchronized(self);
 
-            // Avoid a race between stopFetching and the callback.
-            if (self->_userStoppedFetching) {
-              return;
-            }
+          // Avoid a race between stopFetching and the callback.
+          if (self->_userStoppedFetching) {
+            return;
+          }
 
-            // Also avoid calling back if the service has stopped all fetchers
-            // since this one was created. The fetcher may have stopped before
-            // stopAllFetchers was invoked, so _userStoppedFetching wasn't set,
-            // but the app still won't expect the callback to fire after
-            // the service's stopAllFetchers was invoked.
-            if (serviceStoppedAllDate
-                && [self->_initialBeginFetchDate compare:serviceStoppedAllDate] != NSOrderedDescending) {
-              // stopAllFetchers was called after this fetcher began.
-              return;
-            }
-          }  // @synchronized(self)
-        }
-        block();
+          // Also avoid calling back if the service has stopped all fetchers
+          // since this one was created. The fetcher may have stopped before
+          // stopAllFetchers was invoked, so _userStoppedFetching wasn't set,
+          // but the app still won't expect the callback to fire after
+          // the service's stopAllFetchers was invoked.
+          if (serviceStoppedAllDate &&
+              [self->_initialBeginFetchDate compare:serviceStoppedAllDate] != NSOrderedDescending) {
+            // stopAllFetchers was called after this fetcher began.
+            return;
+          }
+        }  // @synchronized(self)
+      }
+      block();
     });
   }
 }
@@ -2553,11 +2589,11 @@ didReceiveChallenge:(NSURLAuthenticationChallenge *)challenge
 }
 
 - (void)URLSession:(NSURLSession *)session
-              task:(NSURLSessionTask *)uploadTask
- needNewBodyStream:(void (^)(NSInputStream * GTM_NULLABLE_TYPE bodyStream))completionHandler {
+                 task:(NSURLSessionTask *)uploadTask
+    needNewBodyStream:(void (^)(NSInputStream *GTM_NULLABLE_TYPE bodyStream))completionHandler {
   [self setSessionTask:uploadTask];
-  GTM_LOG_SESSION_DELEGATE(@"%@ %p URLSession:%@ task:%@ needNewBodyStream:",
-                           [self class], self, session, uploadTask);
+  GTM_LOG_SESSION_DELEGATE(@"%@ %p URLSession:%@ task:%@ needNewBodyStream:", [self class], self,
+                           session, uploadTask);
   @synchronized(self) {
     GTMSessionMonitorSynchronized(self);
 
@@ -2570,7 +2606,7 @@ didReceiveChallenge:(NSURLAuthenticationChallenge *)challenge
 #endif
     if (provider) {
       [self invokeOnCallbackQueueUnlessStopped:^{
-          provider(completionHandler);
+        provider(completionHandler);
       }];
     } else {
       GTMSESSION_ASSERT_DEBUG(NO, @"NSURLSession expects a stream provider");
@@ -2581,10 +2617,10 @@ didReceiveChallenge:(NSURLAuthenticationChallenge *)challenge
 }
 
 - (void)URLSession:(NSURLSession *)session
-              task:(NSURLSessionTask *)task
-   didSendBodyData:(int64_t)bytesSent
-    totalBytesSent:(int64_t)totalBytesSent
-totalBytesExpectedToSend:(int64_t)totalBytesExpectedToSend {
+                        task:(NSURLSessionTask *)task
+             didSendBodyData:(int64_t)bytesSent
+              totalBytesSent:(int64_t)totalBytesSent
+    totalBytesExpectedToSend:(int64_t)totalBytesExpectedToSend {
   [self setSessionTask:task];
   GTM_LOG_SESSION_DELEGATE(@"%@ %p URLSession:%@ task:%@ didSendBodyData:%lld"
                            @" totalBytesSent:%lld totalBytesExpectedToSend:%lld",
@@ -2631,7 +2667,7 @@ totalBytesExpectedToSend:(int64_t)totalBytesExpectedToSend {
       // Let the client accumulate the data.
       _downloadedLength += bufferLength;
       [self invokeOnCallbackQueueUnlessStopped:^{
-          accumulateBlock(data);
+        accumulateBlock(data);
       }];
     } else if (!_userStoppedFetching) {
       // Append to the mutable data buffer unless the fetch has been cancelled.
@@ -2652,15 +2688,15 @@ totalBytesExpectedToSend:(int64_t)totalBytesExpectedToSend {
       // it if the transfer finishes.
       if (_receivedProgressBlock) {
         [self invokeOnCallbackQueueUnlessStopped:^{
-            GTMSessionFetcherReceivedProgressBlock progressBlock;
-            @synchronized(self) {
-              GTMSessionMonitorSynchronized(self);
+          GTMSessionFetcherReceivedProgressBlock progressBlock;
+          @synchronized(self) {
+            GTMSessionMonitorSynchronized(self);
 
-              progressBlock = self->_receivedProgressBlock;
-            }
-            if (progressBlock) {
-              progressBlock((int64_t)bufferLength, self->_downloadedLength);
-            }
+            progressBlock = self->_receivedProgressBlock;
+          }
+          if (progressBlock) {
+            progressBlock((int64_t)bufferLength, self->_downloadedLength);
+          }
         }];
       }
     }
@@ -2668,12 +2704,11 @@ totalBytesExpectedToSend:(int64_t)totalBytesExpectedToSend {
 }
 
 - (void)URLSession:(NSURLSession *)session
-          dataTask:(NSURLSessionDataTask *)dataTask
- willCacheResponse:(NSCachedURLResponse *)proposedResponse
- completionHandler:(void (^)(NSCachedURLResponse *cachedResponse))completionHandler {
-  GTM_LOG_SESSION_DELEGATE(@"%@ %p URLSession:%@ dataTask:%@ willCacheResponse:%@ %@",
-                           [self class], self, session, dataTask,
-                           proposedResponse, proposedResponse.response);
+             dataTask:(NSURLSessionDataTask *)dataTask
+    willCacheResponse:(NSCachedURLResponse *)proposedResponse
+    completionHandler:(void (^)(NSCachedURLResponse *cachedResponse))completionHandler {
+  GTM_LOG_SESSION_DELEGATE(@"%@ %p URLSession:%@ dataTask:%@ willCacheResponse:%@ %@", [self class],
+                           self, session, dataTask, proposedResponse, proposedResponse.response);
   GTMSessionFetcherWillCacheURLResponseBlock callback;
   @synchronized(self) {
     GTMSessionMonitorSynchronized(self);
@@ -2683,8 +2718,8 @@ totalBytesExpectedToSend:(int64_t)totalBytesExpectedToSend {
     if (callback) {
       [self invokeOnCallbackQueueAfterUserStopped:YES
                                             block:^{
-          callback(proposedResponse, completionHandler);
-      }];
+                                              callback(proposedResponse, completionHandler);
+                                            }];
     }
   }  // @synchronized(self)
   if (!callback) {
@@ -2692,12 +2727,11 @@ totalBytesExpectedToSend:(int64_t)totalBytesExpectedToSend {
   }
 }
 
-
 - (void)URLSession:(NSURLSession *)session
-      downloadTask:(NSURLSessionDownloadTask *)downloadTask
-      didWriteData:(int64_t)bytesWritten
- totalBytesWritten:(int64_t)totalBytesWritten
-totalBytesExpectedToWrite:(int64_t)totalBytesExpectedToWrite {
+                 downloadTask:(NSURLSessionDownloadTask *)downloadTask
+                 didWriteData:(int64_t)bytesWritten
+            totalBytesWritten:(int64_t)totalBytesWritten
+    totalBytesExpectedToWrite:(int64_t)totalBytesExpectedToWrite {
   GTM_LOG_SESSION_DELEGATE(@"%@ %p URLSession:%@ downloadTask:%@ didWriteData:%lld"
                            @" bytesWritten:%lld totalBytesExpectedToWrite:%lld",
                            [self class], self, session, downloadTask, bytesWritten,
@@ -2724,9 +2758,9 @@ totalBytesExpectedToWrite:(int64_t)totalBytesExpectedToWrite {
 }
 
 - (void)URLSession:(NSURLSession *)session
-      downloadTask:(NSURLSessionDownloadTask *)downloadTask
- didResumeAtOffset:(int64_t)fileOffset
-expectedTotalBytes:(int64_t)expectedTotalBytes {
+          downloadTask:(NSURLSessionDownloadTask *)downloadTask
+     didResumeAtOffset:(int64_t)fileOffset
+    expectedTotalBytes:(int64_t)expectedTotalBytes {
   GTM_LOG_SESSION_DELEGATE(@"%@ %p URLSession:%@ downloadTask:%@ didResumeAtOffset:%lld"
                            @" expectedTotalBytes:%lld",
                            [self class], self, session, downloadTask, fileOffset,
@@ -2735,16 +2769,14 @@ expectedTotalBytes:(int64_t)expectedTotalBytes {
 }
 
 - (void)URLSession:(NSURLSession *)session
-      downloadTask:(NSURLSessionDownloadTask *)downloadTask
-didFinishDownloadingToURL:(NSURL *)downloadLocationURL {
+                 downloadTask:(NSURLSessionDownloadTask *)downloadTask
+    didFinishDownloadingToURL:(NSURL *)downloadLocationURL {
   // Download may have relaunched app, so update _sessionTask.
   [self setSessionTask:downloadTask];
   GTM_LOG_SESSION_DELEGATE(@"%@ %p URLSession:%@ downloadTask:%@ didFinishDownloadingToURL:%@",
                            [self class], self, session, downloadTask, downloadLocationURL);
   NSNumber *fileSizeNum;
-  [downloadLocationURL getResourceValue:&fileSizeNum
-                                 forKey:NSURLFileSizeKey
-                                  error:NULL];
+  [downloadLocationURL getResourceValue:&fileSizeNum forKey:NSURLFileSizeKey error:NULL];
   @synchronized(self) {
     GTMSessionMonitorSynchronized(self);
 
@@ -2755,8 +2787,8 @@ didFinishDownloadingToURL:(NSURL *)downloadLocationURL {
     // Overwrite any previous file at the destination URL.
     NSFileManager *fileMgr = [NSFileManager defaultManager];
     NSError *removeError;
-    if (![fileMgr removeItemAtURL:destinationURL error:&removeError]
-        && removeError.code != NSFileNoSuchFileError) {
+    if (![fileMgr removeItemAtURL:destinationURL error:&removeError] &&
+        removeError.code != NSFileNoSuchFileError) {
       GTMSESSION_LOG_DEBUG(@"Could not remove previous file at %@ due to %@",
                            downloadLocationURL.path, removeError);
     }
@@ -2767,8 +2799,8 @@ didFinishDownloadingToURL:(NSURL *)downloadLocationURL {
       // status error.  For convenience of the fetcher client, we'll skip saving the
       // downloaded body to the destination URL so that clients do not need to know
       // to delete the file following fetch errors.
-      GTMSESSION_LOG_DEBUG(@"Abandoning download due to status %ld, file %@",
-                           (long)statusCode, downloadLocationURL.path);
+      GTMSESSION_LOG_DEBUG(@"Abandoning download due to status %ld, file %@", (long)statusCode,
+                           downloadLocationURL.path);
 
       // On error code, add the contents of the temporary file to _downloadTaskErrorData
       // This way fetcher clients have access to error details possibly passed by the server.
@@ -2776,16 +2808,17 @@ didFinishDownloadingToURL:(NSURL *)downloadLocationURL {
         _downloadTaskErrorData = [NSData dataWithContentsOfURL:downloadLocationURL];
       } else if (_downloadedLength > kMaximumDownloadErrorDataLength) {
         GTMSESSION_LOG_DEBUG(@"Download error data for file %@ not passed to userInfo due to size "
-                             @"%lld", downloadLocationURL.path, _downloadedLength);
+                             @"%lld",
+                             downloadLocationURL.path, _downloadedLength);
       }
     } else {
       NSError *moveError;
       NSURL *destinationFolderURL = [destinationURL URLByDeletingLastPathComponent];
       BOOL didMoveDownload = NO;
       if ([fileMgr createDirectoryAtURL:destinationFolderURL
-            withIntermediateDirectories:YES
-                             attributes:nil
-                                  error:&moveError]) {
+              withIntermediateDirectories:YES
+                               attributes:nil
+                                    error:&moveError]) {
         didMoveDownload = [fileMgr moveItemAtURL:downloadLocationURL
                                            toURL:destinationURL
                                            error:&moveError];
@@ -2793,9 +2826,8 @@ didFinishDownloadingToURL:(NSURL *)downloadLocationURL {
       if (!didMoveDownload) {
         _downloadFinishedError = moveError;
       }
-      GTM_LOG_BACKGROUND_SESSION(@"%@ %p Moved download from \"%@\" to \"%@\"  %@",
-                                 [self class], self,
-                                 downloadLocationURL.path, destinationURL.path,
+      GTM_LOG_BACKGROUND_SESSION(@"%@ %p Moved download from \"%@\" to \"%@\"  %@", [self class],
+                                 self, downloadLocationURL.path, destinationURL.path,
                                  error ? error : @"");
     }
   }  // @synchronized(self)
@@ -2805,11 +2837,11 @@ didFinishDownloadingToURL:(NSURL *)downloadLocationURL {
  * nil, which implies that no error occurred and this task is complete.
  */
 - (void)URLSession:(NSURLSession *)session
-              task:(NSURLSessionTask *)task
-didCompleteWithError:(NSError *)error {
+                    task:(NSURLSessionTask *)task
+    didCompleteWithError:(NSError *)error {
   [self setSessionTask:task];
-  GTM_LOG_SESSION_DELEGATE(@"%@ %p URLSession:%@ task:%@ didCompleteWithError:%@",
-                           [self class], self, session, task, error);
+  GTM_LOG_SESSION_DELEGATE(@"%@ %p URLSession:%@ task:%@ didCompleteWithError:%@", [self class],
+                           self, session, task, error);
 
   NSInteger status = self.statusCode;
   BOOL forceAssumeRetry = NO;
@@ -2870,8 +2902,8 @@ didCompleteWithError:(NSError *)error {
                           error:error
                forceAssumeRetry:forceAssumeRetry
                        response:^(BOOL shouldRetry) {
-    [self finishWithError:error shouldRetry:shouldRetry];
-  }];
+                         [self finishWithError:error shouldRetry:shouldRetry];
+                       }];
 }
 
 - (void)URLSession:(NSURLSession *)session
@@ -2922,8 +2954,8 @@ didCompleteWithError:(NSError *)error {
 - (void)URLSession:(NSURLSession *)session didBecomeInvalidWithError:(GTM_NULLABLE NSError *)error {
   // This may happen repeatedly for retries.  On authentication callbacks, the retry
   // may begin before the prior session sends the didBecomeInvalid delegate message.
-  GTM_LOG_SESSION_DELEGATE(@"%@ %p URLSession:%@ didBecomeInvalidWithError:%@",
-                           [self class], self, session, error);
+  GTM_LOG_SESSION_DELEGATE(@"%@ %p URLSession:%@ didBecomeInvalidWithError:%@", [self class], self,
+                           session, error);
   if (session == (NSURLSession *)self.session) {
     GTM_LOG_SESSION_DELEGATE(@"  Unexpected retained invalid session: %@", session);
     self.session = nil;
@@ -2964,14 +2996,13 @@ didCompleteWithError:(NSError *)error {
       if ((_downloadedData.length > 0) && (destinationURL != nil)) {
         // Overwrite any previous file at the destination URL.
         NSFileManager *fileMgr = [NSFileManager defaultManager];
-        [fileMgr removeItemAtURL:destinationURL
-                           error:NULL];
+        [fileMgr removeItemAtURL:destinationURL error:NULL];
         NSURL *destinationFolderURL = [destinationURL URLByDeletingLastPathComponent];
         BOOL didMoveDownload = NO;
         if ([fileMgr createDirectoryAtURL:destinationFolderURL
-              withIntermediateDirectories:YES
-                               attributes:nil
-                                    error:&error]) {
+                withIntermediateDirectories:YES
+                                 attributes:nil
+                                      error:&error]) {
           didMoveDownload = [_downloadedData writeToURL:destinationURL
                                                 options:NSDataWritingAtomic
                                                   error:&error];
@@ -3007,9 +3038,10 @@ didCompleteWithError:(NSError *)error {
           if (resumeBlock) {
             NSData *resumeData = [error.userInfo objectForKey:NSURLSessionDownloadTaskResumeData];
             if (resumeData) {
-              [self invokeOnCallbackQueueAfterUserStopped:YES block:^{
-                  resumeBlock(resumeData);
-              }];
+              [self invokeOnCallbackQueueAfterUserStopped:YES
+                                                    block:^{
+                                                      resumeBlock(resumeData);
+                                                    }];
             }
           }
         }
@@ -3049,8 +3081,7 @@ didCompleteWithError:(NSError *)error {
   [self sendStopNotificationIfNeeded];
 
   if (shouldStopFetching) {
-    [self invokeFetchCallbacksOnCallbackQueueWithData:downloadedData
-                                                error:error];
+    [self invokeFetchCallbacksOnCallbackQueueWithData:downloadedData error:error];
     // The upload subclass doesn't want to release callbacks until upload chunks have completed.
     BOOL shouldRelease = [self shouldReleaseCallbacksUponCompletion];
     [self stopFetchReleasingCallbacks:shouldRelease];
@@ -3089,14 +3120,13 @@ didCompleteWithError:(NSError *)error {
   };
 
   struct RetryRecord retries[] = {
-    { kGTMSessionFetcherStatusDomain, 408 }, // request timeout
-    { kGTMSessionFetcherStatusDomain, 502 }, // failure gatewaying to another server
-    { kGTMSessionFetcherStatusDomain, 503 }, // service unavailable
-    { kGTMSessionFetcherStatusDomain, 504 }, // request timeout
-    { NSURLErrorDomain, NSURLErrorTimedOut },
-    { NSURLErrorDomain, NSURLErrorNetworkConnectionLost },
-    { nil, 0 }
-  };
+      {kGTMSessionFetcherStatusDomain, 408},  // request timeout
+      {kGTMSessionFetcherStatusDomain, 502},  // failure gatewaying to another server
+      {kGTMSessionFetcherStatusDomain, 503},  // service unavailable
+      {kGTMSessionFetcherStatusDomain, 504},  // request timeout
+      {NSURLErrorDomain, NSURLErrorTimedOut},
+      {NSURLErrorDomain, NSURLErrorNetworkConnectionLost},
+      {nil, 0}};
 
   // NSError's isEqual always returns false for equal but distinct instances
   // of NSError, so we have to compare the domain and code values explicitly
@@ -3126,9 +3156,8 @@ didCompleteWithError:(NSError *)error {
   // only in this method, and this method is invoked on the serial delegate queue.
   //
   // We want to avoid calling the authorizer from inside a sync block.
-  BOOL isFirstAuthError = (_authorizer != nil
-                           && !_hasAttemptedAuthRefresh
-                           && status == GTMSessionFetcherStatusUnauthorized); // 401
+  BOOL isFirstAuthError = (_authorizer != nil && !_hasAttemptedAuthRefresh &&
+                           status == GTMSessionFetcherStatusUnauthorized);  // 401
 
   BOOL hasPrimed = NO;
   if (isFirstAuthError) {
@@ -3149,7 +3178,6 @@ didCompleteWithError:(NSError *)error {
 
     BOOL shouldDoRetry = [self isRetryEnabledUnsynchronized];
     if (shouldDoRetry && ![self hasRetryAfterInterval]) {
-
       // Determine if we're doing exponential backoff retries
       shouldDoRetry = [self nextRetryIntervalUnsynchronized] < _maxRetryInterval;
 
@@ -3178,16 +3206,14 @@ didCompleteWithError:(NSError *)error {
       if (error == nil) {
         error = statusError;
       }
-      willRetry = shouldRetryForAuthRefresh ||
-                  forceAssumeRetry ||
-                  [self isRetryError:error] ||
+      willRetry = shouldRetryForAuthRefresh || forceAssumeRetry || [self isRetryError:error] ||
                   ((error != statusError) && [self isRetryError:statusError]);
 
       // If the user has installed a retry callback, consult that.
       GTMSessionFetcherRetryBlock retryBlock = _retryBlock;
       if (retryBlock) {
         [self invokeOnCallbackQueueUnlessStopped:^{
-            retryBlock(willRetry, error, response);
+          retryBlock(willRetry, error, response);
         }];
         return;
       }
@@ -3219,8 +3245,8 @@ didCompleteWithError:(NSError *)error {
   rfc1123DateFormatter.timeZone = [NSTimeZone timeZoneWithAbbreviation:@"GMT"];
   rfc1123DateFormatter.dateFormat = @"EEE',' dd MMM yyyy HH':'mm':'ss z";
   NSDate *retryAfterDate = [rfc1123DateFormatter dateFromString:retryAfterValue];
-  NSTimeInterval retryAfterInterval = (retryAfterDate != nil) ?
-      retryAfterDate.timeIntervalSinceNow : retryAfterValue.intValue;
+  NSTimeInterval retryAfterInterval =
+      (retryAfterDate != nil) ? retryAfterDate.timeIntervalSinceNow : retryAfterValue.intValue;
   retryAfterInterval = MAX(0, retryAfterInterval);
   return retryAfterInterval;
 }
@@ -3230,13 +3256,13 @@ didCompleteWithError:(NSError *)error {
     // Defer creating and starting the timer until we're on the main thread to ensure it has
     // a run loop.
     dispatch_group_async(_callbackGroup, dispatch_get_main_queue(), ^{
-        [self beginRetryTimer];
+      [self beginRetryTimer];
     });
     return;
   }
 
   [self destroyRetryTimer];
-  
+
 #if GTM_BACKGROUND_TASK_FETCHING
   // Don't keep a background task active while awaiting retry, which can lead to the
   // app exceeding the allotted time for keeping the background task open, causing the
@@ -3261,8 +3287,7 @@ didCompleteWithError:(NSError *)error {
                                         userInfo:nil
                                          repeats:NO];
     _retryTimer.tolerance = newIntervalTolerance;
-    [[NSRunLoop mainRunLoop] addTimer:_retryTimer
-                              forMode:NSDefaultRunLoopMode];
+    [[NSRunLoop mainRunLoop] addTimer:_retryTimer forMode:NSDefaultRunLoopMode];
   }  // @synchronized(self)
 
   [self postNotificationOnMainThreadWithName:kGTMSessionFetcherRetryDelayStartedNotification
@@ -3364,7 +3389,6 @@ didCompleteWithError:(NSError *)error {
 }
 
 - (void)setRetryEnabled:(BOOL)flag {
-
   @synchronized(self) {
     GTMSessionMonitorSynchronized(self);
 
@@ -3425,7 +3449,6 @@ didCompleteWithError:(NSError *)error {
       _minRetryInterval = InitialMinRetryInterval();
     }
   }  // @synchronized(self)
-
 }
 
 #pragma mark iOS System Completion Handlers
@@ -3437,12 +3460,14 @@ static NSMutableDictionary *gSystemCompletionHandlers = nil;
   return [[self class] systemCompletionHandlerForSessionIdentifier:_sessionIdentifier];
 }
 
-- (void)setSystemCompletionHandler:(GTM_NULLABLE GTMSessionFetcherSystemCompletionHandler)systemCompletionHandler {
+- (void)setSystemCompletionHandler:
+    (GTM_NULLABLE GTMSessionFetcherSystemCompletionHandler)systemCompletionHandler {
   [[self class] setSystemCompletionHandler:systemCompletionHandler
                       forSessionIdentifier:_sessionIdentifier];
 }
 
-+ (void)setSystemCompletionHandler:(GTM_NULLABLE GTMSessionFetcherSystemCompletionHandler)systemCompletionHandler
++ (void)setSystemCompletionHandler:
+            (GTM_NULLABLE GTMSessionFetcherSystemCompletionHandler)systemCompletionHandler
               forSessionIdentifier:(NSString *)sessionIdentifier {
   if (!sessionIdentifier) {
     NSLog(@"%s with nil identifier", __PRETTY_FUNCTION__);
@@ -3454,12 +3479,12 @@ static NSMutableDictionary *gSystemCompletionHandlers = nil;
       gSystemCompletionHandlers = [[NSMutableDictionary alloc] init];
     }
     // Use setValue: to remove the object if completionHandler is nil.
-    [gSystemCompletionHandlers setValue:systemCompletionHandler
-                                 forKey:sessionIdentifier];
+    [gSystemCompletionHandlers setValue:systemCompletionHandler forKey:sessionIdentifier];
   }
 }
 
-+ (GTM_NULLABLE GTMSessionFetcherSystemCompletionHandler)systemCompletionHandlerForSessionIdentifier:(NSString *)sessionIdentifier {
++ (GTM_NULLABLE GTMSessionFetcherSystemCompletionHandler)
+    systemCompletionHandlerForSessionIdentifier:(NSString *)sessionIdentifier {
   if (!sessionIdentifier) {
     return nil;
   }
@@ -3471,52 +3496,33 @@ static NSMutableDictionary *gSystemCompletionHandlers = nil;
 
 #pragma mark Getters and Setters
 
-@synthesize downloadResumeData = _downloadResumeData,
-            configuration = _configuration,
-            configurationBlock = _configurationBlock,
-            sessionTask = _sessionTask,
+@synthesize downloadResumeData = _downloadResumeData, configuration = _configuration,
+            configurationBlock = _configurationBlock, sessionTask = _sessionTask,
             wasCreatedFromBackgroundSession = _wasCreatedFromBackgroundSession,
             clientWillReconnectBackgroundSession = _clientWillReconnectBackgroundSession,
-            sessionUserInfo = _sessionUserInfo,
-            taskDescription = _taskDescription,
-            taskPriority = _taskPriority,
-            usingBackgroundSession = _usingBackgroundSession,
-            canShareSession = _canShareSession,
-            completionHandler = _completionHandler,
-            credential = _credential,
-            proxyCredential = _proxyCredential,
-            bodyData = _bodyData,
-            bodyLength = _bodyLength,
-            service = _service,
-            serviceHost = _serviceHost,
+            sessionUserInfo = _sessionUserInfo, taskDescription = _taskDescription,
+            taskPriority = _taskPriority, usingBackgroundSession = _usingBackgroundSession,
+            canShareSession = _canShareSession, completionHandler = _completionHandler,
+            credential = _credential, proxyCredential = _proxyCredential, bodyData = _bodyData,
+            bodyLength = _bodyLength, service = _service, serviceHost = _serviceHost,
             accumulateDataBlock = _accumulateDataBlock,
             receivedProgressBlock = _receivedProgressBlock,
-            downloadProgressBlock = _downloadProgressBlock,
-            resumeDataBlock = _resumeDataBlock,
-            didReceiveResponseBlock = _didReceiveResponseBlock,
-            challengeBlock = _challengeBlock,
-            willRedirectBlock = _willRedirectBlock,
-            sendProgressBlock = _sendProgressBlock,
-            willCacheURLResponseBlock = _willCacheURLResponseBlock,
-            retryBlock = _retryBlock,
-            metricsCollectionBlock = _metricsCollectionBlock,
-            retryFactor = _retryFactor,
+            downloadProgressBlock = _downloadProgressBlock, resumeDataBlock = _resumeDataBlock,
+            didReceiveResponseBlock = _didReceiveResponseBlock, challengeBlock = _challengeBlock,
+            willRedirectBlock = _willRedirectBlock, sendProgressBlock = _sendProgressBlock,
+            willCacheURLResponseBlock = _willCacheURLResponseBlock, retryBlock = _retryBlock,
+            metricsCollectionBlock = _metricsCollectionBlock, retryFactor = _retryFactor,
             allowedInsecureSchemes = _allowedInsecureSchemes,
             allowLocalhostRequest = _allowLocalhostRequest,
             allowInvalidServerCertificates = _allowInvalidServerCertificates,
-            cookieStorage = _cookieStorage,
-            callbackQueue = _callbackQueue,
-            initialBeginFetchDate = _initialBeginFetchDate,
-            testBlock = _testBlock,
+            cookieStorage = _cookieStorage, callbackQueue = _callbackQueue,
+            initialBeginFetchDate = _initialBeginFetchDate, testBlock = _testBlock,
             testBlockAccumulateDataChunkCount = _testBlockAccumulateDataChunkCount,
-            comment = _comment,
-            log = _log;
+            comment = _comment, log = _log;
 
 #if !STRIP_GTM_FETCH_LOGGING
-@synthesize redirectedFromURL = _redirectedFromURL,
-            logRequestBody = _logRequestBody,
-            logResponseBody = _logResponseBody,
-            hasLoggedError = _hasLoggedError;
+@synthesize redirectedFromURL = _redirectedFromURL, logRequestBody = _logRequestBody,
+            logResponseBody = _logResponseBody, hasLoggedError = _hasLoggedError;
 #endif
 
 #if GTM_BACKGROUND_TASK_FETCHING
@@ -3682,7 +3688,8 @@ static NSMutableDictionary *gSystemCompletionHandlers = nil;
 
     if (authorizer != _authorizer) {
       if ([self isFetchingUnsynchronized]) {
-        GTMSESSION_ASSERT_DEBUG(0, @"authorizer should not change after beginFetch has been invoked");
+        GTMSESSION_ASSERT_DEBUG(0,
+                                @"authorizer should not change after beginFetch has been invoked");
       } else {
         _authorizer = authorizer;
       }
@@ -3759,14 +3766,14 @@ static NSMutableDictionary *gSystemCompletionHandlers = nil;
     GTMSessionMonitorSynchronized(self);
 
     if (value != _servicePriority) {
-      GTMSESSION_ASSERT_DEBUG(![self isFetchingUnsynchronized],
-        @"servicePriority should not change after beginFetch has been invoked");
+      GTMSESSION_ASSERT_DEBUG(
+          ![self isFetchingUnsynchronized],
+          @"servicePriority should not change after beginFetch has been invoked");
 
       _servicePriority = value;
     }
   }  // @synchronized(self)
 }
-
 
 - (void)setSession:(GTM_NULLABLE NSURLSession *)session {
   @synchronized(self) {
@@ -3807,7 +3814,8 @@ static NSMutableDictionary *gSystemCompletionHandlers = nil;
     GTMSessionMonitorSynchronized(self);
 
     if (flag != _userRequestedBackgroundSession) {
-      GTMSESSION_ASSERT_DEBUG(![self isFetchingUnsynchronized],
+      GTMSESSION_ASSERT_DEBUG(
+          ![self isFetchingUnsynchronized],
           @"useBackgroundSession should not change after beginFetch has been invoked");
 
       _userRequestedBackgroundSession = flag;
@@ -3847,7 +3855,7 @@ static NSMutableDictionary *gSystemCompletionHandlers = nil;
   }  // @synchronized(self)
 }
 
-- (NSOperationQueue * GTM_NONNULL_TYPE)sessionDelegateQueue {
+- (NSOperationQueue *GTM_NONNULL_TYPE)sessionDelegateQueue {
   @synchronized(self) {
     GTMSessionMonitorSynchronized(self);
 
@@ -3855,7 +3863,7 @@ static NSMutableDictionary *gSystemCompletionHandlers = nil;
   }  // @synchronized(self)
 }
 
-- (void)setSessionDelegateQueue:(NSOperationQueue * GTM_NULLABLE_TYPE)queue {
+- (void)setSessionDelegateQueue:(NSOperationQueue *GTM_NULLABLE_TYPE)queue {
   @synchronized(self) {
     GTMSessionMonitorSynchronized(self);
 
@@ -3921,9 +3929,10 @@ static NSMutableDictionary *gSystemCompletionHandlers = nil;
       // URL is expected to happen only across development runs through Xcode.
       NSString *oldFilename = [_destinationFileURL lastPathComponent];
       NSString *newFilename = [destinationFileURL lastPathComponent];
-      #pragma unused(oldFilename)
-      #pragma unused(newFilename)
-      GTMSESSION_ASSERT_DEBUG([oldFilename isEqualToString:newFilename],
+#pragma unused(oldFilename)
+#pragma unused(newFilename)
+      GTMSESSION_ASSERT_DEBUG(
+          [oldFilename isEqualToString:newFilename],
           @"Destination File URL cannot be changed after session identifier has been created");
 #endif
     }
@@ -3985,8 +3994,7 @@ static NSMutableDictionary *gSystemCompletionHandlers = nil;
     va_list argList;
     va_start(argList, format);
 
-    result = [[NSString alloc] initWithFormat:format
-                                    arguments:argList];
+    result = [[NSString alloc] initWithFormat:format arguments:argList];
     va_end(argList);
   }
   [self setComment:result];
@@ -4039,7 +4047,7 @@ static NSMutableDictionary *gSystemCompletionHandlers = nil;
 + (BOOL)isLoggingEnabled {
   return NO;
 }
-#endif // STRIP_GTM_FETCH_LOGGING
+#endif  // STRIP_GTM_FETCH_LOGGING
 
 @end
 
@@ -4051,7 +4059,7 @@ static NSMutableDictionary *gSystemCompletionHandlers = nil;
   // Clients using the GTMSessionFetcher class should set the cookie storage explicitly
   // themselves.
   NSHTTPCookieStorage *storage = nil;
-  switch(method) {
+  switch (method) {
     case 0:  // kGTMHTTPFetcherCookieStorageMethodStatic
              // nil storage will use [[self class] staticCookieStorage] when the fetch begins.
       break;
@@ -4111,9 +4119,8 @@ static NSMutableDictionary *gSystemCompletionHandlers = nil;
 
   if (_policy == NSHTTPCookieAcceptPolicyNever) return;
 
-  BOOL isValidCookie = (newCookie.name.length > 0
-                        && newCookie.domain.length > 0
-                        && newCookie.path.length > 0);
+  BOOL isValidCookie =
+      (newCookie.name.length > 0 && newCookie.domain.length > 0 && newCookie.path.length > 0);
   GTMSESSION_ASSERT_DEBUG(isValidCookie, @"invalid cookie: %@", newCookie);
 
   if (isValidCookie) {
@@ -4145,7 +4152,9 @@ static NSMutableDictionary *gSystemCompletionHandlers = nil;
   }  // @synchronized(self)
 }
 
-- (void)setCookies:(NSArray *)cookies forURL:(GTM_NULLABLE NSURL *)URL mainDocumentURL:(GTM_NULLABLE NSURL *)mainDocumentURL {
+- (void)setCookies:(NSArray *)cookies
+             forURL:(GTM_NULLABLE NSURL *)URL
+    mainDocumentURL:(GTM_NULLABLE NSURL *)mainDocumentURL {
   @synchronized(self) {
     GTMSessionMonitorSynchronized(self);
 
@@ -4216,8 +4225,7 @@ static NSMutableDictionary *gSystemCompletionHandlers = nil;
       if (isLocalhostRetrieval) {
         // Prior to 10.5.6, the domain stored into NSHTTPCookies for localhost
         // is "localhost.local"
-        isDomainOK = (IsLocalhost(cookieDomain)
-                      || [cookieDomain isEqual:@"localhost.local"]);
+        isDomainOK = (IsLocalhost(cookieDomain) || [cookieDomain isEqual:@"localhost.local"]);
       } else {
         // Ensure we're matching exact domain names. We prepended a dot to the
         // requesting domain, so we can also prepend one here if needed before
@@ -4229,8 +4237,8 @@ static NSMutableDictionary *gSystemCompletionHandlers = nil;
       }
 
       BOOL isPathOK = [cookiePath isEqual:@"/"] || [path hasPrefix:cookiePath];
-      BOOL isSecureOK = (!cookieIsSecure
-                         || [scheme caseInsensitiveCompare:@"https"] == NSOrderedSame);
+      BOOL isSecureOK =
+          (!cookieIsSecure || [scheme caseInsensitiveCompare:@"https"] == NSOrderedSame);
 
       if (isDomainOK && isPathOK && isSecureOK) {
         if (foundCookies == nil) {
@@ -4277,9 +4285,8 @@ static NSMutableDictionary *gSystemCompletionHandlers = nil;
                           @"Invalid stored cookie (name:%@ domain:%@ path:%@)", name, domain, path);
 
   for (NSHTTPCookie *storedCookie in _cookies) {
-    if ([storedCookie.name isEqual:name]
-        && [storedCookie.domain isEqual:domain]
-        && [storedCookie.path isEqual:path]) {
+    if ([storedCookie.name isEqual:name] && [storedCookie.domain isEqual:domain] &&
+        [storedCookie.path isEqual:path]) {
       return storedCookie;
     }
   }
@@ -4341,7 +4348,8 @@ static NSMutableDictionary *gSystemCompletionHandlers = nil;
 
 @end
 
-void GTMSessionFetcherAssertValidSelector(id GTM_NULLABLE_TYPE obj, SEL GTM_NULLABLE_TYPE sel, ...) {
+void GTMSessionFetcherAssertValidSelector(id GTM_NULLABLE_TYPE obj, SEL GTM_NULLABLE_TYPE sel,
+                                          ...) {
   // Verify that the object's selector is implemented with the proper
   // number and type of arguments
 #if DEBUG
@@ -4352,24 +4360,22 @@ void GTMSessionFetcherAssertValidSelector(id GTM_NULLABLE_TYPE obj, SEL GTM_NULL
     // Check that the selector is implemented
     if (![obj respondsToSelector:sel]) {
       NSLog(@"\"%@\" selector \"%@\" is unimplemented or misnamed",
-                             NSStringFromClass([(id)obj class]),
-                             NSStringFromSelector((SEL)sel));
+            NSStringFromClass([(id)obj class]), NSStringFromSelector((SEL)sel));
       NSCAssert(0, @"callback selector unimplemented or misnamed");
     } else {
       const char *expectedArgType;
-      unsigned int argCount = 2; // skip self and _cmd
+      unsigned int argCount = 2;  // skip self and _cmd
       NSMethodSignature *sig = [obj methodSignatureForSelector:sel];
 
       // Check that each expected argument is present and of the correct type
-      while ((expectedArgType = va_arg(argList, const char*)) != 0) {
-
+      while ((expectedArgType = va_arg(argList, const char *)) != 0) {
         if ([sig numberOfArguments] > argCount) {
           const char *foundArgType = [sig getArgumentTypeAtIndex:argCount];
 
           if (0 != strncmp(foundArgType, expectedArgType, strlen(expectedArgType))) {
             NSLog(@"\"%@\" selector \"%@\" argument %d should be type %s",
-                  NSStringFromClass([(id)obj class]),
-                  NSStringFromSelector((SEL)sel), (argCount - 2), expectedArgType);
+                  NSStringFromClass([(id)obj class]), NSStringFromSelector((SEL)sel),
+                  (argCount - 2), expectedArgType);
             NSCAssert(0, @"callback selector argument type mistake");
           }
         }
@@ -4379,8 +4385,7 @@ void GTMSessionFetcherAssertValidSelector(id GTM_NULLABLE_TYPE obj, SEL GTM_NULL
       // Check that the proper number of arguments are present in the selector
       if (argCount != [sig numberOfArguments]) {
         NSLog(@"\"%@\" selector \"%@\" should have %d arguments",
-              NSStringFromClass([(id)obj class]),
-              NSStringFromSelector((SEL)sel), (argCount - 2));
+              NSStringFromClass([(id)obj class]), NSStringFromSelector((SEL)sel), (argCount - 2));
         NSCAssert(0, @"callback selector arguments incorrect");
       }
     }
@@ -4417,7 +4422,7 @@ NSString *GTMFetcherCleanedUserAgentString(NSString *str) {
     NSMutableCharacterSet *mutableChars =
         [[NSCharacterSet whitespaceAndNewlineCharacterSet] mutableCopy];
     [mutableChars addCharactersInString:kSeparators];
-    charsToDelete = [mutableChars copy]; // hang on to an immutable copy
+    charsToDelete = [mutableChars copy];  // hang on to an immutable copy
   }
 
   while (1) {
@@ -4435,17 +4440,17 @@ NSString *GTMFetcherSystemVersionString(void) {
 
   static dispatch_once_t onceToken;
   dispatch_once(&onceToken, ^{
-    // The Xcode 8 SDKs finally cleaned up this mess by providing TARGET_OS_OSX
-    // and TARGET_OS_IOS, but to build with older SDKs, those don't exist and
-    // instead one has to rely on TARGET_OS_MAC (which is true for iOS, watchOS,
-    // and tvOS) and TARGET_OS_IPHONE (which is true for iOS, watchOS, tvOS). So
-    // one has to order these carefully so you pick off the specific things
-    // first.
-    // If the code can ever assume Xcode 8 or higher (even when building for
-    // older OSes), then
-    //   TARGET_OS_MAC -> TARGET_OS_OSX
-    //   TARGET_OS_IPHONE -> TARGET_OS_IOS
-    //   TARGET_IPHONE_SIMULATOR -> TARGET_OS_SIMULATOR
+  // The Xcode 8 SDKs finally cleaned up this mess by providing TARGET_OS_OSX
+  // and TARGET_OS_IOS, but to build with older SDKs, those don't exist and
+  // instead one has to rely on TARGET_OS_MAC (which is true for iOS, watchOS,
+  // and tvOS) and TARGET_OS_IPHONE (which is true for iOS, watchOS, tvOS). So
+  // one has to order these carefully so you pick off the specific things
+  // first.
+  // If the code can ever assume Xcode 8 or higher (even when building for
+  // older OSes), then
+  //   TARGET_OS_MAC -> TARGET_OS_OSX
+  //   TARGET_OS_IPHONE -> TARGET_OS_IOS
+  //   TARGET_IPHONE_SIMULATOR -> TARGET_OS_SIMULATOR
 #if TARGET_OS_WATCH
     // watchOS - WKInterfaceDevice
 
@@ -4470,8 +4475,8 @@ NSString *GTMFetcherSystemVersionString(void) {
     }
 #endif
 
-    sSavedSystemString = [[NSString alloc] initWithFormat:@"%@/%@ hw/%@",
-                          model, systemVersion, hardwareModel];
+    sSavedSystemString =
+        [[NSString alloc] initWithFormat:@"%@/%@ hw/%@", model, systemVersion, hardwareModel];
     // Example:  Apple_Watch/3.0 hw/Watch1_2
 #elif TARGET_OS_TV || TARGET_OS_IPHONE
     // iOS and tvOS have UIDevice, use that.
@@ -4553,14 +4558,13 @@ NSString *GTMFetcherSystemVersionString(void) {
   return sSavedSystemString;
 }
 
-NSString *GTMFetcherStandardUserAgentString(NSBundle * GTM_NULLABLE_TYPE bundle) {
-  NSString *result = [NSString stringWithFormat:@"%@ %@",
-                      GTMFetcherApplicationIdentifier(bundle),
-                      GTMFetcherSystemVersionString()];
+NSString *GTMFetcherStandardUserAgentString(NSBundle *GTM_NULLABLE_TYPE bundle) {
+  NSString *result = [NSString stringWithFormat:@"%@ %@", GTMFetcherApplicationIdentifier(bundle),
+                                                GTMFetcherSystemVersionString()];
   return result;
 }
 
-NSString *GTMFetcherApplicationIdentifier(NSBundle * GTM_NULLABLE_TYPE bundle) {
+NSString *GTMFetcherApplicationIdentifier(NSBundle *GTM_NULLABLE_TYPE bundle) {
   @synchronized([GTMSessionFetcher class]) {
     static NSMutableDictionary *sAppIDMap = nil;
 
@@ -4655,7 +4659,7 @@ NSString *GTMFetcherApplicationIdentifier(NSBundle * GTM_NULLABLE_TYPE bundle) {
       functionNamesCounter = [NSCountedSet set];
       counters[_objectKey] = functionNamesCounter;
     }
-    [functionNamesCounter addObject:(id _Nonnull)@(functionName)];
+    [functionNamesCounter addObject:(id _Nonnull) @(functionName)];
   }
   return self;
 }
@@ -4678,7 +4682,7 @@ NSString *GTMFetcherApplicationIdentifier(NSBundle * GTM_NULLABLE_TYPE bundle) {
   }
 }
 
-+ (NSArray * GTM_NULLABLE_TYPE)functionsHoldingSynchronizationOnObject:(id)object {
++ (NSArray *GTM_NULLABLE_TYPE)functionsHoldingSynchronizationOnObject:(id)object {
   Class threadKey = [GTMSessionSyncMonitorInternal class];
   NSValue *localObjectKey = [NSValue valueWithNonretainedObject:object];
 

--- a/Source/GTMSessionFetcherIOS/GTMSessionFetcherIOS.h
+++ b/Source/GTMSessionFetcherIOS/GTMSessionFetcherIOS.h
@@ -2,13 +2,10 @@
 //  GTMSessionFetcherIOS.h
 //
 
-#import "GTMSessionFetcher.h"
-#import "GTMSessionFetcherService.h"
-#import "GTMSessionUploadFetcher.h"
-#import "GTMSessionFetcherService.h"
-#import "GTMSessionFetcherLogging.h"
 #import "GTMGatherInputStream.h"
 #import "GTMMIMEDocument.h"
 #import "GTMReadMonitorInputStream.h"
-
-
+#import "GTMSessionFetcher.h"
+#import "GTMSessionFetcherLogging.h"
+#import "GTMSessionFetcherService.h"
+#import "GTMSessionUploadFetcher.h"

--- a/Source/GTMSessionFetcherLogViewController.h
+++ b/Source/GTMSessionFetcherLogViewController.h
@@ -63,8 +63,7 @@
 //   - (void)logsDone:(UINavigationController *)navController
 //
 // The target and selector may be nil.
-+ (UINavigationController *)controllerWithTarget:(id)target
-                                        selector:(SEL)selector;
++ (UINavigationController *)controllerWithTarget:(id)target selector:(SEL)selector;
 @end
 
 #endif  // !STRIP_GTM_FETCH_LOGGING && !STRIP_GTM_SESSIONLOGVIEWCONTROLLER

--- a/Source/GTMSessionFetcherLogViewController.m
+++ b/Source/GTMSessionFetcherLogViewController.m
@@ -29,21 +29,21 @@
 #import "GTMSessionFetcherLogging.h"
 
 #ifndef STRIP_GTM_FETCH_LOGGING
-  #error GTMSessionFetcher headers should have defaulted this if it wasn't already defined.
+#error GTMSessionFetcher headers should have defaulted this if it wasn't already defined.
 #endif
 
 #if !STRIP_GTM_FETCH_LOGGING && !STRIP_GTM_SESSIONLOGVIEWCONTROLLER
 
 #if ((TARGET_OS_IOS && __IPHONE_OS_VERSION_MIN_REQUIRED >= __IPHONE_10_0) || \
      (TARGET_OS_OSX && __MAC_OS_X_VERSION_MIN_REQUIRED >= __MAC_10_12))
-  // For apps targetting recent only versions of iOS/Mac, use WKWebView rather
-  // than UIWebView/NSWebView.
-  #define GTM_USE_WKWEBVIEW 1
-  #import <WebKit/WebKit.h>
-  typedef WKWebView GTMWebView;
+// For apps targetting recent only versions of iOS/Mac, use WKWebView rather
+// than UIWebView/NSWebView.
+#define GTM_USE_WKWEBVIEW 1
+#import <WebKit/WebKit.h>
+typedef WKWebView GTMWebView;
 #else
-  #define GTM_USE_WKWEBVIEW 0
-  typedef UIWebView GTMWebView;
+#define GTM_USE_WKWEBVIEW 0
+typedef UIWebView GTMWebView;
 #endif
 
 static NSString *const kHTTPLogsCell = @"kGTMHTTPLogsCell";
@@ -65,7 +65,7 @@ static NSString *const kHTTPLogsCell = @"kGTMHTTPLogsCell";
 #pragma mark - Table View Controller
 
 @interface GTMSessionFetcherLogViewController ()
-@property (nonatomic, copy) void (^callbackBlock)(void);
+@property(nonatomic, copy) void (^callbackBlock)(void);
 @end
 
 @implementation GTMSessionFetcherLogViewController {
@@ -87,26 +87,23 @@ static NSString *const kHTTPLogsCell = @"kGTMHTTPLogsCell";
     NSString *processName = [GTMSessionFetcher loggingProcessName];
 
     NSURL *logsURL = [NSURL fileURLWithPath:logsFolderPath];
-    NSMutableArray *mutableURLs =
-        [[fm contentsOfDirectoryAtURL:logsURL
-           includingPropertiesForKeys:@[ NSURLCreationDateKey ]
-                              options:0
-                                error:&error] mutableCopy];
+    NSMutableArray *mutableURLs = [[fm contentsOfDirectoryAtURL:logsURL
+                                     includingPropertiesForKeys:@[ NSURLCreationDateKey ]
+                                                        options:0
+                                                          error:&error] mutableCopy];
 
     // Remove non-log files that lack the process name prefix,
     // and remove the "newest" symlink.
     NSString *symlinkSuffix = [GTMSessionFetcher symlinkNameSuffix];
-    NSIndexSet *nonLogIndexes = [mutableURLs indexesOfObjectsPassingTest:
-        ^BOOL(id obj, NSUInteger idx, BOOL *stop) {
-      NSString *name = [obj lastPathComponent];
-         return (![name hasPrefix:processName]
-                 || [name hasSuffix:symlinkSuffix]);
-    }];
+    NSIndexSet *nonLogIndexes =
+        [mutableURLs indexesOfObjectsPassingTest:^BOOL(id obj, NSUInteger idx, BOOL *stop) {
+          NSString *name = [obj lastPathComponent];
+          return (![name hasPrefix:processName] || [name hasSuffix:symlinkSuffix]);
+        }];
     [mutableURLs removeObjectsAtIndexes:nonLogIndexes];
 
     // Sort to put the newest logs at the top of the list.
-    [mutableURLs sortUsingComparator:^NSComparisonResult(NSURL *url1,
-                                                         NSURL *url2) {
+    [mutableURLs sortUsingComparator:^NSComparisonResult(NSURL *url1, NSURL *url2) {
       NSDate *date1, *date2;
       [url1 getResourceValue:&date1 forKey:NSURLCreationDateKey error:NULL];
       [url2 getResourceValue:&date2 forKey:NSURLCreationDateKey error:NULL];
@@ -145,15 +142,13 @@ static NSString *const kHTTPLogsCell = @"kGTMHTTPLogsCell";
 
 #pragma mark - Table view data source
 
-- (NSInteger)tableView:(UITableView *)tableView
- numberOfRowsInSection:(NSInteger)section {
+- (NSInteger)tableView:(UITableView *)tableView numberOfRowsInSection:(NSInteger)section {
   return (NSInteger)logsFolderURLs_.count;
 }
 
 - (UITableViewCell *)tableView:(UITableView *)tableView
          cellForRowAtIndexPath:(NSIndexPath *)indexPath {
-  UITableViewCell *cell =
-      [tableView dequeueReusableCellWithIdentifier:kHTTPLogsCell];
+  UITableViewCell *cell = [tableView dequeueReusableCellWithIdentifier:kHTTPLogsCell];
   if (cell == nil) {
     cell = [[UITableViewCell alloc] initWithStyle:UITableViewCellStyleDefault
                                   reuseIdentifier:kHTTPLogsCell];
@@ -168,8 +163,7 @@ static NSString *const kHTTPLogsCell = @"kGTMHTTPLogsCell";
 
 #pragma mark - Table view delegate
 
-- (void)tableView:(UITableView *)tableView
-    didSelectRowAtIndexPath:(NSIndexPath *)indexPath {
+- (void)tableView:(UITableView *)tableView didSelectRowAtIndexPath:(NSIndexPath *)indexPath {
   NSURL *folderURL = logsFolderURLs_[(NSUInteger)indexPath.row];
   NSString *htmlName = [GTMSessionFetcher htmlFileName];
   NSURL *htmlURL = [folderURL URLByAppendingPathComponent:htmlName isDirectory:NO];
@@ -194,7 +188,7 @@ static NSString *const kHTTPLogsCell = @"kGTMHTTPLogsCell";
     NSURL *folderURL = logsFolderURLs_[(NSUInteger)indexPath.row];
     if ([[NSFileManager defaultManager] removeItemAtURL:folderURL error:NULL]) {
       [logsFolderURLs_ removeObjectAtIndex:(NSUInteger)indexPath.row];
-      [tableView deleteRowsAtIndexPaths:@[indexPath]
+      [tableView deleteRowsAtIndexPaths:@[ indexPath ]
                        withRowAnimation:UITableViewRowAnimationAutomatic];
     }
   }
@@ -202,8 +196,7 @@ static NSString *const kHTTPLogsCell = @"kGTMHTTPLogsCell";
 
 #pragma mark -
 
-+ (UINavigationController *)controllerWithTarget:(id)target
-                                        selector:(SEL)selector {
++ (UINavigationController *)controllerWithTarget:(id)target selector:(SEL)selector {
   UINavigationController *navController = [[UINavigationController alloc] init];
   GTMSessionFetcherLogViewController *logViewController =
       [[GTMSessionFetcherLogViewController alloc] init];
@@ -259,8 +252,7 @@ static NSString *const kHTTPLogsCell = @"kGTMHTTPLogsCell";
 
 - (void)loadView {
   GTMWebView *webView = [[GTMWebView alloc] init];
-  webView.autoresizingMask = (UIViewAutoresizingFlexibleWidth
-                              | UIViewAutoresizingFlexibleHeight);
+  webView.autoresizingMask = (UIViewAutoresizingFlexibleWidth | UIViewAutoresizingFlexibleHeight);
 #if GTM_USE_WKWEBVIEW
   webView.navigationDelegate = self;
 #else
@@ -286,7 +278,8 @@ static NSString *const kHTTPLogsCell = @"kGTMHTTPLogsCell";
 - (void)didFinishLoadingHTML {
   if (opensScrolledToEnd_) {
     // Scroll to the bottom, because the most recent entry is at the end.
-    NSString *javascript = [NSString stringWithFormat:@"window.scrollBy(0, %ld);", (long)NSIntegerMax];
+    NSString *javascript =
+        [NSString stringWithFormat:@"window.scrollBy(0, %ld);", (long)NSIntegerMax];
 #if GTM_USE_WKWEBVIEW
     [[self webView] evaluateJavaScript:javascript completionHandler:nil];
 #else

--- a/Source/GTMSessionFetcherLogging.m
+++ b/Source/GTMSessionFetcherLogging.m
@@ -23,7 +23,7 @@
 #import "GTMSessionFetcherLogging.h"
 
 #ifndef STRIP_GTM_FETCH_LOGGING
-  #error GTMSessionFetcher headers should have defaulted this if it wasn't already defined.
+#error GTMSessionFetcher headers should have defaulted this if it wasn't already defined.
 #endif
 
 #if !STRIP_GTM_FETCH_LOGGING
@@ -45,8 +45,8 @@
 
 + (instancetype)inputStreamWithStream:(NSInputStream *)input;
 
-@property (assign) id readDelegate;
-@property (assign) SEL readSelector;
+@property(assign) id readDelegate;
+@property(assign) SEL readSelector;
 
 @end
 #else
@@ -157,7 +157,8 @@ static NSString *gLoggingProcessName = nil;
     if (![fileMgr createDirectoryAtPath:logDirectory
             withIntermediateDirectories:YES
                              attributes:nil
-                                  error:NULL]) return nil;
+                                  error:NULL])
+      return nil;
   }
   gLogDirectoryForCurrentRun = logDirectory;
 
@@ -243,18 +244,15 @@ static NSString *gLoggingProcessName = nil;
     if ([itemURL isEqual:logDirectoryForCurrentRun]) continue;
 
     NSDate *modDate;
-    if ([itemURL getResourceValue:&modDate
-                           forKey:NSURLContentModificationDateKey
-                            error:&error]) {
+    if ([itemURL getResourceValue:&modDate forKey:NSURLContentModificationDateKey error:&error]) {
       if ([modDate compare:cutoffDate] == NSOrderedAscending) {
         if (![fileMgr removeItemAtURL:itemURL error:&error]) {
-          NSLog(@"deleteLogDirectoriesOlderThanDate failed to delete %@: %@",
-                itemURL.path, error);
+          NSLog(@"deleteLogDirectoriesOlderThanDate failed to delete %@: %@", itemURL.path, error);
         }
       }
     } else {
-      NSLog(@"deleteLogDirectoriesOlderThanDate failed to get mod date of %@: %@",
-            itemURL.path, error);
+      NSLog(@"deleteLogDirectoriesOlderThanDate failed to get mod date of %@: %@", itemURL.path,
+            error);
     }
   }
 }
@@ -269,9 +267,10 @@ static NSString *gLoggingProcessName = nil;
   // if the content type is JSON and we have the parsing class available, use that
   if ([contentType hasPrefix:@"application/json"] && inputData.length > 5) {
     // convert from JSON string to NSObjects and back to a formatted string
-    NSMutableDictionary *obj = [NSJSONSerialization JSONObjectWithData:inputData
-                                                               options:NSJSONReadingMutableContainers
-                                                                 error:NULL];
+    NSMutableDictionary *obj =
+        [NSJSONSerialization JSONObjectWithData:inputData
+                                        options:NSJSONReadingMutableContainers
+                                          error:NULL];
     if (obj) {
       if (outJSON) *outJSON = obj;
       if ([obj isKindOfClass:[NSMutableDictionary class]]) {
@@ -287,8 +286,7 @@ static NSString *gLoggingProcessName = nil;
                                                      options:NSJSONWritingPrettyPrinted
                                                        error:NULL];
       if (data) {
-        NSString *jsonStr = [[NSString alloc] initWithData:data
-                                                  encoding:NSUTF8StringEncoding];
+        NSString *jsonStr = [[NSString alloc] initWithData:data encoding:NSUTF8StringEncoding];
         return jsonStr;
       }
     }
@@ -305,10 +303,7 @@ static NSString *gLoggingProcessName = nil;
     gIsXMLLintAvailable = [[NSFileManager defaultManager] fileExistsAtPath:kXMLLintPath];
     gHasCheckedAvailability = YES;
   }
-  if (gIsXMLLintAvailable
-      && inputData.length > 5
-      && strncmp(inputData.bytes, "<?xml", 5) == 0) {
-
+  if (gIsXMLLintAvailable && inputData.length > 5 && strncmp(inputData.bytes, "<?xml", 5) == 0) {
     // call xmllint to format the data
     NSTask *task = [[NSTask alloc] init];
     [task setLaunchPath:kXMLLintPath];
@@ -342,8 +337,7 @@ static NSString *gLoggingProcessName = nil;
   // we can't call external tasks on the iPhone; leave the XML unformatted
 #endif
 
-  NSString *dataStr = [[NSString alloc] initWithData:inputData
-                                            encoding:NSUTF8StringEncoding];
+  NSString *dataStr = [[NSString alloc] initWithData:inputData encoding:NSUTF8StringEncoding];
   return dataStr;
 }
 
@@ -356,15 +350,11 @@ static NSString *gLoggingProcessName = nil;
 // For parts that fail, a replacement string showing the part header and <<n bytes>> is supplied
 // in place of the binary data.
 
-- (NSString *)stringFromStreamData:(NSData *)data
-                       contentType:(NSString *)contentType {
-
+- (NSString *)stringFromStreamData:(NSData *)data contentType:(NSString *)contentType {
   if (!data) return nil;
 
   // optimistically, see if the whole data block is UTF-8
-  NSString *streamDataStr = [self formattedStringFromData:data
-                                              contentType:contentType
-                                                     JSON:NULL];
+  NSString *streamDataStr = [self formattedStringFromData:data contentType:contentType JSON:NULL];
   if (streamDataStr) return streamDataStr;
 
   // Munge a buffer by replacing non-ASCII bytes with underscores, and turn that munged buffer an
@@ -378,17 +368,13 @@ static NSString *gLoggingProcessName = nil;
     }
   }
 
-  NSString *mungedStr = [[NSString alloc] initWithData:mutableData
-                                              encoding:NSUTF8StringEncoding];
+  NSString *mungedStr = [[NSString alloc] initWithData:mutableData encoding:NSUTF8StringEncoding];
   if (mungedStr) {
-
     // scan for the boundary string
     NSString *boundary = nil;
     NSScanner *scanner = [NSScanner scannerWithString:mungedStr];
 
-    if ([scanner scanUpToString:@"\r\n" intoString:&boundary]
-        && [boundary hasPrefix:@"--"]) {
-
+    if ([scanner scanUpToString:@"\r\n" intoString:&boundary] && [boundary hasPrefix:@"--"]) {
       // we found a boundary string; use it to divide the string into parts
       NSArray *mungedParts = [mungedStr componentsSeparatedByString:boundary];
 
@@ -412,8 +398,8 @@ static NSString *gLoggingProcessName = nil;
             header = @"";
           }
           // make a part string with the header and <<n bytes>>
-          NSString *binStr = [NSString stringWithFormat:@"\r%@\r<<%lu bytes>>\r",
-                              header, (long)(partSize - header.length)];
+          NSString *binStr = [NSString
+              stringWithFormat:@"\r%@\r<<%lu bytes>>\r", header, (long)(partSize - header.length)];
           [origParts addObject:binStr];
         }
         offset += partSize + boundary.length;
@@ -465,10 +451,8 @@ static NSString *gLoggingProcessName = nil;
   int64_t responseDataLength = self.downloadedLength;
   if (responseDataLength > 0) {
     NSData *downloadedData = self.downloadedData;
-    if (downloadedData == nil
-        && responseDataLength > 0
-        && responseDataLength < 20000
-        && self.destinationFileURL) {
+    if (downloadedData == nil && responseDataLength > 0 && responseDataLength < 20000 &&
+        self.destinationFileURL) {
       // There's a download file that's not too big, so get the data to display from the downloaded
       // file.
       NSURL *destinationURL = self.destinationFileURL;
@@ -482,8 +466,8 @@ static NSString *gLoggingProcessName = nil;
     NSData *dataToWrite = nil;
     if (responseDataStr) {
       // we were able to make a UTF-8 string from the response data
-      if ([responseMIMEType isEqual:@"application/atom+xml"]
-          || [responseMIMEType hasSuffix:@"/xml"]) {
+      if ([responseMIMEType isEqual:@"application/atom+xml"] ||
+          [responseMIMEType hasSuffix:@"/xml"]) {
         responseDataExtn = @"xml";
         dataToWrite = [responseDataStr dataUsingEncoding:NSUTF8StringEncoding];
       }
@@ -505,34 +489,38 @@ static NSString *gLoggingProcessName = nil;
     // if we have an extension, save the raw data in a file with that extension
     if (responseDataExtn && dataToWrite) {
       // generate a response file base name like
-      NSString *responseBaseName = [NSString stringWithFormat:@"fetch_%d_response", responseCounter];
+      NSString *responseBaseName =
+          [NSString stringWithFormat:@"fetch_%d_response", responseCounter];
       responseDataFileName = [responseBaseName stringByAppendingPathExtension:responseDataExtn];
-      NSString *responseDataFilePath = [logDirectory stringByAppendingPathComponent:responseDataFileName];
+      NSString *responseDataFilePath =
+          [logDirectory stringByAppendingPathComponent:responseDataFileName];
 
       NSError *downloadedError = nil;
       if (gIsLoggingToFile && ![dataToWrite writeToFile:responseDataFilePath
                                                 options:0
                                                   error:&downloadedError]) {
-        NSLog(@"%@ logging write error:%@ (%@)", [self class], downloadedError, responseDataFileName);
+        NSLog(@"%@ logging write error:%@ (%@)", [self class], downloadedError,
+              responseDataFileName);
       }
     }
   }
   // we'll have one main html file per run of the app
   NSString *htmlName = [[self class] htmlFileName];
-  NSString *htmlPath =[logDirectory stringByAppendingPathComponent:htmlName];
+  NSString *htmlPath = [logDirectory stringByAppendingPathComponent:htmlName];
 
   // if the html file exists (from logging previous fetches) we don't need
   // to re-write the header or the scripts
   NSFileManager *fileMgr = [NSFileManager defaultManager];
   BOOL didFileExist = [fileMgr fileExistsAtPath:htmlPath];
 
-  NSMutableString* outputHTML = [NSMutableString string];
+  NSMutableString *outputHTML = [NSMutableString string];
 
   // we need a header to say we'll have UTF-8 text
   if (!didFileExist) {
-    [outputHTML appendFormat:@"<html><head><meta http-equiv=\"content-type\" "
-        "content=\"text/html; charset=UTF-8\"><title>%@ HTTP fetch log %@</title>",
-        processName, [[self class] loggingDateStamp]];
+    [outputHTML
+        appendFormat:@"<html><head><meta http-equiv=\"content-type\" "
+                      "content=\"text/html; charset=UTF-8\"><title>%@ HTTP fetch log %@</title>",
+                     processName, [[self class] loggingDateStamp]];
   }
   // now write the visible html elements
   NSString *copyableFileName = [NSString stringWithFormat:@"fetch_%d.txt", responseCounter];
@@ -545,7 +533,8 @@ static NSString *gLoggingProcessName = nil;
   if (comment.length > 0) {
     [outputHTML appendFormat:@"%@ &nbsp;&nbsp;&nbsp;&nbsp; ", comment];
   }
-  [outputHTML appendFormat:@"</b><a href='%@'><i>request/response log</i></a><br>", copyableFileName];
+  [outputHTML
+      appendFormat:@"</b><a href='%@'><i>request/response log</i></a><br>", copyableFileName];
   NSTimeInterval elapsed = -self.initialBeginFetchDate.timeIntervalSinceNow;
   [outputHTML appendFormat:@"elapsed: %5.3fsec<br>", elapsed];
 
@@ -559,7 +548,7 @@ static NSString *gLoggingProcessName = nil;
   self.redirectedFromURL = [requestURL copy];
   if (redirectedFromURLString) {
     [outputHTML appendFormat:@"<FONT COLOR='#990066'><i>redirected from %@</i></FONT><br>",
-                              redirectedFromURLString];
+                             redirectedFromURLString];
   }
   [outputHTML appendFormat:@"<b>request:</b> %@ <code>%@</code><br>\n", requestMethod, requestURL];
 
@@ -590,10 +579,11 @@ static NSString *gLoggingProcessName = nil;
     }
     matchHdr = [requestHeaders objectForKey:@"If-None-Match"];
     if (matchHdr) {
-      headerDetails = [headerDetails stringByAppendingString:@"&nbsp;&nbsp;&nbsp;<i>if-none-match</i>"];
+      headerDetails =
+          [headerDetails stringByAppendingString:@"&nbsp;&nbsp;&nbsp;<i>if-none-match</i>"];
     }
-    [outputHTML appendFormat:@"&nbsp;&nbsp; headers: %d  %@<br>",
-                              (int)numberOfRequestHeaders, headerDetails];
+    [outputHTML appendFormat:@"&nbsp;&nbsp; headers: %d  %@<br>", (int)numberOfRequestHeaders,
+                             headerDetails];
   } else {
     [outputHTML appendFormat:@"&nbsp;&nbsp; headers: none<br>"];
   }
@@ -633,14 +623,13 @@ static NSString *gLoggingProcessName = nil;
 
   if (bodyDataLength > 0) {
     [outputHTML appendFormat:@"&nbsp;&nbsp; data: %llu bytes, <code>%@</code><br>\n",
-                              bodyDataLength, postType ? postType : @"(no type)"];
+                             bodyDataLength, postType ? postType : @"(no type)"];
     NSString *logRequestBody = self.logRequestBody;
     if (logRequestBody) {
       bodyDataStr = [logRequestBody copy];
       self.logRequestBody = nil;
     } else {
-      bodyDataStr = [self stringFromStreamData:bodyData
-                                   contentType:postType];
+      bodyDataStr = [self stringFromStreamData:bodyData contentType:postType];
       if (bodyDataStr) {
         // remove OAuth 2 client secret and refresh token
         bodyDataStr = [[self class] snipSubstringOfString:bodyDataStr
@@ -674,17 +663,17 @@ static NSString *gLoggingProcessName = nil;
             NSString *jsonMessage = [jsonError valueForKey:@"message"];
             if (jsonCode || jsonMessage) {
               // 2691 = ⚑
-              NSString *const jsonErrFmt =
-                  @"&nbsp;&nbsp;&nbsp;<i>JSON error:</i> <FONT COLOR='#FF00FF'>%@ %@ &nbsp;&#x2691;</FONT>";
-              statusString = [statusString stringByAppendingFormat:jsonErrFmt,
-                              jsonCode ? jsonCode : @"",
-                              jsonMessage ? jsonMessage : @""];
+              NSString *const jsonErrFmt = @"&nbsp;&nbsp;&nbsp;<i>JSON error:</i> <FONT "
+                                           @"COLOR='#FF00FF'>%@ %@ &nbsp;&#x2691;</FONT>";
+              statusString =
+                  [statusString stringByAppendingFormat:jsonErrFmt, jsonCode ? jsonCode : @"",
+                                                        jsonMessage ? jsonMessage : @""];
             }
           }
         }
       } else {
         // purple for anything other than 200 or 201
-        NSString *flag = status >= 400 ? @"&nbsp;&#x2691;" : @""; // 2691 = ⚑
+        NSString *flag = status >= 400 ? @"&nbsp;&#x2691;" : @"";  // 2691 = ⚑
         NSString *explanation = [NSHTTPURLResponse localizedStringForStatusCode:status];
         NSString *const statusFormat = @"<FONT COLOR='#FF00FF'>%ld %@ %@</FONT>";
         statusString = [NSString stringWithFormat:statusFormat, (long)status, explanation, flag];
@@ -699,8 +688,8 @@ static NSString *gLoggingProcessName = nil;
           @"<FONT COLOR='#FF00FF'>response URL:</FONT> <code>%@</code><br>\n";
       responseURLStr = [NSString stringWithFormat:responseURLFormat, [responseURL absoluteString]];
     }
-    [outputHTML appendFormat:@"<b>response:</b>&nbsp;&nbsp;status %@<br>\n%@",
-                              statusString, responseURLStr];
+    [outputHTML appendFormat:@"<b>response:</b>&nbsp;&nbsp;status %@<br>\n%@", statusString,
+                             responseURLStr];
     // Write the response headers
     NSUInteger numberOfResponseHeaders = responseHeaders.count;
     if (numberOfResponseHeaders > 0) {
@@ -714,7 +703,7 @@ static NSString *gLoggingProcessName = nil;
       NSString *redirectsStr =
           isRedirect ? @"&nbsp;&nbsp;<FONT COLOR='#990066'><i>redirects</i></FONT>" : @"";
       [outputHTML appendFormat:@"&nbsp;&nbsp; headers: %d  %@ %@<br>\n",
-                                (int)numberOfResponseHeaders, cookiesStr, redirectsStr];
+                               (int)numberOfResponseHeaders, cookiesStr, redirectsStr];
     } else {
       [outputHTML appendString:@"&nbsp;&nbsp; headers: none<br>\n"];
     }
@@ -728,21 +717,22 @@ static NSString *gLoggingProcessName = nil;
     if (isResponseImage) {
       // Make a small inline image that links to the full image file
       [outputHTML appendFormat:@"&nbsp;&nbsp; data: %lld bytes, <code>%@</code><br>",
-                                responseDataLength, responseMIMEType];
-      NSString *const fmt =
-          @"<a href=\"%@\"><img src='%@' alt='image' style='border:solid thin;max-height:32'></a>\n";
+                               responseDataLength, responseMIMEType];
+      NSString *const fmt = @"<a href=\"%@\"><img src='%@' alt='image' style='border:solid "
+                            @"thin;max-height:32'></a>\n";
       [outputHTML appendFormat:fmt, responseDataFileName, responseDataFileName];
     } else {
       // The response data was XML; link to the xml file
-      NSString *const fmt =
-          @"&nbsp;&nbsp; data: %lld bytes, <code>%@</code>&nbsp;&nbsp;&nbsp;<i><a href=\"%@\">%@</a></i>\n";
-      [outputHTML appendFormat:fmt, responseDataLength, responseMIMEType,
-                               responseDataFileName, [responseDataFileName pathExtension]];
+      NSString *const fmt = @"&nbsp;&nbsp; data: %lld bytes, "
+                            @"<code>%@</code>&nbsp;&nbsp;&nbsp;<i><a href=\"%@\">%@</a></i>\n";
+      [outputHTML appendFormat:fmt, responseDataLength, responseMIMEType, responseDataFileName,
+                               [responseDataFileName pathExtension]];
     }
   } else {
     // The response data was not an image; just show the length and MIME type
     [outputHTML appendFormat:@"&nbsp;&nbsp; data: %lld bytes, <code>%@</code>\n",
-        responseDataLength, responseMIMEType ? responseMIMEType : @"(no response type)"];
+                             responseDataLength,
+                             responseMIMEType ? responseMIMEType : @"(no response type)"];
   }
   // Make a single string of the request and response, suitable for copying
   // to the clipboard and pasting into a bug report
@@ -757,7 +747,7 @@ static NSString *gLoggingProcessName = nil;
   [copyable appendFormat:@"Request: %@ %@\n", requestMethod, requestURL];
   if (requestHeaders.count > 0) {
     [copyable appendFormat:@"Request headers:\n%@\n",
-                            [[self class] headersStringForDictionary:requestHeaders]];
+                           [[self class] headersStringForDictionary:requestHeaders]];
   }
   if (bodyDataLength > 0) {
     [copyable appendFormat:@"Request body: (%llu bytes)\n", bodyDataLength];
@@ -767,9 +757,9 @@ static NSString *gLoggingProcessName = nil;
     [copyable appendString:@"\n"];
   }
   if (response) {
-    [copyable appendFormat:@"Response: status %d\n", (int) status];
+    [copyable appendFormat:@"Response: status %d\n", (int)status];
     [copyable appendFormat:@"Response headers:\n%@\n",
-                            [[self class] headersStringForDictionary:responseHeaders]];
+                           [[self class] headersStringForDictionary:responseHeaders]];
     [copyable appendFormat:@"Response body: (%lld bytes)\n", responseDataLength];
     if (responseDataLength > 0) {
       NSString *logResponseBody = self.logResponseBody;
@@ -783,8 +773,8 @@ static NSString *gLoggingProcessName = nil;
       } else {
         // Even though it's redundant, we'll put in text to indicate that all the bytes are binary.
         if (self.destinationFileURL) {
-          [copyable appendFormat:@"<<%lld bytes>>  to file %@\n",
-           responseDataLength, self.destinationFileURL.path];
+          [copyable appendFormat:@"<<%lld bytes>>  to file %@\n", responseDataLength,
+                                 self.destinationFileURL.path];
         } else {
           [copyable appendFormat:@"<<%lld bytes>>\n", responseDataLength];
         }
@@ -819,11 +809,10 @@ static NSString *gLoggingProcessName = nil;
     [outputHTML appendString:@"<br><hr><p>"];
 
     // Append the HTML to the main output file
-    const char* htmlBytes = outputHTML.UTF8String;
-    NSOutputStream *stream = [NSOutputStream outputStreamToFileAtPath:htmlPath
-                                                               append:YES];
+    const char *htmlBytes = outputHTML.UTF8String;
+    NSOutputStream *stream = [NSOutputStream outputStreamToFileAtPath:htmlPath append:YES];
     [stream open];
-    [stream write:(const uint8_t *) htmlBytes maxLength:strlen(htmlBytes)];
+    [stream write:(const uint8_t *)htmlBytes maxLength:strlen(htmlBytes)];
     [stream close];
 
     // Make a symlink to the latest html
@@ -832,9 +821,7 @@ static NSString *gLoggingProcessName = nil;
     NSString *symlinkPath = [parentDir stringByAppendingPathComponent:symlinkName];
 
     [fileMgr removeItemAtPath:symlinkPath error:NULL];
-    [fileMgr createSymbolicLinkAtPath:symlinkPath
-                  withDestinationPath:htmlPath
-                                error:NULL];
+    [fileMgr createSymbolicLinkAtPath:symlinkPath withDestinationPath:htmlPath error:NULL];
 #if TARGET_OS_IPHONE
     static BOOL gReportedLoggingPath = NO;
     if (!gReportedLoggingPath) {
@@ -882,11 +869,11 @@ static NSString *gLoggingProcessName = nil;
   }
   GTMSessionFetcherBodyStreamProvider loggedStreamProvider =
       ^(GTMSessionFetcherBodyStreamProviderResponse response) {
-      streamProvider(^(NSInputStream *bodyStream) {
+        streamProvider(^(NSInputStream *bodyStream) {
           bodyStream = [self loggedInputStreamForInputStream:bodyStream];
           response(bodyStream);
-      });
-  };
+        });
+      };
   return loggedStreamProvider;
 }
 
@@ -898,9 +885,7 @@ static NSString *gLoggingProcessName = nil;
      readIntoBuffer:(void *)buffer
              length:(int64_t)length {
   // append the captured data
-  NSData *data = [NSData dataWithBytesNoCopy:buffer
-                                      length:(NSUInteger)length
-                                freeWhenDone:NO];
+  NSData *data = [NSData dataWithBytesNoCopy:buffer length:(NSUInteger)length freeWhenDone:NO];
   [self appendLoggedStreamData:data];
 }
 
@@ -923,9 +908,7 @@ static NSString *gLoggingProcessName = nil;
   NSUInteger originalLength = originalStr.length;
   NSUInteger startOfTarget = NSMaxRange(startRange);
   NSRange targetAndRest = NSMakeRange(startOfTarget, originalLength - startOfTarget);
-  NSRange endRange = [originalStr rangeOfString:endStr
-                                        options:0
-                                          range:targetAndRest];
+  NSRange endRange = [originalStr rangeOfString:endStr options:0 range:targetAndRest];
   NSRange replaceRange;
   if (endRange.location == NSNotFound) {
     // Found no end marker so replace to end of string
@@ -937,7 +920,7 @@ static NSString *gLoggingProcessName = nil;
   NSString *result = [originalStr stringByReplacingCharactersInRange:replaceRange
                                                           withString:@"_snip_"];
   return result;
-#endif // SKIP_GTM_FETCH_LOGGING_SNIPPING
+#endif  // SKIP_GTM_FETCH_LOGGING_SNIPPING
 }
 
 + (NSString *)headersStringForDictionary:(NSDictionary *)dict {
@@ -979,4 +962,4 @@ static NSString *gLoggingProcessName = nil;
 
 @end
 
-#endif // !STRIP_GTM_FETCH_LOGGING
+#endif  // !STRIP_GTM_FETCH_LOGGING

--- a/Source/GTMSessionFetcherOSX/GTMSessionFetcherOSX.h
+++ b/Source/GTMSessionFetcherOSX/GTMSessionFetcherOSX.h
@@ -2,13 +2,10 @@
 //  GTMSessionFetcherOSX.h
 //
 
-#import "GTMSessionFetcher.h"
-#import "GTMSessionFetcherService.h"
-#import "GTMSessionUploadFetcher.h"
-#import "GTMSessionFetcherService.h"
-#import "GTMSessionFetcherLogging.h"
 #import "GTMGatherInputStream.h"
 #import "GTMMIMEDocument.h"
 #import "GTMReadMonitorInputStream.h"
-
-
+#import "GTMSessionFetcher.h"
+#import "GTMSessionFetcherLogging.h"
+#import "GTMSessionFetcherService.h"
+#import "GTMSessionUploadFetcher.h"

--- a/Source/GTMSessionFetcherService.h
+++ b/Source/GTMSessionFetcherService.h
@@ -34,12 +34,14 @@ GTM_ASSUME_NONNULL_BEGIN
 extern NSString *const kGTMSessionFetcherServiceSessionBecameInvalidNotification;
 extern NSString *const kGTMSessionFetcherServiceSessionKey;
 
-@interface GTMSessionFetcherService : NSObject<GTMSessionFetcherServiceProtocol>
+@interface GTMSessionFetcherService : NSObject <GTMSessionFetcherServiceProtocol>
 
 // Queues of delayed and running fetchers. Each dictionary contains arrays
 // of GTMSessionFetcher *fetchers, keyed by NSString *host
-@property(atomic, strong, readonly, GTM_NULLABLE) GTM_NSDictionaryOf(NSString *, NSArray *) *delayedFetchersByHost;
-@property(atomic, strong, readonly, GTM_NULLABLE) GTM_NSDictionaryOf(NSString *, NSArray *) *runningFetchersByHost;
+@property(atomic, strong, readonly, GTM_NULLABLE) GTM_NSDictionaryOf(NSString *, NSArray *) *
+    delayedFetchersByHost;
+@property(atomic, strong, readonly, GTM_NULLABLE) GTM_NSDictionaryOf(NSString *, NSArray *) *
+    runningFetchersByHost;
 
 // A max value of 0 means no fetchers should be delayed.
 // The default limit is 10 simultaneous fetchers targeting each host.
@@ -55,14 +57,14 @@ extern NSString *const kGTMSessionFetcherServiceSessionKey;
 @property(atomic, copy, GTM_NULLABLE) GTMSessionFetcherChallengeBlock challengeBlock;
 @property(atomic, strong, GTM_NULLABLE) NSURLCredential *credential;
 @property(atomic, strong) NSURLCredential *proxyCredential;
-@property(atomic, copy, GTM_NULLABLE) GTM_NSArrayOf(NSString *) *allowedInsecureSchemes;
+@property(atomic, copy, GTM_NULLABLE) GTM_NSArrayOf(NSString *) * allowedInsecureSchemes;
 @property(atomic, assign) BOOL allowLocalhostRequest;
 @property(atomic, assign) BOOL allowInvalidServerCertificates;
 @property(atomic, assign, getter=isRetryEnabled) BOOL retryEnabled;
 @property(atomic, copy, GTM_NULLABLE) GTMSessionFetcherRetryBlock retryBlock;
 @property(atomic, assign) NSTimeInterval maxRetryInterval;
 @property(atomic, assign) NSTimeInterval minRetryInterval;
-@property(atomic, copy, GTM_NULLABLE) GTM_NSDictionaryOf(NSString *, id) *properties;
+@property(atomic, copy, GTM_NULLABLE) GTM_NSDictionaryOf(NSString *, id) * properties;
 @property(atomic, copy, GTM_NULLABLE)
     GTMSessionFetcherMetricsCollectionBlock metricsCollectionBlock API_AVAILABLE(
         ios(10.0), macosx(10.12), tvos(10.0), watchos(3.0));
@@ -120,12 +122,11 @@ extern NSString *const kGTMSessionFetcherServiceSessionKey;
 // -fetcherWithRequest:fetcherClass: may be overridden to customize creation of
 // fetchers.  This is the ONLY method in the GTMSessionFetcher library intended to
 // be overridden.
-- (id)fetcherWithRequest:(NSURLRequest *)request
-            fetcherClass:(Class)fetcherClass;
+- (id)fetcherWithRequest:(NSURLRequest *)request fetcherClass:(Class)fetcherClass;
 
 - (BOOL)isDelayingFetcher:(GTMSessionFetcher *)fetcher;
 
-- (NSUInteger)numberOfFetchers;        // running + delayed fetchers
+- (NSUInteger)numberOfFetchers;  // running + delayed fetchers
 - (NSUInteger)numberOfRunningFetchers;
 - (NSUInteger)numberOfDelayedFetchers;
 
@@ -138,7 +139,8 @@ extern NSString *const kGTMSessionFetcherServiceSessionKey;
 // Search for running or delayed fetchers with the specified URL.
 //
 // Returns an array of fetcher objects found, or nil if none found.
-- (GTM_NULLABLE GTM_NSArrayOf(GTMSessionFetcher *) *)issuedFetchersWithRequestURL:(NSURL *)requestURL;
+- (GTM_NULLABLE GTM_NSArrayOf(GTMSessionFetcher *) *)issuedFetchersWithRequestURL:
+    (NSURL *)requestURL;
 
 - (void)stopAllFetchers;
 

--- a/Source/GTMSessionFetcherService.m
+++ b/Source/GTMSessionFetcherService.m
@@ -19,15 +19,13 @@
 
 #import "GTMSessionFetcherService.h"
 
-NSString *const kGTMSessionFetcherServiceSessionBecameInvalidNotification
-    = @"kGTMSessionFetcherServiceSessionBecameInvalidNotification";
-NSString *const kGTMSessionFetcherServiceSessionKey
-    = @"kGTMSessionFetcherServiceSessionKey";
+NSString *const kGTMSessionFetcherServiceSessionBecameInvalidNotification =
+    @"kGTMSessionFetcherServiceSessionBecameInvalidNotification";
+NSString *const kGTMSessionFetcherServiceSessionKey = @"kGTMSessionFetcherServiceSessionKey";
 
 #if !GTMSESSION_BUILD_COMBINED_SOURCES
 @interface GTMSessionFetcher (ServiceMethods)
-- (BOOL)beginFetchMayDelay:(BOOL)mayDelay
-              mayAuthorize:(BOOL)mayAuthorize;
+- (BOOL)beginFetchMayDelay:(BOOL)mayDelay mayAuthorize:(BOOL)mayAuthorize;
 @end
 #endif  // !GTMSESSION_BUILD_COMBINED_SOURCES
 
@@ -43,7 +41,7 @@ NSString *const kGTMSessionFetcherServiceSessionKey
 //
 // This class maps a session's tasks to fetchers, and resends delegate messages to the task's
 // fetcher.
-@interface GTMSessionFetcherSessionDelegateDispatcher : NSObject<NSURLSessionDelegate>
+@interface GTMSessionFetcherSessionDelegateDispatcher : NSObject <NSURLSessionDelegate>
 
 // The session for the tasks in this dispatcher's task-to-fetcher map.
 @property(atomic) NSURLSession *session;
@@ -54,12 +52,10 @@ NSString *const kGTMSessionFetcherServiceSessionKey
 // The current discard timer.
 @property(atomic, readonly) NSTimer *discardTimer;
 
-
 - (instancetype)initWithParentService:(GTMSessionFetcherService *)parentService
                sessionDiscardInterval:(NSTimeInterval)discardInterval;
 
-- (void)setFetcher:(GTMSessionFetcher *)fetcher
-           forTask:(NSURLSessionTask *)task;
+- (void)setFetcher:(GTMSessionFetcher *)fetcher forTask:(NSURLSessionTask *)task;
 - (void)removeFetcher:(GTMSessionFetcher *)fetcher;
 
 // Before using a session, tells the delegate dispatcher to stop the discard timer.
@@ -70,7 +66,6 @@ NSString *const kGTMSessionFetcherServiceSessionKey
 - (void)abandon;
 
 @end
-
 
 @implementation GTMSessionFetcherService {
   NSMutableDictionary *_delayedFetchersByHost;
@@ -106,25 +101,16 @@ NSString *const kGTMSessionFetcherServiceSessionKey
   NSDate *_stoppedAllFetchersDate;
 }
 
-@synthesize maxRunningFetchersPerHost = _maxRunningFetchersPerHost,
-            configuration = _configuration,
-            configurationBlock = _configurationBlock,
-            cookieStorage = _cookieStorage,
-            userAgent = _userAgent,
-            challengeBlock = _challengeBlock,
-            credential = _credential,
-            proxyCredential = _proxyCredential,
-            allowedInsecureSchemes = _allowedInsecureSchemes,
+@synthesize maxRunningFetchersPerHost = _maxRunningFetchersPerHost, configuration = _configuration,
+            configurationBlock = _configurationBlock, cookieStorage = _cookieStorage,
+            userAgent = _userAgent, challengeBlock = _challengeBlock, credential = _credential,
+            proxyCredential = _proxyCredential, allowedInsecureSchemes = _allowedInsecureSchemes,
             allowLocalhostRequest = _allowLocalhostRequest,
             allowInvalidServerCertificates = _allowInvalidServerCertificates,
-            retryEnabled = _retryEnabled,
-            retryBlock = _retryBlock,
-            maxRetryInterval = _maxRetryInterval,
-            minRetryInterval = _minRetryInterval,
-            metricsCollectionBlock = _metricsCollectionBlock,
-            properties = _properties,
-            unusedSessionTimeout = _unusedSessionTimeout,
-            testBlock = _testBlock;
+            retryEnabled = _retryEnabled, retryBlock = _retryBlock,
+            maxRetryInterval = _maxRetryInterval, minRetryInterval = _minRetryInterval,
+            metricsCollectionBlock = _metricsCollectionBlock, properties = _properties,
+            unusedSessionTimeout = _unusedSessionTimeout, testBlock = _testBlock;
 
 #if GTM_BACKGROUND_TASK_FETCHING
 @synthesize skipBackgroundTask = _skipBackgroundTask;
@@ -138,9 +124,9 @@ NSString *const kGTMSessionFetcherServiceSessionKey
     _maxRunningFetchersPerHost = 10;
     _cookieStorageMethod = -1;
     _unusedSessionTimeout = 60.0;
-    _delegateDispatcher =
-        [[GTMSessionFetcherSessionDelegateDispatcher alloc] initWithParentService:self
-                                                           sessionDiscardInterval:_unusedSessionTimeout];
+    _delegateDispatcher = [[GTMSessionFetcherSessionDelegateDispatcher alloc]
+         initWithParentService:self
+        sessionDiscardInterval:_unusedSessionTimeout];
     _callbackQueue = dispatch_get_main_queue();
 
     _delegateQueue = [[NSOperationQueue alloc] init];
@@ -152,8 +138,9 @@ NSString *const kGTMSessionFetcherServiceSessionKey
     // Starting with the SDKs for OS X 10.11/iOS 9, the service has a default useragent.
     // Apps can remove this and get the default system "CFNetwork" useragent by setting the
     // fetcher service's userAgent property to nil.
-#if (!TARGET_OS_IPHONE && defined(MAC_OS_X_VERSION_10_11) && MAC_OS_X_VERSION_MAX_ALLOWED >= MAC_OS_X_VERSION_10_11) \
-    || (TARGET_OS_IPHONE && defined(__IPHONE_9_0) && __IPHONE_OS_VERSION_MAX_ALLOWED >= __IPHONE_9_0)
+#if (!TARGET_OS_IPHONE && defined(MAC_OS_X_VERSION_10_11) &&    \
+     MAC_OS_X_VERSION_MAX_ALLOWED >= MAC_OS_X_VERSION_10_11) || \
+    (TARGET_OS_IPHONE && defined(__IPHONE_9_0) && __IPHONE_OS_VERSION_MAX_ALLOWED >= __IPHONE_9_0)
     _userAgent = GTMFetcherStandardUserAgentString(nil);
 #endif
   }
@@ -168,8 +155,7 @@ NSString *const kGTMSessionFetcherServiceSessionKey
 #pragma mark Generate a new fetcher
 
 // Clients may override this method. Clients should not override any other library methods.
-- (id)fetcherWithRequest:(NSURLRequest *)request
-            fetcherClass:(Class)fetcherClass {
+- (id)fetcherWithRequest:(NSURLRequest *)request fetcherClass:(Class)fetcherClass {
   GTMSessionFetcher *fetcher = [[fetcherClass alloc] initWithRequest:request
                                                        configuration:self.configuration];
   fetcher.callbackQueue = self.callbackQueue;
@@ -201,10 +187,8 @@ NSString *const kGTMSessionFetcherServiceSessionKey
 #endif
 
   NSString *userAgent = self.userAgent;
-  if (userAgent.length > 0
-      && [request valueForHTTPHeaderField:@"User-Agent"] == nil) {
-    [fetcher setRequestValue:userAgent
-          forHTTPHeaderField:@"User-Agent"];
+  if (userAgent.length > 0 && [request valueForHTTPHeaderField:@"User-Agent"] == nil) {
+    [fetcher setRequestValue:userAgent forHTTPHeaderField:@"User-Agent"];
   }
   fetcher.testBlock = self.testBlock;
 
@@ -212,8 +196,7 @@ NSString *const kGTMSessionFetcherServiceSessionKey
 }
 
 - (GTMSessionFetcher *)fetcherWithRequest:(NSURLRequest *)request {
-  return [self fetcherWithRequest:request
-                     fetcherClass:[GTMSessionFetcher class]];
+  return [self fetcherWithRequest:request fetcherClass:[GTMSessionFetcher class]];
 }
 
 - (GTMSessionFetcher *)fetcherWithURL:(NSURL *)requestURL {
@@ -284,8 +267,7 @@ NSString *const kGTMSessionFetcherServiceSessionKey
 
 #pragma mark Queue Management
 
-- (void)addRunningFetcher:(GTMSessionFetcher *)fetcher
-                  forHost:(NSString *)host {
+- (void)addRunningFetcher:(GTMSessionFetcher *)fetcher forHost:(NSString *)host {
   // Add to the array of running fetchers for this host, creating the array if needed.
   NSMutableArray *runningForHost = [_runningFetchersByHost objectForKey:host];
   if (runningForHost == nil) {
@@ -296,8 +278,7 @@ NSString *const kGTMSessionFetcherServiceSessionKey
   }
 }
 
-- (void)addDelayedFetcher:(GTMSessionFetcher *)fetcher
-                  forHost:(NSString *)host {
+- (void)addDelayedFetcher:(GTMSessionFetcher *)fetcher forHost:(NSString *)host {
   // Add to the array of delayed fetchers for this host, creating the array if needed.
   NSMutableArray *delayedForHost = [_delayedFetchersByHost objectForKey:host];
   if (delayedForHost == nil) {
@@ -345,16 +326,14 @@ NSString *const kGTMSessionFetcherServiceSessionKey
     GTMSessionMonitorSynchronized(self);
 
     NSMutableArray *runningForHost = [_runningFetchersByHost objectForKey:host];
-    if (runningForHost != nil
-        && [runningForHost indexOfObjectIdenticalTo:fetcher] != NSNotFound) {
+    if (runningForHost != nil && [runningForHost indexOfObjectIdenticalTo:fetcher] != NSNotFound) {
       GTMSESSION_ASSERT_DEBUG(NO, @"%@ was already running", fetcher);
       return YES;
     }
 
-    BOOL shouldRunNow = (fetcher.usingBackgroundSession
-                         || _maxRunningFetchersPerHost == 0
-                         || _maxRunningFetchersPerHost >
-                         [[self class] numberOfNonBackgroundSessionFetchers:runningForHost]);
+    BOOL shouldRunNow = (fetcher.usingBackgroundSession || _maxRunningFetchersPerHost == 0 ||
+                         _maxRunningFetchersPerHost >
+                             [[self class] numberOfNonBackgroundSessionFetchers:runningForHost]);
     if (shouldRunNow) {
       [self addRunningFetcher:fetcher forHost:host];
       shouldBeginResult = YES;
@@ -373,13 +352,13 @@ NSString *const kGTMSessionFetcherServiceSessionKey
 }
 
 - (void)startFetcher:(GTMSessionFetcher *)fetcher {
-  [fetcher beginFetchMayDelay:NO
-                 mayAuthorize:YES];
+  [fetcher beginFetchMayDelay:NO mayAuthorize:YES];
 }
 
 // Internal utility. Returns a fetcher's delegate if it's a dispatcher, or nil if the fetcher
 // is its own delegate (possibly via proxy) and has no dispatcher.
-- (GTMSessionFetcherSessionDelegateDispatcher *)delegateDispatcherForFetcher:(GTMSessionFetcher *)fetcher {
+- (GTMSessionFetcherSessionDelegateDispatcher *)delegateDispatcherForFetcher:
+    (GTMSessionFetcher *)fetcher {
   GTMSessionCheckNotSynchronized(self);
 
   NSURLSession *fetcherSession = fetcher.session;
@@ -388,11 +367,12 @@ NSString *const kGTMSessionFetcherServiceSessionKey
     // If the delegate is non-nil and claims to be a GTMSessionFetcher, there is no dispatcher;
     // assume the fetcher is the delegate or has been proxied (some third-party frameworks
     // are known to swizzle NSURLSession to proxy its delegate).
-    BOOL hasDispatcher = (fetcherDelegate != nil &&
-                          ![fetcherDelegate isKindOfClass:[GTMSessionFetcher class]]);
+    BOOL hasDispatcher =
+        (fetcherDelegate != nil && ![fetcherDelegate isKindOfClass:[GTMSessionFetcher class]]);
     if (hasDispatcher) {
-      GTMSESSION_ASSERT_DEBUG([fetcherDelegate isKindOfClass:[GTMSessionFetcherSessionDelegateDispatcher class]],
-                              @"Fetcher delegate class: %@", [fetcherDelegate class]);
+      GTMSESSION_ASSERT_DEBUG(
+          [fetcherDelegate isKindOfClass:[GTMSessionFetcherSessionDelegateDispatcher class]],
+          @"Fetcher delegate class: %@", [fetcherDelegate class]);
       return (GTMSessionFetcherSessionDelegateDispatcher *)fetcherDelegate;
     }
   }
@@ -425,8 +405,7 @@ NSString *const kGTMSessionFetcherServiceSessionKey
   GTMSessionFetcherSessionDelegateDispatcher *delegateDispatcher =
       [self delegateDispatcherForFetcher:fetcher];
   if (delegateDispatcher) {
-    GTMSESSION_ASSERT_DEBUG(fetcher.canShareSession,
-                            @"Inappropriate shared session: %@", fetcher);
+    GTMSESSION_ASSERT_DEBUG(fetcher.canShareSession, @"Inappropriate shared session: %@", fetcher);
 
     // There should already be a session, from this or a previous fetcher.
     //
@@ -435,16 +414,15 @@ NSString *const kGTMSessionFetcherServiceSessionKey
     NSURLSession *fetcherSession = fetcher.session;
     GTMSESSION_ASSERT_DEBUG(sharedSession != nil, @"Missing delegate session: %@", fetcher);
     GTMSESSION_ASSERT_DEBUG(fetcherSession == sharedSession,
-                            @"Inconsistent session: %@ %@ (shared: %@)",
-                            fetcher, fetcherSession, sharedSession);
+                            @"Inconsistent session: %@ %@ (shared: %@)", fetcher, fetcherSession,
+                            sharedSession);
 
     if (sharedSession != nil && fetcherSession == sharedSession) {
       NSURLSessionTask *task = fetcher.sessionTask;
       GTMSESSION_ASSERT_DEBUG(task != nil, @"Missing session task: %@", fetcher);
 
       if (task) {
-        [delegateDispatcher setFetcher:fetcher
-                               forTask:task];
+        [delegateDispatcher setFetcher:fetcher forTask:task];
       }
     }
   }
@@ -483,15 +461,14 @@ NSString *const kGTMSessionFetcherServiceSessionKey
     NSMutableArray *delayedForHost = [_delayedFetchersByHost objectForKey:host];
     [delayedForHost removeObject:fetcher];
 
-    while (delayedForHost.count > 0
-           && [[self class] numberOfNonBackgroundSessionFetchers:runningForHost]
-              < _maxRunningFetchersPerHost) {
+    while (delayedForHost.count > 0 &&
+           [[self class] numberOfNonBackgroundSessionFetchers:runningForHost] <
+               _maxRunningFetchersPerHost) {
       // Start another delayed fetcher running, scanning for the minimum
       // priority value, defaulting to FIFO for equal priorities
       GTMSessionFetcher *nextFetcher = nil;
       for (GTMSessionFetcher *delayedFetcher in delayedForHost) {
-        if (nextFetcher == nil
-            || delayedFetcher.servicePriority < nextFetcher.servicePriority) {
+        if (nextFetcher == nil || delayedFetcher.servicePriority < nextFetcher.servicePriority) {
           nextFetcher = delayedFetcher;
         }
       }
@@ -566,11 +543,10 @@ NSString *const kGTMSessionFetcherServiceSessionKey
     GTMSessionMonitorSynchronized(self);
 
     NSMutableArray *allFetchers = [NSMutableArray array];
-    void (^accumulateFetchers)(id, id, BOOL *) = ^(NSString *host,
-                                                   NSArray *fetchersForHost,
-                                                   BOOL *stop) {
-        [allFetchers addObjectsFromArray:fetchersForHost];
-    };
+    void (^accumulateFetchers)(id, id, BOOL *) =
+        ^(NSString *host, NSArray *fetchersForHost, BOOL *stop) {
+          [allFetchers addObjectsFromArray:fetchersForHost];
+        };
     [_runningFetchersByHost enumerateKeysAndObjectsUsingBlock:accumulateFetchers];
     [_delayedFetchersByHost enumerateKeysAndObjectsUsingBlock:accumulateFetchers];
 
@@ -589,12 +565,11 @@ NSString *const kGTMSessionFetcherServiceSessionKey
   NSURL *targetURL = [requestURL absoluteURL];
 
   NSArray *allFetchers = [self issuedFetchers];
-  NSIndexSet *indexes = [allFetchers indexesOfObjectsPassingTest:^BOOL(GTMSessionFetcher *fetcher,
-                                                                       NSUInteger idx,
-                                                                       BOOL *stop) {
-      NSURL *fetcherURL = [fetcher.request.URL absoluteURL];
-      return [fetcherURL isEqual:targetURL];
-  }];
+  NSIndexSet *indexes = [allFetchers
+      indexesOfObjectsPassingTest:^BOOL(GTMSessionFetcher *fetcher, NSUInteger idx, BOOL *stop) {
+        NSURL *fetcherURL = [fetcher.request.URL absoluteURL];
+        return [fetcherURL isEqual:targetURL];
+      }];
 
   NSArray *result = nil;
   if (indexes.count > 0) {
@@ -665,9 +640,9 @@ NSString *const kGTMSessionFetcherServiceSessionKey
     if (shouldReuse != wasReusing) {
       [self abandonDispatcher];
       if (shouldReuse) {
-        _delegateDispatcher =
-            [[GTMSessionFetcherSessionDelegateDispatcher alloc] initWithParentService:self
-                                                               sessionDiscardInterval:_unusedSessionTimeout];
+        _delegateDispatcher = [[GTMSessionFetcherSessionDelegateDispatcher alloc]
+             initWithParentService:self
+            sessionDiscardInterval:_unusedSessionTimeout];
       } else {
         _delegateDispatcher = nil;
       }
@@ -693,9 +668,9 @@ NSString *const kGTMSessionFetcherServiceSessionKey
   // The old dispatchers may be retained as delegates of any ongoing sessions by those sessions.
   if (_delegateDispatcher) {
     [self abandonDispatcher];
-    _delegateDispatcher =
-        [[GTMSessionFetcherSessionDelegateDispatcher alloc] initWithParentService:self
-                                                           sessionDiscardInterval:_unusedSessionTimeout];
+    _delegateDispatcher = [[GTMSessionFetcherSessionDelegateDispatcher alloc]
+         initWithParentService:self
+        sessionDiscardInterval:_unusedSessionTimeout];
   }
 }
 
@@ -844,7 +819,7 @@ NSString *const kGTMSessionFetcherServiceSessionKey
   }  // @synchronized(self)
 }
 
-- (NSOperationQueue * GTM_NONNULL_TYPE)sessionDelegateQueue {
+- (NSOperationQueue *GTM_NONNULL_TYPE)sessionDelegateQueue {
   @synchronized(self) {
     GTMSessionMonitorSynchronized(self);
 
@@ -852,7 +827,7 @@ NSString *const kGTMSessionFetcherServiceSessionKey
   }  // @synchronized(self)
 }
 
-- (void)setSessionDelegateQueue:(NSOperationQueue * GTM_NULLABLE_TYPE)queue {
+- (void)setSessionDelegateQueue:(NSOperationQueue *GTM_NULLABLE_TYPE)queue {
   @synchronized(self) {
     GTMSessionMonitorSynchronized(self);
 
@@ -886,8 +861,7 @@ NSString *const kGTMSessionFetcherServiceSessionKey
   NSURL *url = [NSURL URLWithString:@"http://example.invalid"];
   NSHTTPURLResponse *fakedResponse =
       [[NSHTTPURLResponse alloc] initWithURL:url
-                                  statusCode:(fakedErrorOrNil ? 500 : 200)
-                                 HTTPVersion:@"HTTP/1.1"
+                                  statusCode:(fakedErrorOrNil ? 500 : 200)HTTPVersion:@"HTTP/1.1"
                                 headerFields:nil];
   return [self mockFetcherServiceWithFakedData:fakedDataOrNil
                                  fakedResponse:fakedResponse
@@ -904,10 +878,10 @@ NSString *const kGTMSessionFetcherServiceSessionKey
 #if !GTM_DISABLE_FETCHER_TEST_BLOCK
   GTMSessionFetcherService *service = [[self alloc] init];
   service.allowedInsecureSchemes = @[ @"http" ];
-  service.testBlock = ^(GTMSessionFetcher *fetcherToTest,
-                        GTMSessionFetcherTestResponse testResponse) {
-    testResponse(fakedResponse, fakedDataOrNil, fakedErrorOrNil);
-  };
+  service.testBlock =
+      ^(GTMSessionFetcher *fetcherToTest, GTMSessionFetcherTestResponse testResponse) {
+        testResponse(fakedResponse, fakedDataOrNil, fakedErrorOrNil);
+      };
   return service;
 #else
   GTMSESSION_ASSERT_DEBUG(0, @"Test blocks disabled");
@@ -979,8 +953,7 @@ NSString *const kGTMSessionFetcherServiceSessionKey
   NSTimeInterval _discardInterval;
 }
 
-@synthesize discardInterval = _discardInterval,
-            session = _session;
+@synthesize discardInterval = _discardInterval, session = _session;
 
 - (instancetype)init {
   [self doesNotRecognizeSelector:_cmd];
@@ -998,10 +971,9 @@ NSString *const kGTMSessionFetcherServiceSessionKey
 }
 
 - (NSString *)description {
-  return [NSString stringWithFormat:@"%@ %p %@ %@",
-          [self class], self,
-          _session ?: @"<no session>",
-          _taskToFetcherMap.count > 0 ? _taskToFetcherMap : @"<no tasks>"];
+  return
+      [NSString stringWithFormat:@"%@ %p %@ %@", [self class], self, _session ?: @"<no session>",
+                                 _taskToFetcherMap.count > 0 ? _taskToFetcherMap : @"<no tasks>"];
 }
 
 - (NSTimer *)discardTimer {
@@ -1177,10 +1149,9 @@ NSString *const kGTMSessionFetcherServiceSessionKey
 //
 // TODO(seh): How do we route this to an appropriate fetcher?
 
-
 - (void)URLSession:(NSURLSession *)session didBecomeInvalidWithError:(NSError *)error {
-  GTM_LOG_SESSION_DELEGATE(@"%@ %p URLSession:%@ didBecomeInvalidWithError:%@",
-                           [self class], self, session, error);
+  GTM_LOG_SESSION_DELEGATE(@"%@ %p URLSession:%@ didBecomeInvalidWithError:%@", [self class], self,
+                           session, error);
   NSDictionary *localTaskToFetcherMap;
   @synchronized(self) {
     GTMSessionMonitorSynchronized(self);
@@ -1192,30 +1163,28 @@ NSString *const kGTMSessionFetcherServiceSessionKey
 
   // Any "suspended" tasks may not have received callbacks from NSURLSession when the session
   // completes; we'll call them now.
-  [localTaskToFetcherMap enumerateKeysAndObjectsUsingBlock:^(NSURLSessionTask *task,
-                                                             GTMSessionFetcher *fetcher,
-                                                             BOOL *stop) {
+  [localTaskToFetcherMap enumerateKeysAndObjectsUsingBlock:^(
+                             NSURLSessionTask *task, GTMSessionFetcher *fetcher, BOOL *stop) {
     if (fetcher.session == session) {
-        // Our delegate method URLSession:task:didCompleteWithError: will rely on
-        // _taskToFetcherMap so that should still contain this fetcher.
-        NSError *canceledError = [NSError errorWithDomain:NSURLErrorDomain
-                                                     code:NSURLErrorCancelled
-                                                 userInfo:nil];
-        [self URLSession:session task:task didCompleteWithError:canceledError];
-      } else {
-        GTMSESSION_ASSERT_DEBUG(0, @"Unexpected session in fetcher: %@ has %@ (expected %@)",
-                                fetcher, fetcher.session, session);
-      }
+      // Our delegate method URLSession:task:didCompleteWithError: will rely on
+      // _taskToFetcherMap so that should still contain this fetcher.
+      NSError *canceledError = [NSError errorWithDomain:NSURLErrorDomain
+                                                   code:NSURLErrorCancelled
+                                               userInfo:nil];
+      [self URLSession:session task:task didCompleteWithError:canceledError];
+    } else {
+      GTMSESSION_ASSERT_DEBUG(0, @"Unexpected session in fetcher: %@ has %@ (expected %@)", fetcher,
+                              fetcher.session, session);
+    }
   }];
 
   // Our tests rely on this notification to know the session discard timer fired.
-  NSDictionary *userInfo = @{ kGTMSessionFetcherServiceSessionKey : session };
+  NSDictionary *userInfo = @{kGTMSessionFetcherServiceSessionKey : session};
   NSNotificationCenter *nc = [NSNotificationCenter defaultCenter];
   [nc postNotificationName:kGTMSessionFetcherServiceSessionBecameInvalidNotification
                     object:_parentService
                   userInfo:userInfo];
 }
-
 
 #pragma mark - NSURLSessionTaskDelegate
 
@@ -1227,62 +1196,55 @@ NSString *const kGTMSessionFetcherServiceSessionKey
 // delegate is the fetcher or this dispatcher.)
 
 - (void)URLSession:(NSURLSession *)session
-              task:(NSURLSessionTask *)task
-willPerformHTTPRedirection:(NSHTTPURLResponse *)response
-        newRequest:(NSURLRequest *)request
- completionHandler:(void (^)(NSURLRequest *))completionHandler {
+                          task:(NSURLSessionTask *)task
+    willPerformHTTPRedirection:(NSHTTPURLResponse *)response
+                    newRequest:(NSURLRequest *)request
+             completionHandler:(void (^)(NSURLRequest *))completionHandler {
   id<NSURLSessionTaskDelegate> fetcher = [self fetcherForTask:task];
   [fetcher URLSession:session
-                 task:task
-willPerformHTTPRedirection:response
-           newRequest:request
-    completionHandler:completionHandler];
+                            task:task
+      willPerformHTTPRedirection:response
+                      newRequest:request
+               completionHandler:completionHandler];
 }
 
 - (void)URLSession:(NSURLSession *)session
-              task:(NSURLSessionTask *)task
-didReceiveChallenge:(NSURLAuthenticationChallenge *)challenge
- completionHandler:(void (^)(NSURLSessionAuthChallengeDisposition, NSURLCredential *))handler {
+                   task:(NSURLSessionTask *)task
+    didReceiveChallenge:(NSURLAuthenticationChallenge *)challenge
+      completionHandler:(void (^)(NSURLSessionAuthChallengeDisposition, NSURLCredential *))handler {
   id<NSURLSessionTaskDelegate> fetcher = [self fetcherForTask:task];
-  [fetcher URLSession:session
-                 task:task
-  didReceiveChallenge:challenge
-    completionHandler:handler];
+  [fetcher URLSession:session task:task didReceiveChallenge:challenge completionHandler:handler];
 }
 
 - (void)URLSession:(NSURLSession *)session
-              task:(NSURLSessionTask *)task
- needNewBodyStream:(void (^)(NSInputStream *bodyStream))handler {
+                 task:(NSURLSessionTask *)task
+    needNewBodyStream:(void (^)(NSInputStream *bodyStream))handler {
   id<NSURLSessionTaskDelegate> fetcher = [self fetcherForTask:task];
-  [fetcher URLSession:session
-                 task:task
-    needNewBodyStream:handler];
+  [fetcher URLSession:session task:task needNewBodyStream:handler];
 }
 
 - (void)URLSession:(NSURLSession *)session
-              task:(NSURLSessionTask *)task
-   didSendBodyData:(int64_t)bytesSent
-    totalBytesSent:(int64_t)totalBytesSent
-totalBytesExpectedToSend:(int64_t)totalBytesExpectedToSend {
+                        task:(NSURLSessionTask *)task
+             didSendBodyData:(int64_t)bytesSent
+              totalBytesSent:(int64_t)totalBytesSent
+    totalBytesExpectedToSend:(int64_t)totalBytesExpectedToSend {
   id<NSURLSessionTaskDelegate> fetcher = [self fetcherForTask:task];
   [fetcher URLSession:session
-                 task:task
-      didSendBodyData:bytesSent
-       totalBytesSent:totalBytesSent
-totalBytesExpectedToSend:totalBytesExpectedToSend];
+                          task:task
+               didSendBodyData:bytesSent
+                totalBytesSent:totalBytesSent
+      totalBytesExpectedToSend:totalBytesExpectedToSend];
 }
 
 - (void)URLSession:(NSURLSession *)session
-              task:(NSURLSessionTask *)task
-didCompleteWithError:(NSError *)error {
+                    task:(NSURLSessionTask *)task
+    didCompleteWithError:(NSError *)error {
   id<NSURLSessionTaskDelegate> fetcher = [self fetcherForTask:task];
 
   // This is the usual way tasks are removed from the task map.
   [self removeTaskFromMap:task];
 
-  [fetcher URLSession:session
-                 task:task
- didCompleteWithError:error];
+  [fetcher URLSession:session task:task didCompleteWithError:error];
 }
 
 - (void)URLSession:(NSURLSession *)session
@@ -1296,19 +1258,19 @@ didCompleteWithError:(NSError *)error {
 // NSURLSessionDataDelegate protocol methods.
 
 - (void)URLSession:(NSURLSession *)session
-          dataTask:(NSURLSessionDataTask *)dataTask
-didReceiveResponse:(NSURLResponse *)response
- completionHandler:(void (^)(NSURLSessionResponseDisposition))handler {
+              dataTask:(NSURLSessionDataTask *)dataTask
+    didReceiveResponse:(NSURLResponse *)response
+     completionHandler:(void (^)(NSURLSessionResponseDisposition))handler {
   id<NSURLSessionDataDelegate> fetcher = [self fetcherForTask:dataTask];
   [fetcher URLSession:session
-             dataTask:dataTask
-   didReceiveResponse:response
-    completionHandler:handler];
+                dataTask:dataTask
+      didReceiveResponse:response
+       completionHandler:handler];
 }
 
 - (void)URLSession:(NSURLSession *)session
-          dataTask:(NSURLSessionDataTask *)dataTask
-didBecomeDownloadTask:(NSURLSessionDownloadTask *)downloadTask {
+                 dataTask:(NSURLSessionDataTask *)dataTask
+    didBecomeDownloadTask:(NSURLSessionDownloadTask *)downloadTask {
   id<NSURLSessionDataDelegate> fetcher = [self fetcherForTask:dataTask];
   GTMSESSION_ASSERT_DEBUG(fetcher != nil, @"Missing fetcher for %@", dataTask);
   [self removeTaskFromMap:dataTask];
@@ -1318,64 +1280,58 @@ didBecomeDownloadTask:(NSURLSessionDownloadTask *)downloadTask {
     [self setFetcher:(GTMSessionFetcher *)fetcher forTask:downloadTask];
   }
 
-  [fetcher URLSession:session
-             dataTask:dataTask
-didBecomeDownloadTask:downloadTask];
+  [fetcher URLSession:session dataTask:dataTask didBecomeDownloadTask:downloadTask];
 }
 
 - (void)URLSession:(NSURLSession *)session
           dataTask:(NSURLSessionDataTask *)dataTask
     didReceiveData:(NSData *)data {
   id<NSURLSessionDataDelegate> fetcher = [self fetcherForTask:dataTask];
-  [fetcher URLSession:session
-             dataTask:dataTask
-       didReceiveData:data];
+  [fetcher URLSession:session dataTask:dataTask didReceiveData:data];
 }
 
 - (void)URLSession:(NSURLSession *)session
-          dataTask:(NSURLSessionDataTask *)dataTask
- willCacheResponse:(NSCachedURLResponse *)proposedResponse
- completionHandler:(void (^)(NSCachedURLResponse *))handler {
+             dataTask:(NSURLSessionDataTask *)dataTask
+    willCacheResponse:(NSCachedURLResponse *)proposedResponse
+    completionHandler:(void (^)(NSCachedURLResponse *))handler {
   id<NSURLSessionDataDelegate> fetcher = [self fetcherForTask:dataTask];
   [fetcher URLSession:session
-             dataTask:dataTask
-    willCacheResponse:proposedResponse
-    completionHandler:handler];
+               dataTask:dataTask
+      willCacheResponse:proposedResponse
+      completionHandler:handler];
 }
 
 // NSURLSessionDownloadDelegate protocol methods.
 
 - (void)URLSession:(NSURLSession *)session
-      downloadTask:(NSURLSessionDownloadTask *)downloadTask
-didFinishDownloadingToURL:(NSURL *)location {
+                 downloadTask:(NSURLSessionDownloadTask *)downloadTask
+    didFinishDownloadingToURL:(NSURL *)location {
   id<NSURLSessionDownloadDelegate> fetcher = [self fetcherForTask:downloadTask];
-  [fetcher URLSession:session
-         downloadTask:downloadTask
-didFinishDownloadingToURL:location];
+  [fetcher URLSession:session downloadTask:downloadTask didFinishDownloadingToURL:location];
 }
 
 - (void)URLSession:(NSURLSession *)session
-      downloadTask:(NSURLSessionDownloadTask *)downloadTask
-      didWriteData:(int64_t)bytesWritten
- totalBytesWritten:(int64_t)totalWritten
-totalBytesExpectedToWrite:(int64_t)totalExpected {
+                 downloadTask:(NSURLSessionDownloadTask *)downloadTask
+                 didWriteData:(int64_t)bytesWritten
+            totalBytesWritten:(int64_t)totalWritten
+    totalBytesExpectedToWrite:(int64_t)totalExpected {
   id<NSURLSessionDownloadDelegate> fetcher = [self fetcherForTask:downloadTask];
   [fetcher URLSession:session
-         downloadTask:downloadTask
-         didWriteData:bytesWritten
-    totalBytesWritten:totalWritten
-totalBytesExpectedToWrite:totalExpected];
+                   downloadTask:downloadTask
+                   didWriteData:bytesWritten
+              totalBytesWritten:totalWritten
+      totalBytesExpectedToWrite:totalExpected];
 }
 
 - (void)URLSession:(NSURLSession *)session
-      downloadTask:(NSURLSessionDownloadTask *)downloadTask
- didResumeAtOffset:(int64_t)fileOffset
-expectedTotalBytes:(int64_t)expectedTotalBytes {
+          downloadTask:(NSURLSessionDownloadTask *)downloadTask
+     didResumeAtOffset:(int64_t)fileOffset
+    expectedTotalBytes:(int64_t)expectedTotalBytes {
   id<NSURLSessionDownloadDelegate> fetcher = [self fetcherForTask:downloadTask];
   [fetcher URLSession:session
-         downloadTask:downloadTask
-    didResumeAtOffset:fileOffset
-   expectedTotalBytes:expectedTotalBytes];
+            downloadTask:downloadTask
+       didResumeAtOffset:fileOffset
+      expectedTotalBytes:expectedTotalBytes];
 }
 
 @end

--- a/Source/GTMSessionFetchertvOS/GTMSessionFetchertvOS.h
+++ b/Source/GTMSessionFetchertvOS/GTMSessionFetchertvOS.h
@@ -2,11 +2,10 @@
 //  GTMSessionFetchertvOS.h
 //
 
-#import "GTMSessionFetcher.h"
-#import "GTMSessionFetcherService.h"
-#import "GTMSessionUploadFetcher.h"
-#import "GTMSessionFetcherService.h"
-#import "GTMSessionFetcherLogging.h"
 #import "GTMGatherInputStream.h"
 #import "GTMMIMEDocument.h"
 #import "GTMReadMonitorInputStream.h"
+#import "GTMSessionFetcher.h"
+#import "GTMSessionFetcherLogging.h"
+#import "GTMSessionFetcherService.h"
+#import "GTMSessionUploadFetcher.h"

--- a/Source/GTMSessionFetcherwatchOS/GTMSessionFetcherwatchOS.h
+++ b/Source/GTMSessionFetcherwatchOS/GTMSessionFetcherwatchOS.h
@@ -2,11 +2,10 @@
 //  GTMSessionFetcherwatchOS.h
 //
 
-#import "GTMSessionFetcher.h"
-#import "GTMSessionFetcherService.h"
-#import "GTMSessionUploadFetcher.h"
-#import "GTMSessionFetcherService.h"
-#import "GTMSessionFetcherLogging.h"
 #import "GTMGatherInputStream.h"
 #import "GTMMIMEDocument.h"
 #import "GTMReadMonitorInputStream.h"
+#import "GTMSessionFetcher.h"
+#import "GTMSessionFetcherLogging.h"
+#import "GTMSessionFetcherService.h"
+#import "GTMSessionUploadFetcher.h"

--- a/Source/GTMSessionUploadFetcher.h
+++ b/Source/GTMSessionUploadFetcher.h
@@ -68,14 +68,14 @@ extern NSString *const kGTMSessionFetcherUploadLocationObtainedNotification;
 // to its proper value.
 //
 // Pass nil as the data (and optionally an NSError) for a failure.
-typedef void (^GTMSessionUploadFetcherDataProviderResponse)(NSData * GTM_NULLABLE_TYPE data,
+typedef void (^GTMSessionUploadFetcherDataProviderResponse)(NSData *GTM_NULLABLE_TYPE data,
                                                             int64_t fullUploadLength,
-                                                            NSError * GTM_NULLABLE_TYPE error);
+                                                            NSError *GTM_NULLABLE_TYPE error);
 // Do not call the response with an NSData object with less data than the requested length unless
 // you are passing the fullUploadLength to the fetcher for the first time and it is the last chunk
 // of data in the file being uploaded.
-typedef void (^GTMSessionUploadFetcherDataProvider)(int64_t offset, int64_t length,
-    GTMSessionUploadFetcherDataProviderResponse response);
+typedef void (^GTMSessionUploadFetcherDataProvider)(
+    int64_t offset, int64_t length, GTMSessionUploadFetcherDataProviderResponse response);
 
 // Block to be notified about the final status of the cancellation request started in stopFetching.
 //
@@ -83,9 +83,8 @@ typedef void (^GTMSessionUploadFetcherDataProvider)(int64_t offset, int64_t leng
 // going to send a cancel request. If |fetcher| is provided, the other parameters correspond to the
 // completion handler of the cancellation request fetcher.
 typedef void (^GTMSessionUploadFetcherCancellationHandler)(
-    GTMSessionFetcher * GTM_NULLABLE_TYPE fetcher,
-    NSData * GTM_NULLABLE_TYPE data,
-    NSError * GTM_NULLABLE_TYPE error);
+    GTMSessionFetcher *GTM_NULLABLE_TYPE fetcher, NSData *GTM_NULLABLE_TYPE data,
+    NSError *GTM_NULLABLE_TYPE error);
 
 @interface GTMSessionUploadFetcher : GTMSessionFetcher
 
@@ -100,19 +99,22 @@ typedef void (^GTMSessionUploadFetcherCancellationHandler)(
 + (instancetype)uploadFetcherWithRequest:(NSURLRequest *)request
                           uploadMIMEType:(NSString *)uploadMIMEType
                                chunkSize:(int64_t)chunkSize
-                          fetcherService:(GTM_NULLABLE GTMSessionFetcherService *)fetcherServiceOrNil;
+                          fetcherService:
+                              (GTM_NULLABLE GTMSessionFetcherService *)fetcherServiceOrNil;
 
 // Allows cellular access.
-+ (instancetype)uploadFetcherWithLocation:(NSURL * GTM_NULLABLE_TYPE)uploadLocationURL
++ (instancetype)uploadFetcherWithLocation:(NSURL *GTM_NULLABLE_TYPE)uploadLocationURL
                            uploadMIMEType:(NSString *)uploadMIMEType
                                 chunkSize:(int64_t)chunkSize
-                           fetcherService:(GTM_NULLABLE GTMSessionFetcherService *)fetcherServiceOrNil;
+                           fetcherService:
+                               (GTM_NULLABLE GTMSessionFetcherService *)fetcherServiceOrNil;
 
 + (instancetype)uploadFetcherWithLocation:(NSURL *GTM_NULLABLE_TYPE)uploadLocationURL
                            uploadMIMEType:(NSString *)uploadMIMEType
                                 chunkSize:(int64_t)chunkSize
                      allowsCellularAccess:(BOOL)allowsCellularAccess
-                           fetcherService:(GTM_NULLABLE GTMSessionFetcherService *)fetcherServiceOrNil;
+                           fetcherService:
+                               (GTM_NULLABLE GTMSessionFetcherService *)fetcherServiceOrNil;
 
 // Allows dataProviders for files of unknown length. Pass kGTMSessionUploadFetcherUnknownFileSize as
 // |fullLength| if the length is unknown.
@@ -130,7 +132,8 @@ typedef void (^GTMSessionUploadFetcherCancellationHandler)(
 @property(atomic, strong, GTM_NULLABLE) NSData *uploadData;
 @property(atomic, strong, GTM_NULLABLE) NSURL *uploadFileURL;
 @property(atomic, strong, GTM_NULLABLE) NSFileHandle *uploadFileHandle;
-@property(atomic, copy, readonly, GTM_NULLABLE) GTMSessionUploadFetcherDataProvider uploadDataProvider;
+@property(atomic, copy, readonly, GTM_NULLABLE)
+    GTMSessionUploadFetcherDataProvider uploadDataProvider;
 @property(atomic, copy) NSString *uploadMIMEType;
 @property(atomic, readonly, assign) int64_t chunkSize;
 @property(atomic, readonly, assign) int64_t currentOffset;
@@ -157,12 +160,13 @@ typedef void (^GTMSessionUploadFetcherCancellationHandler)(
 // Unlike other callbacks, since this is related specifically to the stopFetching flow it is not
 // cleared by stopFetching. It will instead clear itself after it is invoked or if the completion
 // has occured before stopFetching is called.
-@property(atomic, copy, GTM_NULLABLE) GTMSessionUploadFetcherCancellationHandler
-    cancellationHandler;
+@property(atomic, copy, GTM_NULLABLE)
+    GTMSessionUploadFetcherCancellationHandler cancellationHandler;
 
 // Exposed for testing only.
 @property(atomic, readonly, GTM_NULLABLE) dispatch_queue_t delegateCallbackQueue;
-@property(atomic, readonly, GTM_NULLABLE) GTMSessionFetcherCompletionHandler delegateCompletionHandler;
+@property(atomic, readonly, GTM_NULLABLE)
+    GTMSessionFetcherCompletionHandler delegateCompletionHandler;
 
 @end
 

--- a/Source/GTMSessionUploadFetcher.m
+++ b/Source/GTMSessionUploadFetcher.m
@@ -26,24 +26,25 @@
 #endif
 
 static NSString *const kGTMSessionIdentifierIsUploadChunkFetcherMetadataKey = @"_upChunk";
-static NSString *const kGTMSessionIdentifierUploadFileURLMetadataKey        = @"_upFileURL";
-static NSString *const kGTMSessionIdentifierUploadFileLengthMetadataKey     = @"_upFileLen";
-static NSString *const kGTMSessionIdentifierUploadLocationURLMetadataKey    = @"_upLocURL";
-static NSString *const kGTMSessionIdentifierUploadMIMETypeMetadataKey       = @"_uploadMIME";
-static NSString *const kGTMSessionIdentifierUploadChunkSizeMetadataKey      = @"_upChSize";
-static NSString *const kGTMSessionIdentifierUploadCurrentOffsetMetadataKey  = @"_upOffset";
-static NSString *const kGTMSessionIdentifierUploadAllowsCellularAccess      = @"_upAllowsCellularAccess";
+static NSString *const kGTMSessionIdentifierUploadFileURLMetadataKey = @"_upFileURL";
+static NSString *const kGTMSessionIdentifierUploadFileLengthMetadataKey = @"_upFileLen";
+static NSString *const kGTMSessionIdentifierUploadLocationURLMetadataKey = @"_upLocURL";
+static NSString *const kGTMSessionIdentifierUploadMIMETypeMetadataKey = @"_uploadMIME";
+static NSString *const kGTMSessionIdentifierUploadChunkSizeMetadataKey = @"_upChSize";
+static NSString *const kGTMSessionIdentifierUploadCurrentOffsetMetadataKey = @"_upOffset";
+static NSString *const kGTMSessionIdentifierUploadAllowsCellularAccess = @"_upAllowsCellularAccess";
 
-static NSString *const kGTMSessionHeaderXGoogUploadChunkGranularity = @"X-Goog-Upload-Chunk-Granularity";
-static NSString *const kGTMSessionHeaderXGoogUploadCommand          = @"X-Goog-Upload-Command";
-static NSString *const kGTMSessionHeaderXGoogUploadContentLength    = @"X-Goog-Upload-Content-Length";
-static NSString *const kGTMSessionHeaderXGoogUploadContentType      = @"X-Goog-Upload-Content-Type";
-static NSString *const kGTMSessionHeaderXGoogUploadOffset           = @"X-Goog-Upload-Offset";
-static NSString *const kGTMSessionHeaderXGoogUploadProtocol         = @"X-Goog-Upload-Protocol";
-static NSString *const kGTMSessionXGoogUploadProtocolResumable      = @"resumable";
-static NSString *const kGTMSessionHeaderXGoogUploadSizeReceived     = @"X-Goog-Upload-Size-Received";
-static NSString *const kGTMSessionHeaderXGoogUploadStatus           = @"X-Goog-Upload-Status";
-static NSString *const kGTMSessionHeaderXGoogUploadURL              = @"X-Goog-Upload-URL";
+static NSString *const kGTMSessionHeaderXGoogUploadChunkGranularity =
+    @"X-Goog-Upload-Chunk-Granularity";
+static NSString *const kGTMSessionHeaderXGoogUploadCommand = @"X-Goog-Upload-Command";
+static NSString *const kGTMSessionHeaderXGoogUploadContentLength = @"X-Goog-Upload-Content-Length";
+static NSString *const kGTMSessionHeaderXGoogUploadContentType = @"X-Goog-Upload-Content-Type";
+static NSString *const kGTMSessionHeaderXGoogUploadOffset = @"X-Goog-Upload-Offset";
+static NSString *const kGTMSessionHeaderXGoogUploadProtocol = @"X-Goog-Upload-Protocol";
+static NSString *const kGTMSessionXGoogUploadProtocolResumable = @"resumable";
+static NSString *const kGTMSessionHeaderXGoogUploadSizeReceived = @"X-Goog-Upload-Size-Received";
+static NSString *const kGTMSessionHeaderXGoogUploadStatus = @"X-Goog-Upload-Status";
+static NSString *const kGTMSessionHeaderXGoogUploadURL = @"X-Goog-Upload-URL";
 
 // Property of chunk fetchers identifying the parent upload fetcher.  Non-retained NSValue.
 static NSString *const kGTMSessionUploadFetcherChunkParentKey = @"_uploadFetcherChunkParent";
@@ -53,9 +54,11 @@ int64_t const kGTMSessionUploadFetcherUnknownFileSize = -1;
 int64_t const kGTMSessionUploadFetcherStandardChunkSize = (int64_t)LLONG_MAX;
 
 #if TARGET_OS_IPHONE
-int64_t const kGTMSessionUploadFetcherMaximumDemandBufferSize = 10 * 1024 * 1024;  // 10 MB for iOS, watchOS, tvOS
+int64_t const kGTMSessionUploadFetcherMaximumDemandBufferSize =
+    10 * 1024 * 1024;  // 10 MB for iOS, watchOS, tvOS
 #else
-int64_t const kGTMSessionUploadFetcherMaximumDemandBufferSize = 100 * 1024 * 1024;  // 100 MB for macOS
+int64_t const kGTMSessionUploadFetcherMaximumDemandBufferSize =
+    100 * 1024 * 1024;  // 100 MB for macOS
 #endif
 
 typedef NS_ENUM(NSUInteger, GTMSessionUploadFetcherStatus) {
@@ -99,7 +102,8 @@ NSString *const kGTMSessionFetcherUploadLocationObtainedNotification =
 @property(atomic, readwrite, assign) int64_t currentOffset;
 
 // Internal properties.
-@property(strong, atomic, GTM_NULLABLE) GTMSessionFetcher *fetcherInFlight;  // Synchronized on self.
+@property(strong, atomic, GTM_NULLABLE)
+    GTMSessionFetcher *fetcherInFlight;  // Synchronized on self.
 
 @property(assign, atomic, getter=isSubdataGenerating) BOOL subdataGenerating;
 @property(assign, atomic) BOOL shouldInitiateOffsetQuery;
@@ -197,7 +201,8 @@ NSString *const kGTMSessionFetcherUploadLocationObtainedNotification =
 + (instancetype)uploadFetcherWithLocation:(NSURL *GTM_NULLABLE_TYPE)uploadLocationURL
                            uploadMIMEType:(NSString *)uploadMIMEType
                                 chunkSize:(int64_t)chunkSize
-                           fetcherService:(GTM_NULLABLE GTMSessionFetcherService *)fetcherServiceOrNil {
+                           fetcherService:
+                               (GTM_NULLABLE GTMSessionFetcherService *)fetcherServiceOrNil {
   return [self uploadFetcherWithLocation:uploadLocationURL
                           uploadMIMEType:uploadMIMEType
                                chunkSize:chunkSize
@@ -247,8 +252,7 @@ NSString *const kGTMSessionFetcherUploadLocationObtainedNotification =
   NSURL *uploadLocationURL =
       uploadLocationURLString ? [NSURL URLWithString:uploadLocationURLString] : nil;
 
-  NSString *uploadMIMEType =
-      metadata[kGTMSessionIdentifierUploadMIMETypeMetadataKey];
+  NSString *uploadMIMEType = metadata[kGTMSessionIdentifierUploadMIMETypeMetadataKey];
   int64_t uploadChunkSize =
       [metadata[kGTMSessionIdentifierUploadChunkSizeMetadataKey] longLongValue];
   if (uploadChunkSize <= 0) {
@@ -263,8 +267,8 @@ NSString *const kGTMSessionFetcherUploadLocationObtainedNotification =
   }
 
   GTMSESSION_ASSERT_DEBUG(currentOffset <= uploadFileLength,
-                          @"CurrentOffset (%lld) exceeds UploadFileSize (%lld)",
-                          currentOffset, uploadFileLength);
+                          @"CurrentOffset (%lld) exceeds UploadFileSize (%lld)", currentOffset,
+                          uploadFileLength);
   if (currentOffset > uploadFileLength) return nil;
 
   GTMSessionUploadFetcher *uploadFetcher = [self uploadFetcherWithLocation:uploadLocationURL
@@ -289,8 +293,7 @@ NSString *const kGTMSessionFetcherUploadLocationObtainedNotification =
   // Internal utility method for instantiating fetchers
   GTMSessionUploadFetcher *fetcher;
   if ([fetcherService isKindOfClass:[GTMSessionFetcherService class]]) {
-    fetcher = [fetcherService fetcherWithRequest:request
-                                    fetcherClass:self];
+    fetcher = [fetcherService fetcherWithRequest:request fetcherClass:self];
   } else {
     fetcher = [self fetcherWithRequest:request];
   }
@@ -348,7 +351,8 @@ NSString *const kGTMSessionFetcherUploadLocationObtainedNotification =
     if (sessionIdentifierMetadata == nil) {
       continue;
     }
-    if (![sessionIdentifierMetadata[kGTMSessionIdentifierIsUploadChunkFetcherMetadataKey] boolValue]) {
+    if (![sessionIdentifierMetadata[kGTMSessionIdentifierIsUploadChunkFetcherMetadataKey]
+            boolValue]) {
       continue;
     }
     GTMSessionUploadFetcher *uploadFetcher =
@@ -366,8 +370,8 @@ NSString *const kGTMSessionFetcherUploadLocationObtainedNotification =
         [fetcher completionHandlerWithTarget:uploadFetcher
                            didFinishSelector:@selector(chunkFetcher:finishedWithData:error:)];
 
-    GTMSESSION_LOG_DEBUG(@"%@ restoring upload fetcher %@ for chunk fetcher %@",
-                         [self class], uploadFetcher, fetcher);
+    GTMSESSION_LOG_DEBUG(@"%@ restoring upload fetcher %@ for chunk fetcher %@", [self class],
+                         uploadFetcher, fetcher);
   }
   return uploadFetchers;
 }
@@ -474,7 +478,6 @@ NSString *const kGTMSessionFetcherUploadLocationObtainedNotification =
   }
 }
 
-
 - (void)setUploadMIMEType:(NSString *)uploadMIMEType {
   GTMSESSION_ASSERT_DEBUG(0, @"TODO: disallow setUploadMIMEType by making declaration readonly");
   // (and uploadMIMEType, chunksize, currentOffset)
@@ -513,9 +516,9 @@ NSString *const kGTMSessionFetcherUploadLocationObtainedNotification =
     int hasFileURL = (_uploadFileURL != nil) ? 1 : 0;
     int hasUploadDataProvider = (_uploadDataProvider != nil) ? 1 : 0;
     int numberOfSources = hasData + hasFileHandle + hasFileURL + hasUploadDataProvider;
-    #pragma unused(numberOfSources)
-    GTMSESSION_ASSERT_DEBUG(numberOfSources == 1,
-                            @"Need just one upload source (%d)", numberOfSources);
+#pragma unused(numberOfSources)
+    GTMSESSION_ASSERT_DEBUG(numberOfSources == 1, @"Need just one upload source (%d)",
+                            numberOfSources);
   }  // @synchronized(self)
 #endif
 
@@ -529,8 +532,7 @@ NSString *const kGTMSessionFetcherUploadLocationObtainedNotification =
 
   [mutableRequest setValue:kGTMSessionXGoogUploadProtocolResumable
         forHTTPHeaderField:kGTMSessionHeaderXGoogUploadProtocol];
-  [mutableRequest setValue:@"start"
-        forHTTPHeaderField:kGTMSessionHeaderXGoogUploadCommand];
+  [mutableRequest setValue:@"start" forHTTPHeaderField:kGTMSessionHeaderXGoogUploadCommand];
   [mutableRequest setValue:_uploadMIMEType
         forHTTPHeaderField:kGTMSessionHeaderXGoogUploadContentType];
   [mutableRequest setValue:@([self fullUploadLength]).stringValue
@@ -546,8 +548,7 @@ NSString *const kGTMSessionFetcherUploadLocationObtainedNotification =
   // we need to make a bug fix in the client that the server can recognize.
   NSString *const kUserAgentStub = @"(GTMSUF/1)";
   NSString *userAgent = [mutableRequest valueForHTTPHeaderField:@"User-Agent"];
-  if (userAgent == nil
-      || [userAgent rangeOfString:kUserAgentStub].location == NSNotFound) {
+  if (userAgent == nil || [userAgent rangeOfString:kUserAgentStub].location == NSNotFound) {
     if (userAgent.length == 0) {
       userAgent = GTMFetcherStandardUserAgentString(nil);
     }
@@ -609,8 +610,8 @@ NSString *const kGTMSessionFetcherUploadLocationObtainedNotification =
                                          error:&valueError]) {
             _uploadFileLength = filesizeNum.longLongValue;
           } else {
-            GTMSESSION_ASSERT_DEBUG(NO, @"Cannot get file size: %@\n  %@",
-                                    valueError, _uploadFileURL.path);
+            GTMSESSION_ASSERT_DEBUG(NO, @"Cannot get file size: %@\n  %@", valueError,
+                                    _uploadFileURL.path);
             _uploadFileLength = 0;
           }
         }
@@ -641,12 +642,12 @@ NSString *const kGTMSessionFetcherUploadLocationObtainedNotification =
       int64_t dataLength = (int64_t)uploadData.length;
       // Ensure our range is valid.  b/18007814
       if (offset + length > dataLength) {
-        NSString *errorMessage = [NSString stringWithFormat:
-                                  @"Range invalid for upload data.  offset: %lld\tlength: %lld\tdataLength: %lld",
-                                  offset, length, dataLength];
+        NSString *errorMessage = [NSString
+            stringWithFormat:
+                @"Range invalid for upload data.  offset: %lld\tlength: %lld\tdataLength: %lld",
+                offset, length, dataLength];
         GTMSESSION_ASSERT_DEBUG(NO, @"%@", errorMessage);
-        response(nil,
-                 kGTMSessionUploadFetcherUnknownFileSize,
+        response(nil, kGTMSessionUploadFetcherUnknownFileSize,
                  [self uploadChunkUnavailableErrorWithDescription:errorMessage]);
         return;
       }
@@ -654,12 +655,10 @@ NSString *const kGTMSessionFetcherUploadLocationObtainedNotification =
 
       @try {
         resultData = [uploadData subdataWithRange:range];
-      }
-      @catch (NSException *exception) {
+      } @catch (NSException *exception) {
         NSString *errorMessage = exception.description;
         GTMSESSION_ASSERT_DEBUG(NO, @"%@", errorMessage);
-        response(nil,
-                 kGTMSessionUploadFetcherUnknownFileSize,
+        response(nil, kGTMSessionUploadFetcherUnknownFileSize,
                  [self uploadChunkUnavailableErrorWithDescription:errorMessage]);
         return;
       }
@@ -696,8 +695,7 @@ NSString *const kGTMSessionFetcherUploadLocationObtainedNotification =
   @try {
     [fileHandle seekToFileOffset:(unsigned long long)offset];
     resultData = [fileHandle readDataOfLength:(NSUInteger)length];
-  }
-  @catch (NSException *exception) {
+  } @catch (NSException *exception) {
     GTMSESSION_ASSERT_DEBUG(NO, @"uploadFileHandle failed to read, %@", exception);
     error = [self uploadChunkUnavailableErrorWithDescription:exception.description];
   }
@@ -748,8 +746,7 @@ NSString *const kGTMSessionFetcherUploadLocationObtainedNotification =
                          hasFileSize ? fileSizeNum : @"unknown", error);
 #endif
 
-    NSFileHandle *fileHandle = [NSFileHandle fileHandleForReadingFromURL:fileURL
-                                                                   error:&error];
+    NSFileHandle *fileHandle = [NSFileHandle fileHandleForReadingFromURL:fileURL error:&error];
     if (fileHandle != nil) {
       [self generateChunkSubdataFromFileHandle:fileHandle
                                         offset:offset
@@ -762,12 +759,12 @@ NSString *const kGTMSessionFetcherUploadLocationObtainedNotification =
   } else {
     // Successfully created an NSData by memory-mapping the file.
     if ((NSUInteger)(offset + length) > mappedData.length) {
-      NSString *errorMessage = [NSString stringWithFormat:
-                                @"Range invalid for upload data.  offset: %lld\tlength: %lld\tdataLength: %lld\texpected UploadLength: %lld",
-                                offset, length, (long long)mappedData.length, fullUploadLength];
+      NSString *errorMessage = [NSString
+          stringWithFormat:@"Range invalid for upload data.  offset: %lld\tlength: "
+                           @"%lld\tdataLength: %lld\texpected UploadLength: %lld",
+                           offset, length, (long long)mappedData.length, fullUploadLength];
       GTMSESSION_ASSERT_DEBUG(NO, @"%@", errorMessage);
-      response(nil,
-               kGTMSessionUploadFetcherUnknownFileSize,
+      response(nil, kGTMSessionUploadFetcherUnknownFileSize,
                [self uploadChunkUnavailableErrorWithDescription:errorMessage]);
       return;
     }
@@ -785,7 +782,7 @@ NSString *const kGTMSessionFetcherUploadLocationObtainedNotification =
 - (NSError *)uploadChunkUnavailableErrorWithDescription:(NSString *)description {
   // The description in the userInfo is intended as a clue to programmers, not
   // for client code to examine or rely on.
-  NSDictionary *userInfo = @{ @"description" : description };
+  NSDictionary *userInfo = @{@"description" : description};
   return [NSError errorWithDomain:kGTMSessionFetcherErrorDomain
                              code:GTMSessionFetcherErrorUploadChunkUnavailable
                          userInfo:userInfo];
@@ -849,7 +846,7 @@ NSString *const kGTMSessionFetcherUploadLocationObtainedNotification =
   }
 }
 
-- (GTMSessionFetcher * GTM_NULLABLE_TYPE)chunkFetcher {
+- (GTMSessionFetcher *GTM_NULLABLE_TYPE)chunkFetcher {
   @synchronized(self) {
     GTMSessionMonitorSynchronized(self);
 
@@ -857,7 +854,7 @@ NSString *const kGTMSessionFetcherUploadLocationObtainedNotification =
   }
 }
 
-- (void)setChunkFetcher:(GTMSessionFetcher * GTM_NULLABLE_TYPE)fetcher {
+- (void)setChunkFetcher:(GTMSessionFetcher *GTM_NULLABLE_TYPE)fetcher {
   @synchronized(self) {
     GTMSessionMonitorSynchronized(self);
 
@@ -865,7 +862,7 @@ NSString *const kGTMSessionFetcherUploadLocationObtainedNotification =
   }
 }
 
-- (void)setFetcherInFlight:(GTMSessionFetcher * GTM_NULLABLE_TYPE)fetcher {
+- (void)setFetcherInFlight:(GTMSessionFetcher *GTM_NULLABLE_TYPE)fetcher {
   @synchronized(self) {
     GTMSessionMonitorSynchronized(self);
 
@@ -873,7 +870,7 @@ NSString *const kGTMSessionFetcherUploadLocationObtainedNotification =
   }
 }
 
-- (GTMSessionFetcher * GTM_NULLABLE_TYPE)fetcherInFlight {
+- (GTMSessionFetcher *GTM_NULLABLE_TYPE)fetcherInFlight {
   @synchronized(self) {
     GTMSessionMonitorSynchronized(self);
 
@@ -881,8 +878,8 @@ NSString *const kGTMSessionFetcherUploadLocationObtainedNotification =
   }
 }
 
-- (void)setCancellationHandler:(GTMSessionUploadFetcherCancellationHandler GTM_NULLABLE_TYPE)
-    cancellationHandler {
+- (void)setCancellationHandler:
+    (GTMSessionUploadFetcherCancellationHandler GTM_NULLABLE_TYPE)cancellationHandler {
   @synchronized(self) {
     GTMSessionMonitorSynchronized(self);
 
@@ -948,9 +945,7 @@ NSString *const kGTMSessionFetcherUploadLocationObtainedNotification =
         [self beginChunkFetches];
       } else {
         if ([self retryTimer] == nil) {
-          [self invokeFinalCallbackWithData:nil
-                                      error:error
-                   shouldInvalidateLocation:YES];
+          [self invokeFinalCallbackWithData:nil error:error shouldInvalidateLocation:YES];
         }
       }
     } else {
@@ -959,20 +954,19 @@ NSString *const kGTMSessionFetcherUploadLocationObtainedNotification =
       // is never used, so at this point we call the user's actual completion
       // block.
       if (!hasTestBlock) {
-        [self invokeFinalCallbackWithData:data
-                                    error:error
-                 shouldInvalidateLocation:YES];
+        [self invokeFinalCallbackWithData:data error:error shouldInvalidateLocation:YES];
       } else {
         // There was a test block, so we won't do chunk fetches, but we simulate obtaining
         // the data to be uploaded from the upload data provider block or the file handle,
         // and then call back.
         [self generateChunkSubdataWithOffset:0
                                       length:[self fullUploadLength]
-                                    response:^(NSData *generateData, int64_t fullUploadLength, NSError *generateError) {
-            [self invokeFinalCallbackWithData:data
-                                        error:error
-                     shouldInvalidateLocation:YES];
-        }];
+                                    response:^(NSData *generateData, int64_t fullUploadLength,
+                                               NSError *generateError) {
+                                      [self invokeFinalCallbackWithData:data
+                                                                  error:error
+                                               shouldInvalidateLocation:YES];
+                                    }];
       }
     }
   }];
@@ -990,9 +984,8 @@ NSString *const kGTMSessionFetcherUploadLocationObtainedNotification =
   // resumable request/response.
   if (self.downloadedData.length > 0) {
     NSData *downloadedData = self.downloadedData;
-    NSString *str = [[NSString alloc] initWithData:downloadedData
-                                          encoding:NSUTF8StringEncoding];
-    #pragma unused(str)
+    NSString *str = [[NSString alloc] initWithData:downloadedData encoding:NSUTF8StringEncoding];
+#pragma unused(str)
     GTMSESSION_ASSERT_DEBUG(NO, @"unexpected response data (uploading to the wrong URL?)\n%@", str);
   }
 #endif
@@ -1005,7 +998,8 @@ NSString *const kGTMSessionFetcherUploadLocationObtainedNotification =
   GTMSessionUploadFetcherStatus uploadStatus =
       [[self class] uploadStatusFromResponseHeaders:responseHeaders];
   GTMSESSION_ASSERT_DEBUG(uploadStatus != kStatusUnknown,
-      @"beginChunkFetches has unexpected upload status for headers %@", responseHeaders);
+                          @"beginChunkFetches has unexpected upload status for headers %@",
+                          responseHeaders);
 
   BOOL isPrematureStop = (uploadStatus == kStatusFinal) || (uploadStatus == kStatusCancelled);
 
@@ -1014,26 +1008,24 @@ NSString *const kGTMSessionFetcherUploadLocationObtainedNotification =
 
   if (isPrematureStop || !hasUploadLocation) {
     GTMSESSION_ASSERT_DEBUG(NO, @"Premature failure: upload-status:\"%@\"  location:%@",
-        [responseHeaders objectForKey:kGTMSessionHeaderXGoogUploadStatus], uploadLocationURLStr);
+                            [responseHeaders objectForKey:kGTMSessionHeaderXGoogUploadStatus],
+                            uploadLocationURLStr);
     // We cannot continue since we do not know the location to use
     // as our upload destination.
     NSDictionary *userInfo = nil;
     NSData *downloadedData = self.downloadedData;
     if (downloadedData.length > 0) {
-      userInfo = @{ kGTMSessionFetcherStatusDataKey : downloadedData };
+      userInfo = @{kGTMSessionFetcherStatusDataKey : downloadedData};
     }
     NSError *failureError = [self prematureFailureErrorWithUserInfo:userInfo];
-    [self invokeFinalCallbackWithData:nil
-                                error:failureError
-             shouldInvalidateLocation:YES];
+    [self invokeFinalCallbackWithData:nil error:failureError shouldInvalidateLocation:YES];
     return;
   }
 
   self.uploadLocationURL = [NSURL URLWithString:uploadLocationURLStr];
 
   NSNotificationCenter *nc = [NSNotificationCenter defaultCenter];
-  [nc postNotificationName:kGTMSessionFetcherUploadLocationObtainedNotification
-                    object:self];
+  [nc postNotificationName:kGTMSessionFetcherUploadLocationObtainedNotification object:self];
 
   // we've now sent all of the initial post body data, so we need to include
   // its size in future progress indicator callbacks
@@ -1046,9 +1038,9 @@ NSString *const kGTMSessionFetcherUploadLocationObtainedNotification =
 }
 
 - (void)URLSession:(NSURLSession *)session
-              task:(NSURLSessionTask *)task
-   didSendBodyData:(int64_t)bytesSent
-    totalBytesSent:(int64_t)totalBytesSent
+                        task:(NSURLSessionTask *)task
+             didSendBodyData:(int64_t)bytesSent
+              totalBytesSent:(int64_t)totalBytesSent
     totalBytesExpectedToSend:(int64_t)totalBytesExpectedToSend {
   // Overrides the superclass.
   [self invokeDelegateWithDidSendBytes:bytesSent
@@ -1083,8 +1075,8 @@ NSString *const kGTMSessionFetcherUploadLocationObtainedNotification =
       [self invokeOnCallbackQueue:queue
                  afterUserStopped:NO
                             block:^{
-          handler(data, error);
-      }];
+                              handler(data, error);
+                            }];
     }
   }  // @synchronized(self)
 
@@ -1130,18 +1122,16 @@ NSString *const kGTMSessionFetcherUploadLocationObtainedNotification =
   // use the properties in each chunk fetcher
   NSDictionary *props = [self properties];
 
-  [self uploadNextChunkWithOffset:offset
-                fetcherProperties:props];
+  [self uploadNextChunkWithOffset:offset fetcherProperties:props];
 }
 
 - (void)sendQueryForUploadOffsetWithFetcherProperties:(NSDictionary *)props {
-  GTMSessionFetcher *queryFetcher = [self uploadFetcherWithProperties:props
-                                                         isQueryFetch:YES];
+  GTMSessionFetcher *queryFetcher = [self uploadFetcherWithProperties:props isQueryFetch:YES];
   queryFetcher.bodyData = [NSData data];
 
   NSString *originalComment = self.comment;
-  [queryFetcher setCommentWithFormat:@"%@ (query offset)",
-   originalComment ? originalComment : @"upload"];
+  [queryFetcher
+      setCommentWithFormat:@"%@ (query offset)", originalComment ? originalComment : @"upload"];
 
   [queryFetcher setRequestValue:@"query" forHTTPHeaderField:kGTMSessionHeaderXGoogUploadCommand];
 
@@ -1161,7 +1151,8 @@ NSString *const kGTMSessionFetcherUploadLocationObtainedNotification =
   GTMSessionUploadFetcherStatus uploadStatus =
       [[self class] uploadStatusFromResponseHeaders:responseHeaders];
   GTMSESSION_ASSERT_DEBUG(uploadStatus != kStatusUnknown || error != nil,
-      @"query fetcher completion has unexpected upload status for headers %@", responseHeaders);
+                          @"query fetcher completion has unexpected upload status for headers %@",
+                          responseHeaders);
 
   if (error == nil) {
     sizeReceivedHeader = [responseHeaders objectForKey:kGTMSessionHeaderXGoogUploadSizeReceived];
@@ -1170,7 +1161,7 @@ NSString *const kGTMSessionFetcherUploadLocationObtainedNotification =
         (uploadStatus == kStatusActive && sizeReceivedHeader == nil)) {
       NSDictionary *userInfo = nil;
       if (data.length > 0) {
-        userInfo = @{ kGTMSessionFetcherStatusDataKey : data };
+        userInfo = @{kGTMSessionFetcherStatusDataKey : data};
       }
       error = [self prematureFailureErrorWithUserInfo:userInfo];
     }
@@ -1198,32 +1189,30 @@ NSString *const kGTMSessionFetcherUploadLocationObtainedNotification =
   @synchronized(self) {
     _isCancelInFlight = YES;
   }
-  GTMSessionFetcher *cancelFetcher = [self uploadFetcherWithProperties:props
-                                                          isQueryFetch:YES];
+  GTMSessionFetcher *cancelFetcher = [self uploadFetcherWithProperties:props isQueryFetch:YES];
   cancelFetcher.bodyData = [NSData data];
 
   NSString *originalComment = self.comment;
-  [cancelFetcher setCommentWithFormat:@"%@ (cancel)",
-      originalComment ? originalComment : @"upload"];
+  [cancelFetcher
+      setCommentWithFormat:@"%@ (cancel)", originalComment ? originalComment : @"upload"];
 
   [cancelFetcher setRequestValue:@"cancel" forHTTPHeaderField:kGTMSessionHeaderXGoogUploadCommand];
 
   self.fetcherInFlight = cancelFetcher;
   [cancelFetcher beginFetchWithCompletionHandler:^(NSData *data, NSError *error) {
-      self.fetcherInFlight = nil;
-      if (![self triggerCancellationHandlerForFetch:cancelFetcher data:data error:error]) {
-        if (error) {
-          GTMSESSION_LOG_DEBUG(@"cancelFetcher %@", error);
-        }
+    self.fetcherInFlight = nil;
+    if (![self triggerCancellationHandlerForFetch:cancelFetcher data:data error:error]) {
+      if (error) {
+        GTMSESSION_LOG_DEBUG(@"cancelFetcher %@", error);
       }
-      @synchronized(self) {
-        self->_isCancelInFlight = NO;
-      }
+    }
+    @synchronized(self) {
+      self->_isCancelInFlight = NO;
+    }
   }];
 }
 
-- (void)uploadNextChunkWithOffset:(int64_t)offset
-                fetcherProperties:(NSDictionary *)props {
+- (void)uploadNextChunkWithOffset:(int64_t)offset fetcherProperties:(NSDictionary *)props {
   GTMSessionCheckNotSynchronized(self);
 
   // Example chunk headers:
@@ -1235,93 +1224,96 @@ NSString *const kGTMSessionFetcherUploadLocationObtainedNotification =
   //  {bytes 0-1999999}
 
   // The chunk upload URL requires no authentication header.
-  GTMSessionFetcher *chunkFetcher = [self uploadFetcherWithProperties:props
-                                                         isQueryFetch:NO];
+  GTMSessionFetcher *chunkFetcher = [self uploadFetcherWithProperties:props isQueryFetch:NO];
   [self attachSendProgressBlockToChunkFetcher:chunkFetcher];
-  int64_t chunkSize = [self updateChunkFetcher:chunkFetcher
-                              forChunkAtOffset:offset];
+  int64_t chunkSize = [self updateChunkFetcher:chunkFetcher forChunkAtOffset:offset];
   BOOL isUploadingFileURL = (self.uploadFileURL != nil);
   int64_t fullUploadLength = [self fullUploadLength];
 
   // The chunk size may have changed, so determine again if we're uploading the full file.
-  BOOL isUploadingFullFile = (offset == 0 &&
-                              fullUploadLength != kGTMSessionUploadFetcherUnknownFileSize &&
-                              chunkSize >= fullUploadLength);
+  BOOL isUploadingFullFile =
+      (offset == 0 && fullUploadLength != kGTMSessionUploadFetcherUnknownFileSize &&
+       chunkSize >= fullUploadLength);
   if (isUploadingFullFile && isUploadingFileURL) {
     // The data is the full upload file URL.
     chunkFetcher.bodyFileURL = self.uploadFileURL;
-    [self beginChunkFetcher:chunkFetcher
-                     offset:offset];
+    [self beginChunkFetcher:chunkFetcher offset:offset];
   } else {
     // Make an NSData for the subset for this upload chunk.
     self.subdataGenerating = YES;
     [self generateChunkSubdataWithOffset:offset
                                   length:chunkSize
-                                response:^(NSData *chunkData, int64_t uploadFileLength, NSError *chunkError) {
-      // The subdata methods may leave us on a background thread.
-      dispatch_async(dispatch_get_main_queue(), ^{
-        self.subdataGenerating = NO;
+                                response:^(NSData *chunkData, int64_t uploadFileLength,
+                                           NSError *chunkError) {
+                                  // The subdata methods may leave us on a background thread.
+                                  dispatch_async(dispatch_get_main_queue(), ^{
+                                    self.subdataGenerating = NO;
 
-        // dont allow the updating of fileLength for uploads not using a data provider as they
-        // should know the file length before the upload starts.
-        if (self->_uploadDataProvider != nil && uploadFileLength > 0) {
-          [self setUploadFileLength:uploadFileLength];
-          // Update the command and content-length headers if this is the last chunk to be sent.
-          if (offset + chunkSize >= uploadFileLength) {
-            int64_t updatedChunkSize = [self updateChunkFetcher:chunkFetcher
-                                               forChunkAtOffset:offset];
-            if (updatedChunkSize == 0) {
-              // Calling beginChunkFetcher early when there is no more data to send allows us to
-              // properly handle nil chunkData below without having to account for the case where
-              // we are just finalizing the file.
-              chunkFetcher.bodyData = [[NSData alloc] init];
-              [self beginChunkFetcher:chunkFetcher
-                               offset:offset];
-              return;
-            }
-          }
-        }
+                                    // dont allow the updating of fileLength for uploads not using a
+                                    // data provider as they should know the file length before the
+                                    // upload starts.
+                                    if (self->_uploadDataProvider != nil && uploadFileLength > 0) {
+                                      [self setUploadFileLength:uploadFileLength];
+                                      // Update the command and content-length headers if this is
+                                      // the last chunk to be sent.
+                                      if (offset + chunkSize >= uploadFileLength) {
+                                        int64_t updatedChunkSize =
+                                            [self updateChunkFetcher:chunkFetcher
+                                                    forChunkAtOffset:offset];
+                                        if (updatedChunkSize == 0) {
+                                          // Calling beginChunkFetcher early when there is no more
+                                          // data to send allows us to properly handle nil chunkData
+                                          // below without having to account for the case where we
+                                          // are just finalizing the file.
+                                          chunkFetcher.bodyData = [[NSData alloc] init];
+                                          [self beginChunkFetcher:chunkFetcher offset:offset];
+                                          return;
+                                        }
+                                      }
+                                    }
 
-        if (chunkData == nil) {
-          NSError *responseError = chunkError;
-          if (!responseError) {
-            responseError = [self uploadChunkUnavailableErrorWithDescription:@"chunkData is nil"];
-          }
-          [self invokeFinalCallbackWithData:nil
-                                      error:responseError
-                   shouldInvalidateLocation:YES];
-          return;
-        }
+                                    if (chunkData == nil) {
+                                      NSError *responseError = chunkError;
+                                      if (!responseError) {
+                                        responseError =
+                                            [self uploadChunkUnavailableErrorWithDescription:
+                                                      @"chunkData is nil"];
+                                      }
+                                      [self invokeFinalCallbackWithData:nil
+                                                                  error:responseError
+                                               shouldInvalidateLocation:YES];
+                                      return;
+                                    }
 
-        BOOL didWriteFile = NO;
-        if (isUploadingFileURL) {
-          // Make a temporary file with the data subset.
-          NSString *tempName =
-              [NSString stringWithFormat:@"GTMUpload_temp_%@", [[NSUUID UUID] UUIDString]];
-          NSString *tempPath = [NSTemporaryDirectory() stringByAppendingPathComponent:tempName];
-          NSError *writeError;
-          didWriteFile = [chunkData writeToFile:tempPath
-                                        options:NSDataWritingAtomic
-                                          error:&writeError];
-          if (didWriteFile) {
-            chunkFetcher.bodyFileURL = [NSURL fileURLWithPath:tempPath];
-          } else {
-            GTMSESSION_LOG_DEBUG(@"writeToFile failed: %@\n%@", writeError, tempPath);
-          }
-        }
-        if (!didWriteFile) {
-          chunkFetcher.bodyData = [chunkData copy];
-        }
-        [self beginChunkFetcher:chunkFetcher
-                         offset:offset];
-      });
-    }];
+                                    BOOL didWriteFile = NO;
+                                    if (isUploadingFileURL) {
+                                      // Make a temporary file with the data subset.
+                                      NSString *tempName =
+                                          [NSString stringWithFormat:@"GTMUpload_temp_%@",
+                                                                     [[NSUUID UUID] UUIDString]];
+                                      NSString *tempPath = [NSTemporaryDirectory()
+                                          stringByAppendingPathComponent:tempName];
+                                      NSError *writeError;
+                                      didWriteFile = [chunkData writeToFile:tempPath
+                                                                    options:NSDataWritingAtomic
+                                                                      error:&writeError];
+                                      if (didWriteFile) {
+                                        chunkFetcher.bodyFileURL = [NSURL fileURLWithPath:tempPath];
+                                      } else {
+                                        GTMSESSION_LOG_DEBUG(@"writeToFile failed: %@\n%@",
+                                                             writeError, tempPath);
+                                      }
+                                    }
+                                    if (!didWriteFile) {
+                                      chunkFetcher.bodyData = [chunkData copy];
+                                    }
+                                    [self beginChunkFetcher:chunkFetcher offset:offset];
+                                  });
+                                }];
   }
 }
 
-- (void)beginChunkFetcher:(GTMSessionFetcher *)chunkFetcher
-                   offset:(int64_t)offset {
-
+- (void)beginChunkFetcher:(GTMSessionFetcher *)chunkFetcher offset:(int64_t)offset {
   // Track the current offset for progress reporting
   self.currentOffset = offset;
 
@@ -1339,18 +1331,18 @@ NSString *const kGTMSessionFetcherUploadLocationObtainedNotification =
 }
 
 - (void)attachSendProgressBlockToChunkFetcher:(GTMSessionFetcher *)chunkFetcher {
-  chunkFetcher.sendProgressBlock = ^(int64_t bytesSent, int64_t totalBytesSent,
-                                     int64_t totalBytesExpectedToSend) {
-    // The total bytes expected include the initial body and the full chunked
-    // data, independent of how big this fetcher's chunk is.
-    int64_t initialBodySent = [self bodyLength];  // TODO(grobbins) use [self initialBodySent]
-    int64_t totalSent = initialBodySent + self.currentOffset + totalBytesSent;
-    int64_t totalExpected = initialBodySent + [self fullUploadLength];
+  chunkFetcher.sendProgressBlock =
+      ^(int64_t bytesSent, int64_t totalBytesSent, int64_t totalBytesExpectedToSend) {
+        // The total bytes expected include the initial body and the full chunked
+        // data, independent of how big this fetcher's chunk is.
+        int64_t initialBodySent = [self bodyLength];  // TODO(grobbins) use [self initialBodySent]
+        int64_t totalSent = initialBodySent + self.currentOffset + totalBytesSent;
+        int64_t totalExpected = initialBodySent + [self fullUploadLength];
 
-    [self invokeDelegateWithDidSendBytes:bytesSent
-                          totalBytesSent:totalSent
-                totalBytesExpectedToSend:totalExpected];
-  };
+        [self invokeDelegateWithDidSendBytes:bytesSent
+                              totalBytesSent:totalSent
+                    totalBytesExpectedToSend:totalExpected];
+      };
 }
 
 - (NSDictionary *)uploadSessionIdentifierMetadata {
@@ -1433,28 +1425,28 @@ NSString *const kGTMSessionFetcherUploadLocationObtainedNotification =
   if ([self isRetryEnabled]) {
     // We interpose our own retry method both so we can change the request to ask the server to
     // tell us where to resume the chunk.
-    chunkFetcher.retryBlock = ^(BOOL suggestedWillRetry, NSError *chunkError,
-                                GTMSessionFetcherRetryResponse response) {
-      void (^finish)(BOOL) = ^(BOOL shouldRetry){
-        // We'll retry by sending an offset query.
-        if (shouldRetry) {
-          self.shouldInitiateOffsetQuery = !isQueryFetch;
+    chunkFetcher.retryBlock =
+        ^(BOOL suggestedWillRetry, NSError *chunkError, GTMSessionFetcherRetryResponse response) {
+          void (^finish)(BOOL) = ^(BOOL shouldRetry) {
+            // We'll retry by sending an offset query.
+            if (shouldRetry) {
+              self.shouldInitiateOffsetQuery = !isQueryFetch;
 
-          // We don't know what our actual offset is anymore, but the server will tell us.
-          self.currentOffset = 0;
-        }
-        // We don't actually want to retry this specific fetcher.
-        response(NO);
-      };
+              // We don't know what our actual offset is anymore, but the server will tell us.
+              self.currentOffset = 0;
+            }
+            // We don't actually want to retry this specific fetcher.
+            response(NO);
+          };
 
-      GTMSessionFetcherRetryBlock retryBlock = self.retryBlock;
-      if (retryBlock) {
-        // Ask the client, then call the finish block above.
-        retryBlock(suggestedWillRetry, chunkError, finish);
-      } else {
-        finish(suggestedWillRetry);
-      }
-    };
+          GTMSessionFetcherRetryBlock retryBlock = self.retryBlock;
+          if (retryBlock) {
+            // Ask the client, then call the finish block above.
+            retryBlock(suggestedWillRetry, chunkError, finish);
+          } else {
+            finish(suggestedWillRetry);
+          }
+        };
   }
 
   return chunkFetcher;
@@ -1469,9 +1461,8 @@ NSString *const kGTMSessionFetcherUploadLocationObtainedNotification =
   NSDictionary *responseHeaders = [chunkFetcher responseHeaders];
   GTMSessionUploadFetcherStatus uploadStatus =
       [[self class] uploadStatusFromResponseHeaders:responseHeaders];
-  GTMSESSION_ASSERT_DEBUG(uploadStatus != kStatusUnknown
-                          || error != nil
-                          || self.wasCreatedFromBackgroundSession,
+  GTMSESSION_ASSERT_DEBUG(
+      uploadStatus != kStatusUnknown || error != nil || self.wasCreatedFromBackgroundSession,
       @"chunk fetcher completion has kStatusUnknown upload status for headers %@ fetcher %@",
       responseHeaders, self);
   BOOL isUploadStatusStopped = (uploadStatus == kStatusFinal || uploadStatus == kStatusCancelled);
@@ -1483,7 +1474,8 @@ NSString *const kGTMSessionFetcherUploadLocationObtainedNotification =
   BOOL isQueryFetch = [uploadCommand isEqual:@"query"];
 
   // TODO
-  // Maybe here we can check to see if the request had x goog content length set. (the file length one).
+  // Maybe here we can check to see if the request had x goog content length set. (the file length
+  // one).
   NSString *previousContentLengthValue =
       [chunkFetcher.request valueForHTTPHeaderField:@"Content-Length"];
   // The Content-Length header may not be present if the chunk fetcher was recreated from
@@ -1499,13 +1491,9 @@ NSString *const kGTMSessionFetcherUploadLocationObtainedNotification =
     // Status 4xx indicates a bad offset in the Google upload protocol. However, do not retry status
     // 404 per spec, nor if the upload size appears to have been zero (since the server will just
     // keep asking us to retry.)
-    if (self.shouldInitiateOffsetQuery ||
-        (needsQuery && !isQueryFetch) ||
-        ([error.domain isEqual:kGTMSessionFetcherStatusDomain] &&
-         status >= 400 && status <= 499 &&
-         status != 404 &&
-         uploadStatus == kStatusActive &&
-         previousContentLength > 0)) {
+    if (self.shouldInitiateOffsetQuery || (needsQuery && !isQueryFetch) ||
+        ([error.domain isEqual:kGTMSessionFetcherStatusDomain] && status >= 400 && status <= 499 &&
+         status != 404 && uploadStatus == kStatusActive && previousContentLength > 0)) {
       self.shouldInitiateOffsetQuery = NO;
       [self destroyChunkFetcher];
       hasDestroyedOldChunkFetcher = YES;
@@ -1513,9 +1501,7 @@ NSString *const kGTMSessionFetcherUploadLocationObtainedNotification =
     } else {
       // Some unexpected status has occurred; handle it as we would a regular
       // object fetcher failure.
-      [self invokeFinalCallbackWithData:data
-                                  error:error
-               shouldInvalidateLocation:NO];
+      [self invokeFinalCallbackWithData:data error:error shouldInvalidateLocation:NO];
     }
   } else {
     // The chunk has uploaded successfully.
@@ -1525,25 +1511,23 @@ NSString *const kGTMSessionFetcherUploadLocationObtainedNotification =
     // the "final" upload status.
     BOOL hasUploadAllData = (newOffset == [self fullUploadLength]);
     BOOL isFinalStatus = (uploadStatus == kStatusFinal);
-    #pragma unused(hasUploadAllData,isFinalStatus)
+#pragma unused(hasUploadAllData, isFinalStatus)
     GTMSESSION_ASSERT_DEBUG(hasUploadAllData == isFinalStatus || !hasKnownChunkSize,
                             @"uploadStatus:%@  newOffset:%lld (%lld + %lld)  fullUploadLength:%lld"
                             @" chunkFetcher:%@ requestHeaders:%@ responseHeaders:%@",
                             [responseHeaders objectForKey:kGTMSessionHeaderXGoogUploadStatus],
                             newOffset, self.currentOffset, previousContentLength,
-                            [self fullUploadLength],
-                            chunkFetcher, chunkFetcher.request.allHTTPHeaderFields,
-                            responseHeaders);
+                            [self fullUploadLength], chunkFetcher,
+                            chunkFetcher.request.allHTTPHeaderFields, responseHeaders);
 #endif
-    if (isUploadStatusStopped ||
-        (!_uploadData && _uploadFileLength == 0) ||
+    if (isUploadStatusStopped || (!_uploadData && _uploadFileLength == 0) ||
         (_currentOffset > _uploadFileLength && _uploadFileLength > 0)) {
       // This was the last chunk.
       if (error == nil && uploadStatus == kStatusCancelled) {
         // Report cancelled status as an error.
         NSDictionary *userInfo = nil;
         if (data.length > 0) {
-          userInfo = @{ kGTMSessionFetcherStatusDataKey : data };
+          userInfo = @{kGTMSessionFetcherStatusDataKey : data};
         }
         data = nil;
         error = [self prematureFailureErrorWithUserInfo:userInfo];
@@ -1556,9 +1540,7 @@ NSString *const kGTMSessionFetcherUploadLocationObtainedNotification =
       }
 
       // we're done
-      [self invokeFinalCallbackWithData:data
-                                  error:error
-               shouldInvalidateLocation:YES];
+      [self invokeFinalCallbackWithData:data error:error shouldInvalidateLocation:YES];
     } else {
       // Start the next chunk.
       self.currentOffset = newOffset;
@@ -1572,8 +1554,7 @@ NSString *const kGTMSessionFetcherUploadLocationObtainedNotification =
       [self destroyChunkFetcher];
       hasDestroyedOldChunkFetcher = YES;
 
-      [self uploadNextChunkWithOffset:newOffset
-                    fetcherProperties:props];
+      [self uploadNextChunkWithOffset:newOffset fetcherProperties:props];
     }
   }
   if (!hasDestroyedOldChunkFetcher) {
@@ -1595,8 +1576,7 @@ NSString *const kGTMSessionFetcherUploadLocationObtainedNotification =
     BOOL wasTemporaryUploadFile = ![chunkFileURL isEqual:_uploadFileURL];
     if (wasTemporaryUploadFile) {
       NSError *error;
-      [[NSFileManager defaultManager] removeItemAtURL:chunkFileURL
-                                                error:&error];
+      [[NSFileManager defaultManager] removeItemAtURL:chunkFileURL error:&error];
       if (error) {
         GTMSESSION_LOG_DEBUG(@"removingItemAtURL failed: %@\n%@", error, chunkFileURL);
       }
@@ -1606,7 +1586,7 @@ NSString *const kGTMSessionFetcherUploadLocationObtainedNotification =
 
     // To avoid retain cycles, remove all properties except the parent identifier.
     _chunkFetcher.properties =
-        @{ kGTMSessionUploadFetcherChunkParentKey : [NSValue valueWithNonretainedObject:self] };
+        @{kGTMSessionUploadFetcherChunkParentKey : [NSValue valueWithNonretainedObject:self]};
 
     _chunkFetcher.retryBlock = nil;
     _chunkFetcher.sendProgressBlock = nil;
@@ -1630,12 +1610,13 @@ NSString *const kGTMSessionFetcherUploadLocationObtainedNotification =
   [self invokeOnCallbackQueue:self.delegateCallbackQueue
              afterUserStopped:NO
                         block:^{
-      GTMSessionFetcherSendProgressBlock sendProgressBlock = self.sendProgressBlock;
-      if (sendProgressBlock) {
-        sendProgressBlock(bytesSent, totalBytesSent, totalBytesExpected);
-      }
-      holdFetcher = nil;
-  }];
+                          GTMSessionFetcherSendProgressBlock sendProgressBlock =
+                              self.sendProgressBlock;
+                          if (sendProgressBlock) {
+                            sendProgressBlock(bytesSent, totalBytesSent, totalBytesExpected);
+                          }
+                          holdFetcher = nil;
+                        }];
 }
 
 - (void)retrieveUploadChunkGranularityFromResponseHeaders:(NSDictionary *)responseHeaders {
@@ -1700,16 +1681,17 @@ NSString *const kGTMSessionFetcherUploadLocationObtainedNotification =
     [self invokeOnCallbackQueue:self.callbackQueue
                afterUserStopped:YES
                           block:^{
-      // Repeated calls to stopFetching may cause this path to be reached despite having sent a real
-      // cancel request, check here to ensure that the cancellation handler invocation which fires
-      // will definitely be for the real request sent previously.
-      @synchronized(self) {
-        if (self->_isCancelInFlight) {
-          return;
-        }
-      }
-      [self triggerCancellationHandlerForFetch:nil data:nil error:nil];
-    }];
+                            // Repeated calls to stopFetching may cause this path to be reached
+                            // despite having sent a real cancel request, check here to ensure that
+                            // the cancellation handler invocation which fires will definitely be
+                            // for the real request sent previously.
+                            @synchronized(self) {
+                              if (self->_isCancelInFlight) {
+                                return;
+                              }
+                            }
+                            [self triggerCancellationHandlerForFetch:nil data:nil error:nil];
+                          }];
   }
 
   [super stopFetching];
@@ -1730,8 +1712,7 @@ NSString *const kGTMSessionFetcherUploadLocationObtainedNotification =
 
 #pragma mark -
 
-- (int64_t)updateChunkFetcher:(GTMSessionFetcher *)chunkFetcher
-             forChunkAtOffset:(int64_t)offset {
+- (int64_t)updateChunkFetcher:(GTMSessionFetcher *)chunkFetcher forChunkAtOffset:(int64_t)offset {
   BOOL isUploadingFileURL = (self.uploadFileURL != nil);
 
   // Upload another chunk, meeting server-required granularity.
@@ -1799,19 +1780,16 @@ NSString *const kGTMSessionFetcherUploadLocationObtainedNotification =
 
   // Append the range of bytes in this chunk to the fetcher comment.
   NSString *baseComment = self.comment;
-  [chunkFetcher setCommentWithFormat:@"%@ (%lld-%lld)",
-      baseComment ? baseComment : @"upload", offset, MAX(0, offset + thisChunkSize - 1)];
+  [chunkFetcher setCommentWithFormat:@"%@ (%lld-%lld)", baseComment ? baseComment : @"upload",
+                                     offset, MAX(0, offset + thisChunkSize - 1)];
 
   return thisChunkSize;
 }
 
 // Public properties.
-@synthesize currentOffset = _currentOffset,
-            allowsCellularAccess = _allowsCellularAccess,
-            delegateCompletionHandler = _delegateCompletionHandler,
-            chunkFetcher = _chunkFetcher,
-            lastChunkRequest = _lastChunkRequest,
-            subdataGenerating = _subdataGenerating,
+@synthesize currentOffset = _currentOffset, allowsCellularAccess = _allowsCellularAccess,
+            delegateCompletionHandler = _delegateCompletionHandler, chunkFetcher = _chunkFetcher,
+            lastChunkRequest = _lastChunkRequest, subdataGenerating = _subdataGenerating,
             shouldInitiateOffsetQuery = _shouldInitiateOffsetQuery,
             uploadGranularity = _uploadGranularity;
 
@@ -1901,7 +1879,6 @@ NSString *const kGTMSessionFetcherUploadLocationObtainedNotification =
     return [super statusCodeUnsynchronized];
   }
 }
-
 
 - (void)setStatusCode:(NSInteger)val {
   @synchronized(self) {

--- a/Source/TestApps/FetcherOSXTestApp/FTAAppDelegate.m
+++ b/Source/TestApps/FetcherOSXTestApp/FTAAppDelegate.m
@@ -19,8 +19,8 @@
 
 #import "FTAAppDelegate.h"
 #import "GTMSessionFetcher.h"
-#import "GTMSessionUploadFetcher.h"
 #import "GTMSessionFetcherLogging.h"
+#import "GTMSessionUploadFetcher.h"
 
 @implementation FTAAppDelegate
 
@@ -39,12 +39,11 @@
   NSUInteger kUploadDataSize = 1000000;
   NSData *uploadData = [self generatedUploadDataWithLength:kUploadDataSize];
 
-
   NSURL *localUploadURL = [NSURL URLWithString:@"http://0.upload.google.com/null"];
   NSMutableURLRequest *request =
       [NSMutableURLRequest requestWithURL:localUploadURL
                               cachePolicy:NSURLRequestReloadIgnoringCacheData
-                          timeoutInterval:60*60];
+                          timeoutInterval:60 * 60];
   [request setHTTPMethod:@"POST"];
 
   GTMSessionFetcherService *fetcherService = [[GTMSessionFetcherService alloc] init];

--- a/Source/TestApps/FetcherOSXTestApp/main.m
+++ b/Source/TestApps/FetcherOSXTestApp/main.m
@@ -19,6 +19,4 @@
 
 #import <Cocoa/Cocoa.h>
 
-int main(int argc, const char *argv[]) {
-  return NSApplicationMain(argc, argv);
-}
+int main(int argc, const char *argv[]) { return NSApplicationMain(argc, argv); }

--- a/Source/TestApps/FetcheriOSTestApp/FTAIOSAppDelegate.m
+++ b/Source/TestApps/FetcheriOSTestApp/FTAIOSAppDelegate.m
@@ -20,22 +20,22 @@
 
 // Supports running a test case test within this app.
 // Update the kTestCase... constants to run the desired test.
-#define ENABLE_TEST_CASE_TESTING                0
+#define ENABLE_TEST_CASE_TESTING 0
 
 // Supports the out of process download acceptance test, since unit tests are not feasible for it.
 // When enabled, this app will download a test file and verify it downloaded the expected content.
 // Tap the Home button after the progress indicator starts. This kills the app, while not stopping
 // the download. The app will either be re-launched by the system if the download finishes or you
 // can re-launch the app to re-attach to the download and continue updating the progress bar.
-#define ENABLE_OUT_OF_PROCESS_DOWNLOAD_TESTING  0
+#define ENABLE_OUT_OF_PROCESS_DOWNLOAD_TESTING 0
 
 // Supports the out of process chunked upload acceptance test, since unit tests are not feasible for
-// it. When enabled, this app will upload a dynamically created test file to the test upload endpoint.
-// Tap the Home button after the progress indicator starts. This kills the app, while not stopping
-// the upload. The app will be re-launched when the current upload chunk finishes, so the app can
-// queue up the next chunk, if applicable. You can re-launch the app to re-attach to the upload
-// and continue updating the progress bar.
-#define ENABLE_OUT_OF_PROCESS_UPLOAD_TESTING    0
+// it. When enabled, this app will upload a dynamically created test file to the test upload
+// endpoint. Tap the Home button after the progress indicator starts. This kills the app, while not
+// stopping the upload. The app will be re-launched when the current upload chunk finishes, so the
+// app can queue up the next chunk, if applicable. You can re-launch the app to re-attach to the
+// upload and continue updating the progress bar.
+#define ENABLE_OUT_OF_PROCESS_UPLOAD_TESTING 0
 
 #define ENABLE_POST_TESTING 0
 
@@ -50,7 +50,6 @@ static NSString *const kTestCaseSelectorString = @"testCancelAndResumeFetchToFil
 
 #endif  // ENABLE_TEST_CASE_TESTING
 
-
 #import "GTMSessionFetcherService.h"
 
 #if ENABLE_OUT_OF_PROCESS_DOWNLOAD_TESTING
@@ -61,19 +60,18 @@ static NSString *const kDownloadTestURLString = @"http://";
 
 #endif  // ENABLE_OUT_OF_PROCESS_DOWNLOAD_TESTING
 
-
 #if ENABLE_OUT_OF_PROCESS_UPLOAD_TESTING
 
 #import "GTMSessionFetcherTestServer.h"
 #import "GTMSessionUploadFetcher.h"
 
 // Test upload > 2GB.
-static NSString *const kUploadTestURLString = @"http://0.upload.google.com/null";  // null upload server.
+static NSString *const kUploadTestURLString =
+    @"http://0.upload.google.com/null";  // null upload server.
 static NSUInteger const kBigUploadChunkSize = 500 * 1024 * 1024;
 static NSUInteger const kBigUploadChunkCount = 5;
 
 #endif  // ENABLE_OUT_OF_PROCESS_UPLOAD_TESTING
-
 
 #if ENABLE_POST_TESTING
 
@@ -82,7 +80,6 @@ static NSUInteger const kBigUploadChunkCount = 5;
 static NSUInteger const kPostDataSize = 512 * 1024;
 
 #endif  // ENABLE_POST_TESTING
-
 
 @interface FTAIOSAppRootViewController : UIViewController
 
@@ -121,8 +118,7 @@ static NSUInteger const kPostDataSize = 512 * 1024;
 
 - (void)applicationDidBecomeActive:(UIApplication *)application {
 #if ENABLE_TEST_CASE_TESTING
-  [self invokeTestSelectorString:kTestCaseSelectorString
-                   onClassString:kTestCaseClassString];
+  [self invokeTestSelectorString:kTestCaseSelectorString onClassString:kTestCaseClassString];
 #endif
 
 #if ENABLE_POST_TESTING
@@ -218,20 +214,19 @@ static NSUInteger const kPostDataSize = 512 * 1024;
 
   XCTestCase *testCase =
       [[NSClassFromString(testCaseClassString) alloc] initWithSelector:testCaseSelector];
-  NSAssert(testCase, @"Invalid testCase: %@ or selector: %@",
-                     testCaseClassString, testCaseSelectorString);
+  NSAssert(testCase, @"Invalid testCase: %@ or selector: %@", testCaseClassString,
+           testCaseSelectorString);
   XCTestRun *testRun = [[XCTestRun alloc] initWithTest:testCase];
   [testCase invokeTest];
 
   NSString *message =
-      [NSString stringWithFormat:@"Test count: %u\nFailure count: %u",
-                                 [testRun testCaseCount], [testRun totalFailureCount]];
-  UIAlertView *testResultsAlert =
-      [[UIAlertView alloc] initWithTitle:@"Test Run Complete"
-                                 message:message
-                                delegate:nil
-                       cancelButtonTitle:@"Cool"
-                       otherButtonTitles:nil];
+      [NSString stringWithFormat:@"Test count: %u\nFailure count: %u", [testRun testCaseCount],
+                                 [testRun totalFailureCount]];
+  UIAlertView *testResultsAlert = [[UIAlertView alloc] initWithTitle:@"Test Run Complete"
+                                                             message:message
+                                                            delegate:nil
+                                                   cancelButtonTitle:@"Cool"
+                                                   otherButtonTitles:nil];
   [testResultsAlert show];
 }
 
@@ -249,11 +244,10 @@ static NSUInteger const kPostDataSize = 512 * 1024;
   fetcher.bodyData = postData;
   [fetcher setRequestValue:@"text/plain" forHTTPHeaderField:@"Content-Type"];
 
-  fetcher.sendProgressBlock = ^(int64_t bytesSent,
-                                int64_t totalBytesSent,
-                                int64_t totalBytesExpectedToSend) {
-    NSLog(@"body post fetcher sent %lld/%lld", totalBytesSent, totalBytesExpectedToSend);
-  };
+  fetcher.sendProgressBlock =
+      ^(int64_t bytesSent, int64_t totalBytesSent, int64_t totalBytesExpectedToSend) {
+        NSLog(@"body post fetcher sent %lld/%lld", totalBytesSent, totalBytesExpectedToSend);
+      };
 
   NSLog(@"Starting post fetch");
   [fetcher beginFetchWithCompletionHandler:^(NSData *receivedData, NSError *error) {
@@ -282,7 +276,7 @@ static NSUInteger const kPostDataSize = 512 * 1024;
   if (fetcher) {
     NSURL *destinationFileURL = fetcher.destinationFileURL;
     fetcher.completionHandler = ^(NSData *data, NSError *error) {
-        [self downloadCompletedToFile:destinationFileURL error:error];
+      [self downloadCompletedToFile:destinationFileURL error:error];
     };
   } else {
     NSURL *destinationFileURL = [self downloadDestinationFileURL];
@@ -292,15 +286,14 @@ static NSUInteger const kPostDataSize = 512 * 1024;
     fetcher.allowLocalhostRequest = YES;
     fetcher.allowedInsecureSchemes = @[ @"http" ];
     [fetcher beginFetchWithCompletionHandler:^(NSData *data, NSError *error) {
-        [self downloadCompletedToFile:destinationFileURL error:error];
+      [self downloadCompletedToFile:destinationFileURL error:error];
     }];
   }
-  fetcher.downloadProgressBlock = ^(int64_t bytesWritten,
-                                    int64_t totalBytesWritten,
-                                    int64_t totalBytesExpectedToWrite) {
-      float progress = (float)totalBytesWritten / (float)totalBytesExpectedToWrite;
-      [self setProgress:progress];
-  };
+  fetcher.downloadProgressBlock =
+      ^(int64_t bytesWritten, int64_t totalBytesWritten, int64_t totalBytesExpectedToWrite) {
+        float progress = (float)totalBytesWritten / (float)totalBytesExpectedToWrite;
+        [self setProgress:progress];
+      };
 }
 
 - (NSURL *)downloadDestinationFileURL {
@@ -324,17 +317,17 @@ static NSUInteger const kPostDataSize = 512 * 1024;
     if (didSucceed) {
       message = [NSString stringWithFormat:@"Data is correct"];
     } else {
-      message = [NSString stringWithFormat:@"Data is incorrect\n%d of %d bytes\n%@",
-                 (int)[downloadedData length], (int)[actualData length], error];
+      message =
+          [NSString stringWithFormat:@"Data is incorrect\n%d of %d bytes\n%@",
+                                     (int)[downloadedData length], (int)[actualData length], error];
     }
     [self setProgress:1];
   }
-  UIAlertView *downloadCompleteAlert =
-      [[UIAlertView alloc] initWithTitle:@"Finished download"
-                                 message:message
-                                delegate:nil
-                       cancelButtonTitle:(didSucceed ? @"Success" : @"Failed")
-                       otherButtonTitles:nil];
+  UIAlertView *downloadCompleteAlert = [[UIAlertView alloc]
+          initWithTitle:@"Finished download"
+                message:message
+               delegate:nil
+      cancelButtonTitle:(didSucceed ? @"Success" : @"Failed")otherButtonTitles:nil];
   [downloadCompleteAlert show];
 }
 
@@ -347,34 +340,33 @@ static NSUInteger const kPostDataSize = 512 * 1024;
   GTMSessionUploadFetcher *uploadFetcher = [uploadFetchers firstObject];
   if (uploadFetcher) {
     uploadFetcher.completionHandler = ^(NSData *data, NSError *error) {
-        [self uploadCompletedWithError:error];
+      [self uploadCompletedWithError:error];
     };
   } else {
     NSURL *requestURL = [NSURL URLWithString:kUploadTestURLString];
     NSMutableURLRequest *request =
         [NSMutableURLRequest requestWithURL:requestURL
                                 cachePolicy:NSURLRequestReloadIgnoringCacheData
-                            timeoutInterval:60*60];
+                            timeoutInterval:60 * 60];
     NSURL *bigFileURL = [self bigFileToUploadURL];
-    uploadFetcher =
-        [GTMSessionUploadFetcher uploadFetcherWithRequest:request
-                                           uploadMIMEType:@"text/plain"
-                                                chunkSize:kBigUploadChunkSize
-                                           fetcherService:nil];
+    uploadFetcher = [GTMSessionUploadFetcher uploadFetcherWithRequest:request
+                                                       uploadMIMEType:@"text/plain"
+                                                            chunkSize:kBigUploadChunkSize
+                                                       fetcherService:nil];
     uploadFetcher.allowedInsecureSchemes = @[ @"http" ];
     uploadFetcher.uploadFileURL = bigFileURL;
     uploadFetcher.retryEnabled = YES;
 
     // Start the upload.
     [uploadFetcher beginFetchWithCompletionHandler:^(NSData *data, NSError *error) {
-        [self uploadCompletedWithError:error];
+      [self uploadCompletedWithError:error];
     }];
   }
   uploadFetcher.sendProgressBlock =
       ^(int64_t bytesSent, int64_t totalBytesSent, int64_t totalBytesExpectedToSend) {
-          float progress = (float)totalBytesSent / (float)totalBytesExpectedToSend;
-          [self setProgress:progress];
-  };
+        float progress = (float)totalBytesSent / (float)totalBytesExpectedToSend;
+        [self setProgress:progress];
+      };
 }
 
 - (NSURL *)bigFileToUploadURL {

--- a/Source/TestApps/FetcheriOSTestApp/main.m
+++ b/Source/TestApps/FetcheriOSTestApp/main.m
@@ -15,7 +15,7 @@
 
 #import "FTAIOSAppDelegate.h"
 
-int main(int argc, char * argv[]) {
+int main(int argc, char* argv[]) {
   @autoreleasepool {
     return UIApplicationMain(argc, argv, nil, NSStringFromClass([FTAIOSAppDelegate class]));
   }

--- a/Source/UnitTests/GTMGatherInputStreamTest.m
+++ b/Source/UnitTests/GTMGatherInputStreamTest.m
@@ -75,10 +75,7 @@
   NSArray *array = [NSArray array];
   NSInputStream *input = [GTMGatherInputStream streamWithArray:array];
 
-  [self doReadTestForInputStream:input
-                  expectedString:@""
-                 usingSmallReads:NO
-                      testMethod:_cmd];
+  [self doReadTestForInputStream:input expectedString:@"" usingSmallReads:NO testMethod:_cmd];
 }
 
 - (void)testGatherStreamWithEmptyParts {
@@ -120,7 +117,6 @@
                  usingSmallReads:NO
                       testMethod:_cmd];
 }
-
 
 // We read one byte at a time to make sure that many calls to read work properly.
 - (void)testGatherStreamWithManyCalls {

--- a/Source/UnitTests/GTMHTTPServer.h
+++ b/Source/UnitTests/GTMHTTPServer.h
@@ -32,26 +32,27 @@
 #import <Foundation/Foundation.h>
 
 #if GTM_IPHONE_SDK
-  #import <CFNetwork/CFNetwork.h>
-#endif // GTM_IPHONE_SDK
+#import <CFNetwork/CFNetwork.h>
+#endif  // GTM_IPHONE_SDK
 
 // Global contants needed for errors from start
 
 #undef _EXTERN
 #undef _INITIALIZE_AS
 #ifdef GTMHTTPSERVER_DEFINE_GLOBALS
-  #define _EXTERN
-  #define _INITIALIZE_AS(x) =x
+#define _EXTERN
+#define _INITIALIZE_AS(x) = x
 #else
-  #define _EXTERN extern
-  #define _INITIALIZE_AS(x)
+#define _EXTERN extern
+#define _INITIALIZE_AS(x)
 #endif
 
-_EXTERN NSString* const kGTMHTTPServerErrorDomain _INITIALIZE_AS(@"com.google.mactoolbox.HTTPServerDomain");
+_EXTERN NSString *const kGTMHTTPServerErrorDomain
+    _INITIALIZE_AS(@"com.google.mactoolbox.HTTPServerDomain");
 enum {
-  kGTMHTTPServerSocketCreateFailedError   = -100,
-  kGTMHTTPServerBindFailedError           = -101,
-  kGTMHTTPServerListenFailedError         = -102,
+  kGTMHTTPServerSocketCreateFailedError = -100,
+  kGTMHTTPServerBindFailedError = -101,
+  kGTMHTTPServerListenFailedError = -102,
   kGTMHTTPServerCFSocketCreateFailedError = -103,
 };
 
@@ -118,7 +119,7 @@ enum {
 + (instancetype)redirectResponseWithRedirectURL:(NSURL *)redirectURL;
 
 // TODO: add helper for expire/no-cache
-- (void)setValue:(NSString*)value forHeaderField:(NSString*)headerField;
+- (void)setValue:(NSString *)value forHeaderField:(NSString *)headerField;
 - (void)setHeaderValuesFromDictionary:(NSDictionary *)dict;
 
 @end

--- a/Source/UnitTests/GTMHTTPServer.m
+++ b/Source/UnitTests/GTMHTTPServer.m
@@ -151,7 +151,7 @@ static NSString *kResponseOffset = @"ResponseOffset";
 - (NSData *)serializedData;
 @end
 
-@interface GTMHTTPServer ()<NSStreamDelegate>
+@interface GTMHTTPServer () <NSStreamDelegate>
 
 @property(nonatomic, readonly) CFSocketRef socket;
 
@@ -159,8 +159,8 @@ static NSString *kResponseOffset = @"ResponseOffset";
 
 @end
 
-static void AcceptCallback(CFSocketRef socket, CFSocketCallBackType callBackType,
-                           CFDataRef address, const void *data, void *info) {
+static void AcceptCallback(CFSocketRef socket, CFSocketCallBackType callBackType, CFDataRef address,
+                           const void *data, void *info) {
   NSCAssert(callBackType == kCFSocketAcceptCallBack, @"Unexpected callBackType: %lu", callBackType);
   NSCAssert(data != NULL, @"Unexpected NULL data, socket wasn't included in callback");
 
@@ -184,7 +184,7 @@ static void AcceptCallback(CFSocketRef socket, CFSocketCallBackType callBackType
 @synthesize socket = _socket;
 
 + (instancetype)startedServerWithDelegate:(id<GTMHTTPServerDelegate>)delegate {
-  GTMHTTPServer *server = [(GTMHTTPServer*)[self alloc] initWithDelegate:delegate];
+  GTMHTTPServer *server = [(GTMHTTPServer *)[self alloc] initWithDelegate:delegate];
   NSError *error = nil;
   if (![server start:&error]) {
     NSLog(@"Failed to start up %@ (error=%@)", NSStringFromClass(self), error);
@@ -216,7 +216,7 @@ static void AcceptCallback(CFSocketRef socket, CFSocketCallBackType callBackType
   [self stop];
 }
 
-- (BOOL)start:(NSError * __autoreleasing *)error {
+- (BOOL)start:(NSError *__autoreleasing *)error {
   NSAssert(_socket == NULL, @"start called when we already have a _socket");
 
   if (error) *error = NULL;
@@ -224,7 +224,7 @@ static void AcceptCallback(CFSocketRef socket, CFSocketCallBackType callBackType
   const int kDefaultProtocol = 0;
   __block int fd = socket(AF_INET6, SOCK_STREAM, kDefaultProtocol);
 
-  void (^startFailed)(NSInteger) = ^(NSInteger startFailureCode){
+  void (^startFailed)(NSInteger) = ^(NSInteger startFailureCode) {
     if (error) {
       *error = [[NSError alloc] initWithDomain:kGTMHTTPServerErrorDomain
                                           code:startFailureCode
@@ -252,22 +252,21 @@ static void AcceptCallback(CFSocketRef socket, CFSocketCallBackType callBackType
   // enable address reuse quicker after we are done w/ our socket
   int yes = 1;
   int sock_opt = SO_REUSEADDR;
-  if (setsockopt(fd, SOL_SOCKET, sock_opt,
-                 (void *)&yes, (socklen_t)sizeof(yes)) != 0) {
-    NSLog(@"failed to mark the socket as reusable"); // COV_NF_LINE
+  if (setsockopt(fd, SOL_SOCKET, sock_opt, (void *)&yes, (socklen_t)sizeof(yes)) != 0) {
+    NSLog(@"failed to mark the socket as reusable");  // COV_NF_LINE
   }
 
   // bind
   struct sockaddr_in6 addr;
   memset(&addr, 0, sizeof(addr));
-  addr.sin6_len    = sizeof(addr);
+  addr.sin6_len = sizeof(addr);
   addr.sin6_family = AF_INET6;
-  addr.sin6_port   = htons(_port);
+  addr.sin6_port = htons(_port);
 
   // localhost-only
   addr.sin6_addr = in6addr_loopback;
 
-  if (bind(fd, (struct sockaddr*)(&addr), (socklen_t)sizeof(addr)) != 0) {
+  if (bind(fd, (struct sockaddr *)(&addr), (socklen_t)sizeof(addr)) != 0) {
     startFailed(kGTMHTTPServerBindFailedError);
     return NO;
   }
@@ -275,7 +274,7 @@ static void AcceptCallback(CFSocketRef socket, CFSocketCallBackType callBackType
   // collect the port back out
   if (_port == 0) {
     socklen_t len = (socklen_t)sizeof(addr);
-    if (getsockname(fd, (struct sockaddr*)(&addr), &len) == 0) {
+    if (getsockname(fd, (struct sockaddr *)(&addr), &len) == 0) {
       _port = ntohs(addr.sin6_port);
     }
   }
@@ -348,9 +347,8 @@ static void AcceptCallback(CFSocketRef socket, CFSocketCallBackType callBackType
 }
 
 - (NSString *)description {
-  NSString *result =
-    [NSString stringWithFormat:@"%@<%p>{ port=%d status=%@ }",
-     [self class], self, _port, (_socket != NULL ? @"Started" : @"Stopped")];
+  NSString *result = [NSString stringWithFormat:@"%@<%p>{ port=%d status=%@ }", [self class], self,
+                                                _port, (_socket != NULL ? @"Started" : @"Stopped")];
   return result;
 }
 
@@ -399,7 +397,7 @@ static void AcceptCallback(CFSocketRef socket, CFSocketCallBackType callBackType
             response = [_delegate httpServer:self handleRequest:request];
           } @catch (NSException *e) {
             NSLog(@"Exception trying to handle http request: %@", e);
-          } // COV_NF_LINE - radar 5851992 only reachable w/ an uncaught exception, un-testable
+          }  // COV_NF_LINE - radar 5851992 only reachable w/ an uncaught exception, un-testable
 
           if (!response) {
             // No response, shut it down
@@ -440,8 +438,7 @@ static void AcceptCallback(CFSocketRef socket, CFSocketCallBackType callBackType
         NSUInteger kMaxWriteDataChunkSize = 32768;
         const uint8_t *buffer = response.bytes;
         NSUInteger maxLength = MIN((responseLength - offset), kMaxWriteDataChunkSize);
-        NSInteger bytesWritten = [outputStream write:&buffer[offset]
-                                           maxLength:maxLength];
+        NSInteger bytesWritten = [outputStream write:&buffer[offset] maxLength:maxLength];
         if (bytesWritten == -1) {
           [self closeConnection:connDict];
           return;
@@ -537,8 +534,7 @@ static void AcceptCallback(CFSocketRef socket, CFSocketCallBackType callBackType
 
 - (NSString *)description {
   CFStringRef desc = CFCopyDescription(_message);
-  NSString *result =
-    [NSString stringWithFormat:@"%@<%p>{ message=%@ }", [self class], self, desc];
+  NSString *result = [NSString stringWithFormat:@"%@<%p>{ message=%@ }", [self class], self, desc];
   CFRelease(desc);
   return result;
 }
@@ -605,7 +601,7 @@ static void AcceptCallback(CFSocketRef socket, CFSocketCallBackType callBackType
           NSData *newBody = [NSData dataWithBytes:body.bytes length:(NSUInteger)contentLength];
           [self setBody:newBody];
           NSLog(@"Got %lu extra bytes on http request, ignoring them",
-                     (unsigned long)(bodyLength - (unsigned long)contentLength));
+                (unsigned long)(bodyLength - (unsigned long)contentLength));
         }
       }
     }
@@ -640,7 +636,7 @@ static void AcceptCallback(CFSocketRef socket, CFSocketCallBackType callBackType
 
 - (void)setBody:(NSData *)body {
   if (!body) {
-    body = [NSData data]; // COV_NF_LINE - can only happen if we fail to make the new data object
+    body = [NSData data];  // COV_NF_LINE - can only happen if we fail to make the new data object
   }
   CFHTTPMessageSetBody(_message, (__bridge CFDataRef)body);
 }
@@ -663,9 +659,7 @@ static void AcceptCallback(CFSocketRef socket, CFSocketCallBackType callBackType
 
 + (instancetype)responseWithString:(NSString *)plainText {
   NSData *body = [plainText dataUsingEncoding:NSUTF8StringEncoding];
-  return [self responseWithBody:body
-                    contentType:@"text/plain; charset=UTF-8"
-                     statusCode:200];
+  return [self responseWithBody:body contentType:@"text/plain; charset=UTF-8" statusCode:200];
 }
 
 + (instancetype)responseWithHTMLString:(NSString *)htmlString {
@@ -677,21 +671,15 @@ static void AcceptCallback(CFSocketRef socket, CFSocketCallBackType callBackType
 + (instancetype)responseWithBody:(NSData *)body
                      contentType:(NSString *)contentType
                       statusCode:(int)statusCode {
-  return [[self alloc] initWithBody:body
-                        contentType:contentType
-                         statusCode:statusCode];
+  return [[self alloc] initWithBody:body contentType:contentType statusCode:statusCode];
 }
 
 + (instancetype)emptyResponseWithCode:(int)statusCode {
-  return [[self alloc] initWithBody:nil
-                        contentType:nil
-                         statusCode:statusCode];
+  return [[self alloc] initWithBody:nil contentType:nil statusCode:statusCode];
 }
 
 + (instancetype)redirectResponseWithRedirectURL:(NSURL *)redirectURL {
-  GTMHTTPResponseMessage *response = [[self alloc] initWithBody:nil
-                                                    contentType:nil
-                                                     statusCode:302];
+  GTMHTTPResponseMessage *response = [[self alloc] initWithBody:nil contentType:nil statusCode:302];
   [response setValue:[redirectURL absoluteString] forHeaderField:@"Location"];
   return response;
 }
@@ -713,13 +701,13 @@ static void AcceptCallback(CFSocketRef socket, CFSocketCallBackType callBackType
   [self setValue:bodyLenStr forHeaderField:@"Content-Length"];
 }
 
-- (void)setValue:(NSString*)value forHeaderField:(NSString*)headerField {
+- (void)setValue:(NSString *)value forHeaderField:(NSString *)headerField {
   if (headerField.length == 0) return;
   if (value == nil) {
     value = @"";
   }
-  CFHTTPMessageSetHeaderFieldValue(_message,
-                                   (__bridge CFStringRef)headerField, (__bridge CFStringRef)value);
+  CFHTTPMessageSetHeaderFieldValue(_message, (__bridge CFStringRef)headerField,
+                                   (__bridge CFStringRef)value);
 }
 
 - (void)setHeaderValuesFromDictionary:(NSDictionary *)dict {
@@ -731,8 +719,7 @@ static void AcceptCallback(CFSocketRef socket, CFSocketCallBackType callBackType
 
 - (NSString *)description {
   CFStringRef desc = CFCopyDescription(_message);
-  NSString *result =
-    [NSString stringWithFormat:@"%@<%p>{ message=%@ }", [self class], self, desc];
+  NSString *result = [NSString stringWithFormat:@"%@<%p>{ message=%@ }", [self class], self, desc];
   CFRelease(desc);
   return result;
 }
@@ -747,9 +734,8 @@ static void AcceptCallback(CFSocketRef socket, CFSocketCallBackType callBackType
     if ((statusCode < 100) || (statusCode > 599)) {
       return nil;
     }
-    _message = CFHTTPMessageCreateResponse(kCFAllocatorDefault,
-                                           statusCode, NULL,
-                                           kCFHTTPVersion1_1);
+    _message =
+        CFHTTPMessageCreateResponse(kCFAllocatorDefault, statusCode, NULL, kCFHTTPVersion1_1);
     if (!_message) {
       // COV_NF_START
       return nil;

--- a/Source/UnitTests/GTMMIMEDocumentTest.m
+++ b/Source/UnitTests/GTMMIMEDocumentTest.m
@@ -79,9 +79,7 @@ static NSMutableData *DataForTestWithLength(NSUInteger length);
 
   // Generate the boundary and the data.
   dispatch_data_t data;
-  [doc generateDispatchData:&data
-                     length:&length
-                   boundary:&boundary];
+  [doc generateDispatchData:&data length:&length boundary:&boundary];
 
   XCTAssertEqualObjects(boundary, expectedBoundary);
   XCTAssertEqual((NSUInteger)length, expectedLength);
@@ -89,33 +87,29 @@ static NSMutableData *DataForTestWithLength(NSUInteger length);
   [self doDataTestForDispatchData:data expectedString:expectedString];
 
   // Generate the boundary and the input stream.
-  [doc generateInputStream:&stream
-                    length:&length
-                  boundary:&boundary];
+  [doc generateInputStream:&stream length:&length boundary:&boundary];
 
   XCTAssertEqualObjects(boundary, expectedBoundary);
   XCTAssertEqual((NSUInteger)length, expectedLength);
 
-  [self doReadTestForInputStream:stream
-                  expectedString:expectedString];
-
+  [self doReadTestForInputStream:stream expectedString:expectedString];
 }
 
 - (void)testSinglePartDoc {
   GTMMIMEDocument *doc = [GTMMIMEDocument MIMEDocument];
 
-  NSDictionary *h1 = @{ @"hfoo": @"bar", @"hfaz" : @"baz" };
+  NSDictionary *h1 = @{@"hfoo" : @"bar", @"hfaz" : @"baz"};
   NSData *b1 = [@"Hi mom" dataUsingEncoding:NSUTF8StringEncoding];
   [doc addPartWithHeaders:h1 body:b1];
 
   NSString *expectedBoundary = @"END_OF_PART";
-  NSString *expectedResultString = [NSString stringWithFormat:
-                                    @"\r\n--%@\r\n"
-                                    "hfaz: baz\r\n"
-                                    "hfoo: bar\r\n"
-                                    "\r\n"    // Newline after headers.
-                                    "Hi mom"
-                                    "\r\n--%@--\r\n", expectedBoundary, expectedBoundary];
+  NSString *expectedResultString = [NSString stringWithFormat:@"\r\n--%@\r\n"
+                                                               "hfaz: baz\r\n"
+                                                               "hfoo: bar\r\n"
+                                                               "\r\n"  // Newline after headers.
+                                                               "Hi mom"
+                                                               "\r\n--%@--\r\n",
+                                                              expectedBoundary, expectedBoundary];
   NSUInteger expectedLength = expectedResultString.length;
 
   // Generate the boundary and the input stream.
@@ -123,36 +117,28 @@ static NSMutableData *DataForTestWithLength(NSUInteger length);
   NSString *boundary = nil;
   unsigned long long length = ULONG_MAX;
 
-
   // Generate the boundary and the data.
   dispatch_data_t data;
-  [doc generateDispatchData:&data
-                     length:&length
-                   boundary:&boundary];
+  [doc generateDispatchData:&data length:&length boundary:&boundary];
 
   XCTAssertEqualObjects(boundary, expectedBoundary);
   XCTAssertEqual((NSUInteger)length, expectedLength);
 
-  [self doDataTestForDispatchData:data
-                   expectedString:expectedResultString];
+  [self doDataTestForDispatchData:data expectedString:expectedResultString];
 
   // Generate the boundary and the input stream.
-  [doc generateInputStream:&stream
-                    length:&length
-                  boundary:&boundary];
+  [doc generateInputStream:&stream length:&length boundary:&boundary];
 
   XCTAssertEqualObjects(boundary, expectedBoundary);
   XCTAssertEqual((NSUInteger)length, expectedLength);
 
-  [self doReadTestForInputStream:stream
-                  expectedString:expectedResultString];
+  [self doReadTestForInputStream:stream expectedString:expectedResultString];
 }
-
 
 - (void)testMultiPartDoc {
   GTMMIMEDocument *doc = [GTMMIMEDocument MIMEDocument];
 
-  NSDictionary *h1 = @{ @"hfoo": @"bar", @"hfaz" : @"baz" };
+  NSDictionary *h1 = @{@"hfoo" : @"bar", @"hfaz" : @"baz"};
   NSData *b1 = [@"Hi mom" dataUsingEncoding:NSUTF8StringEncoding];
 
   NSDictionary *h2 = [NSDictionary dictionary];
@@ -161,60 +147,51 @@ static NSMutableData *DataForTestWithLength(NSUInteger length);
   NSDictionary *h3 = @{
     @"Content-Type" : @"text/html",
     @"Content-Disposition" : @"angry",
-    @"Content-ID" : @"MyCat:fluffy",   // Value should allow a colon.
+    @"Content-ID" : @"MyCat:fluffy",  // Value should allow a colon.
   };
-  NSData* b3 = [@"Hi brother" dataUsingEncoding:NSUTF8StringEncoding];
+  NSData *b3 = [@"Hi brother" dataUsingEncoding:NSUTF8StringEncoding];
 
   [doc addPartWithHeaders:h1 body:b1];
   [doc addPartWithHeaders:h2 body:b2];
   [doc addPartWithHeaders:h3 body:b3];
 
-  NSString *const expectedResultTemplate =
-     @"\r\n--%@\r\n"
-      "hfaz: baz\r\n"
-      "hfoo: bar\r\n"
-      "\r\n"    // Newline after headers.
-      "Hi mom"
-      "\r\n--%@\r\n"
-      "\r\n"    // No header here, but still need the newline.
-      "Hi dad"
-      "\r\n--%@\r\n"
-      "Content-Disposition: angry\r\n"
-      "Content-ID: MyCat:fluffy\r\n"
-      "Content-Type: text/html\r\n"
-      "\r\n"    // Newline after headers.
-      "Hi brother"
-      "\r\n--%@--\r\n";
+  NSString *const expectedResultTemplate = @"\r\n--%@\r\n"
+                                            "hfaz: baz\r\n"
+                                            "hfoo: bar\r\n"
+                                            "\r\n"  // Newline after headers.
+                                            "Hi mom"
+                                            "\r\n--%@\r\n"
+                                            "\r\n"  // No header here, but still need the newline.
+                                            "Hi dad"
+                                            "\r\n--%@\r\n"
+                                            "Content-Disposition: angry\r\n"
+                                            "Content-ID: MyCat:fluffy\r\n"
+                                            "Content-Type: text/html\r\n"
+                                            "\r\n"  // Newline after headers.
+                                            "Hi brother"
+                                            "\r\n--%@--\r\n";
 
   NSString *boundary = nil;
   unsigned long long length = ULONG_MAX;
 
   // Generate the boundary and the data.
   dispatch_data_t data;
-  [doc generateDispatchData:&data
-                     length:&length
-                   boundary:&boundary];
+  [doc generateDispatchData:&data length:&length boundary:&boundary];
 
   NSString *expectedResultString =
-      [NSString stringWithFormat:expectedResultTemplate,
-       boundary, boundary, boundary, boundary];
+      [NSString stringWithFormat:expectedResultTemplate, boundary, boundary, boundary, boundary];
 
-  [self doDataTestForDispatchData:data
-                   expectedString:expectedResultString];
+  [self doDataTestForDispatchData:data expectedString:expectedResultString];
 
   // Generate the boundary and the input stream.
   NSInputStream *stream = nil;
 
-  [doc generateInputStream:&stream
-                    length:&length
-                  boundary:&boundary];
+  [doc generateInputStream:&stream length:&length boundary:&boundary];
 
   expectedResultString =
-      [NSString stringWithFormat:expectedResultTemplate,
-        boundary, boundary, boundary, boundary];
+      [NSString stringWithFormat:expectedResultTemplate, boundary, boundary, boundary, boundary];
 
-  [self doReadTestForInputStream:stream
-                  expectedString:expectedResultString];
+  [self doReadTestForInputStream:stream expectedString:expectedResultString];
 
   //
   // These tests check behavior with NULL parameters.
@@ -223,43 +200,32 @@ static NSMutableData *DataForTestWithLength(NSUInteger length);
   NSString *expectedBoundary = boundary;
 
   // Generate the length and boundary only via data request.
-  [doc generateDispatchData:NULL
-                     length:&length
-                   boundary:&boundary];
+  [doc generateDispatchData:NULL length:&length boundary:&boundary];
 
   XCTAssertEqualObjects(boundary, expectedBoundary);
   XCTAssertEqual((NSUInteger)length, expectedLength);
 
   // Generate the length and boundary only via stream request.
-  [doc generateInputStream:NULL
-                    length:&length
-                  boundary:&boundary];
+  [doc generateInputStream:NULL length:&length boundary:&boundary];
 
   XCTAssertEqualObjects(boundary, expectedBoundary);
   XCTAssertEqual((NSUInteger)length, expectedLength);
 
   // Generate the data only.
-  [doc generateDispatchData:&data
-                     length:NULL
-                   boundary:NULL];
+  [doc generateDispatchData:&data length:NULL boundary:NULL];
 
-  [self doDataTestForDispatchData:data
-                   expectedString:expectedResultString];
+  [self doDataTestForDispatchData:data expectedString:expectedResultString];
 
   // Generate the stream only.
-  [doc generateInputStream:&stream
-                    length:NULL
-                  boundary:NULL];
+  [doc generateInputStream:&stream length:NULL boundary:NULL];
 
-  [self doReadTestForInputStream:stream
-                  expectedString:expectedResultString];
-
+  [self doReadTestForInputStream:stream expectedString:expectedResultString];
 }
 
 - (void)testExplicitBoundary {
   GTMMIMEDocument *doc = [GTMMIMEDocument MIMEDocument];
 
-  NSDictionary *h1 = @{ @"hfoo": @"bar", @"hfaz" : @"baz" };
+  NSDictionary *h1 = @{@"hfoo" : @"bar", @"hfaz" : @"baz"};
   NSData *b1 = [@"Hi mom" dataUsingEncoding:NSUTF8StringEncoding];
 
   NSDictionary *h2 = [NSDictionary dictionary];
@@ -275,40 +241,32 @@ static NSMutableData *DataForTestWithLength(NSUInteger length);
   NSString *boundary = nil;
   unsigned long long length = ULONG_MAX;
 
-  NSString *const expectedResultTemplate =
-     @"\r\n--%@\r\n"
-      "hfaz: baz\r\n"
-      "hfoo: bar\r\n"
-      "\r\n"    // Newline after headers.
-      "Hi mom"
-      "\r\n--%@\r\n"
-      "\r\n"    // No header here, but still need the newline.
-      "Hi dad"
-      "\r\n--%@--\r\n";
+  NSString *const expectedResultTemplate = @"\r\n--%@\r\n"
+                                            "hfaz: baz\r\n"
+                                            "hfoo: bar\r\n"
+                                            "\r\n"  // Newline after headers.
+                                            "Hi mom"
+                                            "\r\n--%@\r\n"
+                                            "\r\n"  // No header here, but still need the newline.
+                                            "Hi dad"
+                                            "\r\n--%@--\r\n";
 
   // Generate the boundary and the data.
   dispatch_data_t data;
-  [doc generateDispatchData:&data
-                     length:&length
-                   boundary:&boundary];
+  [doc generateDispatchData:&data length:&length boundary:&boundary];
 
   NSString *expectedResultString =
-      [NSString stringWithFormat:expectedResultTemplate,
-       birdy, birdy, birdy];
+      [NSString stringWithFormat:expectedResultTemplate, birdy, birdy, birdy];
 
-  [self doDataTestForDispatchData:data
-                   expectedString:expectedResultString];
+  [self doDataTestForDispatchData:data expectedString:expectedResultString];
 
   // Generate the boundary and the input stream.
-  [doc generateInputStream:&stream
-                    length:&length
-                  boundary:&boundary];
+  [doc generateInputStream:&stream length:&length boundary:&boundary];
 
   expectedResultString = [NSString stringWithFormat:expectedResultTemplate, birdy, birdy, birdy];
 
   // Now read the document from the input stream.
-  [self doReadTestForInputStream:stream
-                  expectedString:expectedResultString];
+  [self doReadTestForInputStream:stream expectedString:expectedResultString];
 }
 
 - (void)testBoundaryConflict {
@@ -318,13 +276,13 @@ static NSMutableData *DataForTestWithLength(NSUInteger length);
   // both the normal boundary ("END_OF_PART") and the first alternate
   // guess (given a random seed of 1, done below).
 
-  NSDictionary *h1 = @{ @"hfoo": @"bar", @"hfaz" : @"baz" };
+  NSDictionary *h1 = @{@"hfoo" : @"bar", @"hfaz" : @"baz"};
   NSData *b1 = [@"Hi mom END_OF_PART" dataUsingEncoding:NSUTF8StringEncoding];
 
   NSDictionary *h2 = [NSDictionary dictionary];
   NSData *b2 = [@"Hi dad" dataUsingEncoding:NSUTF8StringEncoding];
 
-  NSDictionary *h3 = @{ @"Content-Type": @"text/html", @"Content-Disposition": @"angry" };
+  NSDictionary *h3 = @{@"Content-Type" : @"text/html", @"Content-Disposition" : @"angry"};
   NSData *b3 = [@"Hi brother END_OF_PART_6b8b4567" dataUsingEncoding:NSUTF8StringEncoding];
 
   [doc addPartWithHeaders:h1 body:b1];
@@ -332,36 +290,32 @@ static NSMutableData *DataForTestWithLength(NSUInteger length);
   [doc addPartWithHeaders:h3 body:b3];
 
   NSString *const expectedResultTemplate =
-     @"\r\n--%@\r\n"
-      "hfaz: baz\r\n"
-      "hfoo: bar\r\n"
-      "\r\n"    // Newline after headers.
-      "Hi mom END_OF_PART"  // Intentional conflict.
-      "\r\n--%@\r\n"
-      "\r\n"    // No header here, but still need the newline.
-      "Hi dad"
-      "\r\n--%@\r\n"
-      "Content-Disposition: angry\r\n"
-      "Content-Type: text/html\r\n"
-      "\r\n"    // Newline after headers.
-      "Hi brother END_OF_PART_6b8b4567" // Conflict with the first guess.
-      "\r\n--%@--\r\n";
+      @"\r\n--%@\r\n"
+       "hfaz: baz\r\n"
+       "hfoo: bar\r\n"
+       "\r\n"                // Newline after headers.
+       "Hi mom END_OF_PART"  // Intentional conflict.
+       "\r\n--%@\r\n"
+       "\r\n"  // No header here, but still need the newline.
+       "Hi dad"
+       "\r\n--%@\r\n"
+       "Content-Disposition: angry\r\n"
+       "Content-Type: text/html\r\n"
+       "\r\n"                             // Newline after headers.
+       "Hi brother END_OF_PART_6b8b4567"  // Conflict with the first guess.
+       "\r\n--%@--\r\n";
 
   // Generate the boundary and the data.
   dispatch_data_t data;
   NSString *boundary = nil;
   unsigned long long length = ULONG_MAX;
 
-  [doc generateDispatchData:&data
-                     length:&length
-                   boundary:&boundary];
+  [doc generateDispatchData:&data length:&length boundary:&boundary];
 
   NSString *expectedResultString =
-    [NSString stringWithFormat:expectedResultTemplate, boundary, boundary, boundary, boundary];
+      [NSString stringWithFormat:expectedResultTemplate, boundary, boundary, boundary, boundary];
 
-  [self doDataTestForDispatchData:data
-                   expectedString:expectedResultString];
-
+  [self doDataTestForDispatchData:data expectedString:expectedResultString];
 
   // Generate the boundary and the input stream.
   NSInputStream *stream = nil;
@@ -372,9 +326,7 @@ static NSMutableData *DataForTestWithLength(NSUInteger length);
   NSString *expectedBoundary = @"END_OF_PART_00000001";
   XCTAssertEqualObjects(resultBoundary, expectedBoundary);
 
-  [doc generateInputStream:&stream
-                    length:&length
-                  boundary:&boundary];
+  [doc generateInputStream:&stream length:&length boundary:&boundary];
 
   // The second alternate boundary, given the random seed.
 
@@ -382,8 +334,7 @@ static NSMutableData *DataForTestWithLength(NSUInteger length);
       [NSString stringWithFormat:expectedResultTemplate, boundary, boundary, boundary, boundary];
 
   // Now read the document from the input stream.
-  [self doReadTestForInputStream:stream
-                  expectedString:expectedResultString];
+  [self doReadTestForInputStream:stream expectedString:expectedResultString];
 }
 
 #pragma mark - Separating Parts Tests
@@ -391,12 +342,12 @@ static NSMutableData *DataForTestWithLength(NSUInteger length);
 - (void)testFindBytes {
   NSUInteger (^find)(NSData *, NSData *, NSUInteger *) =
       ^(NSData *needle, NSData *haystack, NSUInteger *foundOffset) {
-    return [GTMMIMEDocument findBytesWithNeedle:needle.bytes
-                                   needleLength:needle.length
-                                       haystack:haystack.bytes
-                                 haystackLength:haystack.length
-                                    foundOffset:foundOffset];
-  };
+        return [GTMMIMEDocument findBytesWithNeedle:needle.bytes
+                                       needleLength:needle.length
+                                           haystack:haystack.bytes
+                                     haystackLength:haystack.length
+                                        foundOffset:foundOffset];
+      };
 
   NSUInteger numberOfBytesMatched, foundOffset;
 
@@ -438,7 +389,8 @@ static NSMutableData *DataForTestWithLength(NSUInteger length);
   XCTAssertEqual(foundOffset, (NSUInteger)0);
 
   haystackData = DataForTestWithLength(100);
-  [haystackData appendData:[needleData subdataWithRange:NSMakeRange(0, 5)]];  // Five bytes of needle.
+  [haystackData
+      appendData:[needleData subdataWithRange:NSMakeRange(0, 5)]];  // Five bytes of needle.
   [haystackData appendData:DataForTestWithLength(100)];
 
   numberOfBytesMatched = find(needleData, haystackData, &foundOffset);
@@ -454,7 +406,8 @@ static NSMutableData *DataForTestWithLength(NSUInteger length);
   XCTAssertEqual(foundOffset, (NSUInteger)1000);
 
   haystackData = DataForTestWithLength(1000);
-  [haystackData appendData:[needleData subdataWithRange:NSMakeRange(0, 5)]];  // Five bytes of needle.
+  [haystackData
+      appendData:[needleData subdataWithRange:NSMakeRange(0, 5)]];  // Five bytes of needle.
 
   numberOfBytesMatched = find(needleData, haystackData, &foundOffset);
   XCTAssertEqual(numberOfBytesMatched, (NSUInteger)5);
@@ -489,13 +442,13 @@ static NSMutableData *DataForTestWithLength(NSUInteger length);
 }
 
 - (void)testSearchDataForBytes {
-  void (^search)(NSData *, NSData *, NSArray **, NSArray **) =
-    ^(NSData *fullBuffer, NSData *needleData, NSArray **foundOffsets, NSArray **foundBlockNumbers) {
-       [GTMMIMEDocument searchData:fullBuffer
-                       targetBytes:needleData.bytes
-                      targetLength:needleData.length
-                      foundOffsets:foundOffsets
-                 foundBlockNumbers:foundBlockNumbers];
+  void (^search)(NSData *, NSData *, NSArray **, NSArray **) = ^(
+      NSData *fullBuffer, NSData *needleData, NSArray **foundOffsets, NSArray **foundBlockNumbers) {
+    [GTMMIMEDocument searchData:fullBuffer
+                    targetBytes:needleData.bytes
+                   targetLength:needleData.length
+                   foundOffsets:foundOffsets
+              foundBlockNumbers:foundBlockNumbers];
   };
 
   NSArray *offsets, *foundBlockNumbers, *expectedOffsets, *expectedBlockNums;
@@ -516,17 +469,13 @@ static NSMutableData *DataForTestWithLength(NSUInteger length);
   //
 
   // One data range, no target.
-  fullBuffer = [self concatenatedDispatchDataWithDatas:@[
-      DataForTestWithLength(100)
-  ]];
+  fullBuffer = [self concatenatedDispatchDataWithDatas:@[ DataForTestWithLength(100) ]];
   search((NSData *)fullBuffer, catpawTargetData, &offsets, &foundBlockNumbers);
   XCTAssertEqualObjects(offsets, [NSArray array]);
   XCTAssertEqualObjects(foundBlockNumbers, [NSArray array]);
 
   // One data range, target alone.
-  fullBuffer = [self concatenatedDispatchDataWithDatas:@[
-      catpawTargetData
-  ]];
+  fullBuffer = [self concatenatedDispatchDataWithDatas:@[ catpawTargetData ]];
   search((NSData *)fullBuffer, catpawTargetData, &offsets, &foundBlockNumbers);
   expectedOffsets = @[ @0 ];
   expectedBlockNums = @[ @0 ];
@@ -534,9 +483,7 @@ static NSMutableData *DataForTestWithLength(NSUInteger length);
   XCTAssertEqualObjects(foundBlockNumbers, expectedBlockNums);
 
   // One data range, target at beginning.
-  fullBuffer = [self concatenatedDispatchDataWithDatas:@[
-      catpawPlusTestBlock
-  ]];
+  fullBuffer = [self concatenatedDispatchDataWithDatas:@[ catpawPlusTestBlock ]];
   search((NSData *)fullBuffer, catpawTargetData, &offsets, &foundBlockNumbers);
   expectedOffsets = @[ @0 ];
   expectedBlockNums = @[ @0 ];
@@ -544,9 +491,7 @@ static NSMutableData *DataForTestWithLength(NSUInteger length);
   XCTAssertEqualObjects(foundBlockNumbers, expectedBlockNums);
 
   // One data range, target at end.
-  fullBuffer = [self concatenatedDispatchDataWithDatas:@[
-      testPlusCatPawBlock
-  ]];
+  fullBuffer = [self concatenatedDispatchDataWithDatas:@[ testPlusCatPawBlock ]];
   search((NSData *)fullBuffer, catpawTargetData, &offsets, &foundBlockNumbers);
   expectedOffsets = @[ @100 ];
   expectedBlockNums = @[ @0 ];
@@ -555,11 +500,8 @@ static NSMutableData *DataForTestWithLength(NSUInteger length);
 
   // Five data ranges, targets in middle.
   fullBuffer = [self concatenatedDispatchDataWithDatas:@[
-      DataForTestWithLength(100),
-      catpawTargetData,
-      DataForTestWithLength(100),
-      catpawTargetData,
-      DataForTestWithLength(100)
+    DataForTestWithLength(100), catpawTargetData, DataForTestWithLength(100), catpawTargetData,
+    DataForTestWithLength(100)
   ]];
   search((NSData *)fullBuffer, catpawTargetData, &offsets, &foundBlockNumbers);
 
@@ -574,11 +516,8 @@ static NSMutableData *DataForTestWithLength(NSUInteger length);
   [repeatedTargetData appendData:catpawTargetData];
 
   fullBuffer = [self concatenatedDispatchDataWithDatas:@[
-      catpawTargetData,
-      DataForTestWithLength(100),
-      DataForTestWithLength(100),
-      DataForTestWithLength(100),
-      repeatedTargetData
+    catpawTargetData, DataForTestWithLength(100), DataForTestWithLength(100),
+    DataForTestWithLength(100), repeatedTargetData
   ]];
   search((NSData *)fullBuffer, catpawTargetData, &offsets, &foundBlockNumbers);
 
@@ -594,8 +533,8 @@ static NSMutableData *DataForTestWithLength(NSUInteger length);
   [pawPlusTestBlock appendData:DataForTestWithLength(100)];
 
   fullBuffer = [self concatenatedDispatchDataWithDatas:@[
-      testPlusCatBlock,
-      pawPlusTestBlock,
+    testPlusCatBlock,
+    pawPlusTestBlock,
   ]];
   search((NSData *)fullBuffer, catpawTargetData, &offsets, &foundBlockNumbers);
 
@@ -610,8 +549,8 @@ static NSMutableData *DataForTestWithLength(NSUInteger length);
   [testPlusPawBlock appendData:pawTargetData];
 
   fullBuffer = [self concatenatedDispatchDataWithDatas:@[
-      testPlusCatBlock,
-      testPlusPawBlock,
+    testPlusCatBlock,
+    testPlusPawBlock,
   ]];
   search((NSData *)fullBuffer, catpawTargetData, &offsets, &foundBlockNumbers);
 
@@ -620,9 +559,9 @@ static NSMutableData *DataForTestWithLength(NSUInteger length);
 
   // Target spans second and third blocks.
   fullBuffer = [self concatenatedDispatchDataWithDatas:@[
-      DataForTestWithLength(100),
-      testPlusCatBlock,
-      pawPlusTestBlock,
+    DataForTestWithLength(100),
+    testPlusCatBlock,
+    pawPlusTestBlock,
   ]];
   search((NSData *)fullBuffer, catpawTargetData, &offsets, &foundBlockNumbers);
 
@@ -633,10 +572,7 @@ static NSMutableData *DataForTestWithLength(NSUInteger length);
 
   // Target finishes first and start fourth blocks, and spans second and third blocks.
   fullBuffer = [self concatenatedDispatchDataWithDatas:@[
-      testPlusCatPawBlock,
-      testPlusCatBlock,
-      pawPlusTestBlock,
-      catpawPlusTestBlock
+    testPlusCatPawBlock, testPlusCatBlock, pawPlusTestBlock, catpawPlusTestBlock
   ]];
   search((NSData *)fullBuffer, catpawTargetData, &offsets, &foundBlockNumbers);
 
@@ -649,15 +585,16 @@ static NSMutableData *DataForTestWithLength(NSUInteger length);
   NSMutableData *testPlusCaBlock = DataForTestWithLength(100);
   [testPlusCaBlock appendData:[catpawTargetData subdataWithRange:NSMakeRange(0, 2)]];
   NSMutableData *tpBlock = [[catpawTargetData subdataWithRange:NSMakeRange(2, 2)] mutableCopy];
-  NSMutableData *awPlusTestBlock= [[catpawTargetData subdataWithRange:NSMakeRange(4, 2)] mutableCopy];
+  NSMutableData *awPlusTestBlock =
+      [[catpawTargetData subdataWithRange:NSMakeRange(4, 2)] mutableCopy];
   [awPlusTestBlock appendData:DataForTestWithLength(100)];
 
   fullBuffer = [self concatenatedDispatchDataWithDatas:@[
-      DataForTestWithLength(100),
-      testPlusCaBlock,
-      tpBlock,
-      awPlusTestBlock,
-      catpawTargetData,
+    DataForTestWithLength(100),
+    testPlusCaBlock,
+    tpBlock,
+    awPlusTestBlock,
+    catpawTargetData,
   ]];
   search((NSData *)fullBuffer, catpawTargetData, &offsets, &foundBlockNumbers);
 
@@ -668,9 +605,9 @@ static NSMutableData *DataForTestWithLength(NSUInteger length);
 
   // Target starts but doesn't complete in first and third blocks.
   fullBuffer = [self concatenatedDispatchDataWithDatas:@[
-      testPlusCatBlock,
-      DataForTestWithLength(100),
-      testPlusCatBlock,
+    testPlusCatBlock,
+    DataForTestWithLength(100),
+    testPlusCatBlock,
   ]];
   search((NSData *)fullBuffer, catpawTargetData, &offsets, &foundBlockNumbers);
 
@@ -678,19 +615,14 @@ static NSMutableData *DataForTestWithLength(NSUInteger length);
   XCTAssertEqualObjects(foundBlockNumbers, [NSArray array]);
 
   // Ignore partial matches across blocks.
-  fullBuffer = [self concatenatedDispatchDataWithDatas:@[
-    catTargetData,
-    testPlusPawBlock
-  ]];
+  fullBuffer = [self concatenatedDispatchDataWithDatas:@[ catTargetData, testPlusPawBlock ]];
   search((NSData *)fullBuffer, catpawTargetData, &offsets, &foundBlockNumbers);
 
   XCTAssertEqualObjects(offsets, [NSArray array]);
   XCTAssertEqualObjects(foundBlockNumbers, [NSArray array]);
 
   fullBuffer = [self concatenatedDispatchDataWithDatas:@[
-      catTargetData,
-      DataForTestWithLength(1),
-      pawTargetData
+    catTargetData, DataForTestWithLength(1), pawTargetData
   ]];
   search((NSData *)fullBuffer, catpawTargetData, &offsets, &foundBlockNumbers);
 
@@ -705,7 +637,7 @@ static NSMutableData *DataForTestWithLength(NSUInteger length);
   [blockWithOverlap appendData:DataForTestWithLength(100)];
 
   fullBuffer = [self concatenatedDispatchDataWithDatas:@[
-      blockWithOverlap,
+    blockWithOverlap,
   ]];
   search((NSData *)fullBuffer, catscatsTargetData, &offsets, &foundBlockNumbers);
 
@@ -748,8 +680,9 @@ static NSMutableData *DataForTestWithLength(NSUInteger length);
   dispatch_data_t result;
 
   for (NSData *oneData in datas) {
-    dispatch_data_t ddata = dispatch_data_create(oneData.bytes, oneData.length,
-                                                 bgQueue, ^{ [oneData self]; });
+    dispatch_data_t ddata = dispatch_data_create(oneData.bytes, oneData.length, bgQueue, ^{
+      [oneData self];
+    });
     if (!result) {
       result = ddata;
     } else {
@@ -770,10 +703,9 @@ static NSMutableData *DataForTestWithLength(NSUInteger length);
   NSString *docString = [NSString stringWithFormat:docTemplate, docBoundary, docBoundary];
   NSData *docData = [docString dataUsingEncoding:NSUTF8StringEncoding];
 
-  NSArray *parts = [GTMMIMEDocument MIMEPartsWithBoundary:docBoundary
-                                                     data:docData];
-  NSDictionary *expectedHeaders = @{ @"cat-breed" : @"Maine Coon",
-                                     @"dog-breed" : @"German Shepherd" };
+  NSArray *parts = [GTMMIMEDocument MIMEPartsWithBoundary:docBoundary data:docData];
+  NSDictionary *expectedHeaders =
+      @{@"cat-breed" : @"Maine Coon", @"dog-breed" : @"German Shepherd"};
   NSData *expectedBody = [@"Go Spot, go!" dataUsingEncoding:NSUTF8StringEncoding];
 
   GTMMIMEDocumentPart *part0 = parts[0];
@@ -791,8 +723,7 @@ static NSMutableData *DataForTestWithLength(NSUInteger length);
   NSString *docString = [NSString stringWithFormat:docTemplate, docBoundary, docBoundary];
   NSData *docData = [docString dataUsingEncoding:NSUTF8StringEncoding];
 
-  NSArray *parts = [GTMMIMEDocument MIMEPartsWithBoundary:docBoundary
-                                                     data:docData];
+  NSArray *parts = [GTMMIMEDocument MIMEPartsWithBoundary:docBoundary data:docData];
   NSData *expectedBody = [@"Go Spot, go!" dataUsingEncoding:NSUTF8StringEncoding];
 
   GTMMIMEDocumentPart *part0 = parts[0];
@@ -811,10 +742,9 @@ static NSMutableData *DataForTestWithLength(NSUInteger length);
   NSString *docString = [NSString stringWithFormat:docTemplate, docBoundary, docBoundary];
   NSData *docData = [docString dataUsingEncoding:NSUTF8StringEncoding];
 
-  NSArray *parts = [GTMMIMEDocument MIMEPartsWithBoundary:docBoundary
-                                                     data:docData];
-  NSDictionary *expectedHeaders = @{ @"cat-breed" : @"Maine Coon",
-                                     @"dog-breed" : @"German Shepherd" };
+  NSArray *parts = [GTMMIMEDocument MIMEPartsWithBoundary:docBoundary data:docData];
+  NSDictionary *expectedHeaders =
+      @{@"cat-breed" : @"Maine Coon", @"dog-breed" : @"German Shepherd"};
 
   GTMMIMEDocumentPart *part0 = parts[0];
   XCTAssertEqualObjects(part0.headers, expectedHeaders);
@@ -830,8 +760,7 @@ static NSMutableData *DataForTestWithLength(NSUInteger length);
   NSString *docString = [NSString stringWithFormat:docTemplate, docBoundary, docBoundary];
   NSData *docData = [docString dataUsingEncoding:NSUTF8StringEncoding];
 
-  NSArray *parts = [GTMMIMEDocument MIMEPartsWithBoundary:docBoundary
-                                                     data:docData];
+  NSArray *parts = [GTMMIMEDocument MIMEPartsWithBoundary:docBoundary data:docData];
   GTMMIMEDocumentPart *part0 = parts[0];
   XCTAssertNil(part0.headers);
   XCTAssertEqualObjects(part0.body, [NSData data]);
@@ -850,25 +779,24 @@ static NSMutableData *DataForTestWithLength(NSUInteger length);
                                  @"Hi ho, Silver\nAway!\r\nThat's all, folks."
                                  @"\r\n--%@--\r\n this should be ignored");
   NSString *docBoundary = @"END_OF_PART";
-  NSString *docString = [NSString stringWithFormat:docTemplate,
-                         docBoundary, docBoundary, docBoundary];
+  NSString *docString =
+      [NSString stringWithFormat:docTemplate, docBoundary, docBoundary, docBoundary];
   NSData *docData = [docString dataUsingEncoding:NSUTF8StringEncoding];
 
-  NSArray *parts = [GTMMIMEDocument MIMEPartsWithBoundary:docBoundary
-                                                     data:docData];
+  NSArray *parts = [GTMMIMEDocument MIMEPartsWithBoundary:docBoundary data:docData];
   XCTAssertEqual(parts.count, (NSUInteger)2);
 
-  NSDictionary *expectedHeaders0 = @{ @"cat-breed" : @"Maine Coon",
-                                     @"dog-breed" : @"German Shepherd" };
+  NSDictionary *expectedHeaders0 =
+      @{@"cat-breed" : @"Maine Coon", @"dog-breed" : @"German Shepherd"};
   NSData *expectedBody0 = [@"Go Spot, go!" dataUsingEncoding:NSUTF8StringEncoding];
 
   GTMMIMEDocumentPart *part0 = parts[0];
   XCTAssertEqualObjects(part0.headers, expectedHeaders0);
   XCTAssertEqualObjects(part0.body, expectedBody0);
 
-  NSDictionary *expectedHeaders1 = @{ @"Horse-breed" : @"Friesian" };
+  NSDictionary *expectedHeaders1 = @{@"Horse-breed" : @"Friesian"};
   NSData *expectedBody1 =
-    [@"Hi ho, Silver\nAway!\r\nThat's all, folks." dataUsingEncoding:NSUTF8StringEncoding];
+      [@"Hi ho, Silver\nAway!\r\nThat's all, folks." dataUsingEncoding:NSUTF8StringEncoding];
 
   GTMMIMEDocumentPart *part1 = parts[1];
   XCTAssertEqualObjects(part1.headers, expectedHeaders1);
@@ -887,8 +815,7 @@ static NSMutableData *DataForTestWithLength(NSUInteger length);
   NSString *docString = [NSString stringWithFormat:docTemplate, docBoundary, docBoundary];
   NSData *docData = [docString dataUsingEncoding:NSUTF8StringEncoding];
 
-  NSArray *parts = [GTMMIMEDocument MIMEPartsWithBoundary:docBoundary
-                                                     data:docData];
+  NSArray *parts = [GTMMIMEDocument MIMEPartsWithBoundary:docBoundary data:docData];
   XCTAssertEqual(parts.count, (NSUInteger)1);
   GTMMIMEDocumentPart *part0 = parts[0];
   XCTAssertNil(part0.headers);
@@ -907,4 +834,3 @@ static NSMutableData *DataForTestWithLength(NSUInteger length) {
   }
   return mutable;
 }
-

--- a/Source/UnitTests/GTMReadMonitorInputStreamTest.m
+++ b/Source/UnitTests/GTMReadMonitorInputStreamTest.m
@@ -68,7 +68,6 @@
 
   [monitorStream open];
   while ([monitorStream hasBytesAvailable]) {
-
     unsigned char buffer[101];
     NSUInteger numBytesToRead = (arc4random() % 100) + 1;
 
@@ -81,14 +80,12 @@
   [monitorStream close];
 
   // Verify we read all the data.
-  XCTAssertEqualObjects(readData, testData,
-                       @"read data doesn't match stream data");
+  XCTAssertEqualObjects(readData, testData, @"read data doesn't match stream data");
 
   // Verify the callback saw the same data.
   XCTAssertEqualObjects(_monitoredData, testData,
-                       @"callback progress doesn't match actual progress");
+                        @"callback progress doesn't match actual progress");
 }
-
 
 - (void)inputStream:(GTMReadMonitorInputStream *)stream
      readIntoBuffer:(uint8_t *)buffer

--- a/Source/UnitTests/GTMSessionFetcherChunkedUploadTest.m
+++ b/Source/UnitTests/GTMSessionFetcherChunkedUploadTest.m
@@ -21,21 +21,21 @@
 
 // Helper macro to create fetcher start/stop notification expectations. These use alloc/init
 // directly to prevent them being waited for by wait helper methods on XCTestCase.
-#define CREATE_START_STOP_NOTIFICATION_EXPECTATIONS(START_COUNT, STOP_COUNT) \
-    XCTestExpectation *fetcherStartedExpectation__ = \
-        [[XCTNSNotificationExpectation alloc] initWithName:kGTMSessionFetcherStartedNotification]; \
-    XCTestExpectation *fetcherStoppedExpectation__ = \
-        [[XCTNSNotificationExpectation alloc] initWithName:kGTMSessionFetcherStoppedNotification]; \
-    fetcherStartedExpectation__.expectedFulfillmentCount = (START_COUNT); \
-    fetcherStartedExpectation__.assertForOverFulfill = YES; \
-    fetcherStoppedExpectation__.expectedFulfillmentCount = (STOP_COUNT); \
-    fetcherStoppedExpectation__.assertForOverFulfill = YES;
+#define CREATE_START_STOP_NOTIFICATION_EXPECTATIONS(START_COUNT, STOP_COUNT)                     \
+  XCTestExpectation *fetcherStartedExpectation__ =                                               \
+      [[XCTNSNotificationExpectation alloc] initWithName:kGTMSessionFetcherStartedNotification]; \
+  XCTestExpectation *fetcherStoppedExpectation__ =                                               \
+      [[XCTNSNotificationExpectation alloc] initWithName:kGTMSessionFetcherStoppedNotification]; \
+  fetcherStartedExpectation__.expectedFulfillmentCount = (START_COUNT);                          \
+  fetcherStartedExpectation__.assertForOverFulfill = YES;                                        \
+  fetcherStoppedExpectation__.expectedFulfillmentCount = (STOP_COUNT);                           \
+  fetcherStoppedExpectation__.assertForOverFulfill = YES;
 
 // Helper macro to wait on the notification expectations created by the CREATE_START_STOP macro.
 // Using -[XCTestCase waitForExpectations...] methods will NOT wait for them.
-#define WAIT_FOR_START_STOP_NOTIFICATION_EXPECTATIONS() \
-    [self waitForExpectations:@[ fetcherStartedExpectation__, fetcherStoppedExpectation__ ] \
-                      timeout:5.0];
+#define WAIT_FOR_START_STOP_NOTIFICATION_EXPECTATIONS()                                   \
+  [self waitForExpectations:@[ fetcherStartedExpectation__, fetcherStoppedExpectation__ ] \
+                    timeout:5.0];
 
 @interface GTMSessionFetcherChunkedUploadTest : GTMSessionFetcherBaseTest
 @end
@@ -72,7 +72,7 @@
   // No test server needed.
   _testServer = nil;
   _isServerRunning = NO;
-  
+
   CREATE_START_STOP_NOTIFICATION_EXPECTATIONS(2, 2);
 
   FetcherNotificationsCounter *fnctr = [[FetcherNotificationsCounter alloc] init];
@@ -94,13 +94,13 @@
       [[NSHTTPURLResponse alloc] initWithURL:testURL
                                   statusCode:200
                                  HTTPVersion:@"HTTP/1.1"
-                                headerFields:@{ @"Bichon" : @"Frise" }];
+                                headerFields:@{@"Bichon" : @"Frise"}];
   NSError *fakedResultError = nil;
 
-  fetcher.testBlock = ^(GTMSessionFetcher *fetcherToTest,
-                        GTMSessionFetcherTestResponse testResponse) {
-      testResponse(fakedResultResponse, fakedResultData, fakedResultError);
-  };
+  fetcher.testBlock =
+      ^(GTMSessionFetcher *fetcherToTest, GTMSessionFetcherTestResponse testResponse) {
+        testResponse(fakedResultResponse, fakedResultData, fakedResultError);
+      };
 
   fetcher.useBackgroundSession = NO;
   fetcher.allowedInsecureSchemes = @[ @"http" ];
@@ -108,10 +108,10 @@
   XCTestExpectation *expectation =
       [self expectationWithDescription:@"NSData upload test completion"];
   [fetcher beginFetchWithCompletionHandler:^(NSData *data, NSError *error) {
-      XCTAssertEqualObjects(data, fakedResultData);
-      XCTAssertNil(error);
-      XCTAssertEqual(fetcher.statusCode, (NSInteger)200);
-      [expectation fulfill];
+    XCTAssertEqualObjects(data, fakedResultData);
+    XCTAssertNil(error);
+    XCTAssertEqual(fetcher.statusCode, (NSInteger)200);
+    [expectation fulfill];
   }];
   [self waitForExpectationsWithTimeout:_timeoutInterval handler:nil];
   [self assertCallbacksReleasedForFetcher:fetcher];
@@ -134,34 +134,35 @@
   [fetcher setUploadDataLength:(int64_t)expectedRange.length
                       provider:^(int64_t offset, int64_t length,
                                  GTMSessionUploadFetcherDataProviderResponse response) {
-      NSRange providingRange = NSMakeRange((NSUInteger)offset, (NSUInteger)length);
-      uploadedRange = NSUnionRange(uploadedRange, providingRange);
-      NSData *subdata = [bigUploadData subdataWithRange:providingRange];
-      response(subdata, kGTMSessionUploadFetcherUnknownFileSize, nil);
-  }];
+                        NSRange providingRange =
+                            NSMakeRange((NSUInteger)offset, (NSUInteger)length);
+                        uploadedRange = NSUnionRange(uploadedRange, providingRange);
+                        NSData *subdata = [bigUploadData subdataWithRange:providingRange];
+                        response(subdata, kGTMSessionUploadFetcherUnknownFileSize, nil);
+                      }];
 
   fakedResultError = nil;
 
-  fetcher.testBlock = ^(GTMSessionFetcher *fetcherToTest,
-                        GTMSessionFetcherTestResponse testResponse) {
-      testResponse(fakedResultResponse, fakedResultData, fakedResultError);
-  };
+  fetcher.testBlock =
+      ^(GTMSessionFetcher *fetcherToTest, GTMSessionFetcherTestResponse testResponse) {
+        testResponse(fakedResultResponse, fakedResultData, fakedResultError);
+      };
 
   fetcher.useBackgroundSession = NO;
   fetcher.allowedInsecureSchemes = @[ @"http" ];
 
   expectation = [self expectationWithDescription:@"upload data provider completion"];
   [fetcher beginFetchWithCompletionHandler:^(NSData *data, NSError *error) {
-      XCTAssertEqualObjects(data, fakedResultData);
-      XCTAssertNil(error);
-      XCTAssertEqual(fetcher.statusCode, (NSInteger)200);
-      [expectation fulfill];
+    XCTAssertEqualObjects(data, fakedResultData);
+    XCTAssertNil(error);
+    XCTAssertEqual(fetcher.statusCode, (NSInteger)200);
+    [expectation fulfill];
   }];
   [self waitForExpectationsWithTimeout:_timeoutInterval handler:nil];
   XCTAssertTrue(NSEqualRanges(uploadedRange, expectedRange), @"Uploaded %@ (expected %@)",
                 NSStringFromRange(uploadedRange), NSStringFromRange(expectedRange));
   [self assertCallbacksReleasedForFetcher:fetcher];
-  
+
   WAIT_FOR_START_STOP_NOTIFICATION_EXPECTATIONS();
 
   XCTAssertEqual(fnctr.fetchStarted, 2);
@@ -190,15 +191,13 @@ static const NSUInteger kBigUploadDataLength = 199000;
 // and to change the upload location URL to cause a chunk upload
 // failure and retry.
 
-static NSString* const kPauseAtKey = @"pauseAt";
-static NSString* const kCancelAtKey = @"cancelAt";
-static NSString* const kRetryAtKey = @"retryAt";
-static NSString* const kOriginalURLKey = @"originalURL";
+static NSString *const kPauseAtKey = @"pauseAt";
+static NSString *const kCancelAtKey = @"cancelAt";
+static NSString *const kRetryAtKey = @"retryAt";
+static NSString *const kOriginalURLKey = @"originalURL";
 
-static void TestProgressBlock(GTMSessionUploadFetcher *fetcher,
-                              int64_t bytesSent,
-                              int64_t totalBytesSent,
-                              int64_t totalBytesExpectedToSend) {
+static void TestProgressBlock(GTMSessionUploadFetcher *fetcher, int64_t bytesSent,
+                              int64_t totalBytesSent, int64_t totalBytesExpectedToSend) {
   NSNumber *pauseAtNum = [fetcher propertyForKey:kPauseAtKey];
   if (pauseAtNum) {
     int pauseAt = [pauseAtNum intValue];
@@ -210,13 +209,9 @@ static void TestProgressBlock(GTMSessionUploadFetcher *fetcher,
       //
       // Use perform selector to avoid pausing immediately, as that would nuke
       // the chunk upload fetcher that is calling us back now.
-      [fetcher performSelector:@selector(pauseFetching)
-                    withObject:nil
-                    afterDelay:0.0];
+      [fetcher performSelector:@selector(pauseFetching) withObject:nil afterDelay:0.0];
 
-      [fetcher performSelector:@selector(resumeFetching)
-                    withObject:nil
-                    afterDelay:1.0];
+      [fetcher performSelector:@selector(resumeFetching) withObject:nil afterDelay:1.0];
     }
   }
 
@@ -230,9 +225,7 @@ static void TestProgressBlock(GTMSessionUploadFetcher *fetcher,
       //
       // Use perform selector to avoid stopping immediately, as that would nuke
       // the chunk upload fetcher that is calling us back now.
-      [fetcher performSelector:@selector(stopFetching)
-                    withObject:nil
-                    afterDelay:0.0];
+      [fetcher performSelector:@selector(stopFetching) withObject:nil afterDelay:0.0];
     }
   }
 
@@ -255,7 +248,7 @@ static void TestProgressBlock(GTMSessionUploadFetcher *fetcher,
 
 - (void)testSmallDataChunkedUploadFetch {
   if (!_isServerRunning) return;
-  
+
   CREATE_START_STOP_NOTIFICATION_EXPECTATIONS(2, 2);
 
   FetcherNotificationsCounter *fnctr = [[FetcherNotificationsCounter alloc] init];
@@ -274,21 +267,20 @@ static void TestProgressBlock(GTMSessionUploadFetcher *fetcher,
   fetcher.useBackgroundSession = NO;
 
   XCTAssertEqualObjects([fetcher.request.allHTTPHeaderFields valueForKey:@"User-Agent"],
-                        @"UploadTest (GTMSUF/1)",
-                        @"%@", fetcher.request.allHTTPHeaderFields);
+                        @"UploadTest (GTMSUF/1)", @"%@", fetcher.request.allHTTPHeaderFields);
 
   XCTestExpectation *expectation = [self expectationWithDescription:@"fetched"];
   [fetcher beginFetchWithCompletionHandler:^(NSData *data, NSError *error) {
-      XCTAssertEqualObjects(data, [self gettysburgAddress]);
-      XCTAssertNil(error);
-      XCTAssertEqual(fetcher.statusCode, (NSInteger)200);
-      [expectation fulfill];
+    XCTAssertEqualObjects(data, [self gettysburgAddress]);
+    XCTAssertNil(error);
+    XCTAssertEqual(fetcher.statusCode, (NSInteger)200);
+    [expectation fulfill];
   }];
   [self waitForExpectationsWithTimeout:_timeoutInterval handler:nil];
   [self assertCallbacksReleasedForFetcher:fetcher];
 
   [self assertSmallUploadFetchNotificationsWithCounter:fnctr];
-  
+
   WAIT_FOR_START_STOP_NOTIFICATION_EXPECTATIONS();
 
   XCTAssertEqual(fnctr.fetchStarted, 2);
@@ -302,7 +294,7 @@ static void TestProgressBlock(GTMSessionUploadFetcher *fetcher,
 
 - (void)testSmallDataProviderChunkedUploadFetch {
   if (!_isServerRunning) return;
-  
+
   CREATE_START_STOP_NOTIFICATION_EXPECTATIONS(2, 2);
 
   FetcherNotificationsCounter *fnctr = [[FetcherNotificationsCounter alloc] init];
@@ -320,34 +312,33 @@ static void TestProgressBlock(GTMSessionUploadFetcher *fetcher,
   [fetcher setUploadDataLength:(int64_t)smallData.length
                       provider:^(int64_t offset, int64_t length,
                                  GTMSessionUploadFetcherDataProviderResponse response) {
-      NSRange range = NSMakeRange((NSUInteger)offset, (NSUInteger)length);
-      NSData *responseData = [smallData subdataWithRange:range];
-      response(responseData, kGTMSessionUploadFetcherUnknownFileSize, nil);
-  }];
+                        NSRange range = NSMakeRange((NSUInteger)offset, (NSUInteger)length);
+                        NSData *responseData = [smallData subdataWithRange:range];
+                        response(responseData, kGTMSessionUploadFetcherUnknownFileSize, nil);
+                      }];
 
   // The unit tests run in a process without a signature, so they are not allowed to
   // use background sessions.
   fetcher.useBackgroundSession = NO;
   fetcher.allowLocalhostRequest = YES;
 
-  NSString *expectedUserAgent = [NSString stringWithFormat:@"%@ (GTMSUF/1)",
-                                 GTMFetcherStandardUserAgentString(nil)];
+  NSString *expectedUserAgent =
+      [NSString stringWithFormat:@"%@ (GTMSUF/1)", GTMFetcherStandardUserAgentString(nil)];
   XCTAssertEqualObjects([fetcher.request.allHTTPHeaderFields valueForKey:@"User-Agent"],
-                        expectedUserAgent,
-                        @"%@", fetcher.request.allHTTPHeaderFields);
+                        expectedUserAgent, @"%@", fetcher.request.allHTTPHeaderFields);
 
   XCTestExpectation *expectation = [self expectationWithDescription:@"fetched"];
   [fetcher beginFetchWithCompletionHandler:^(NSData *data, NSError *error) {
-      XCTAssertEqualObjects(data, [self gettysburgAddress]);
-      XCTAssertNil(error);
-      XCTAssertEqual(fetcher.statusCode, (NSInteger)200);
-      [expectation fulfill];
+    XCTAssertEqualObjects(data, [self gettysburgAddress]);
+    XCTAssertNil(error);
+    XCTAssertEqual(fetcher.statusCode, (NSInteger)200);
+    [expectation fulfill];
   }];
   [self waitForExpectationsWithTimeout:_timeoutInterval handler:nil];
   [self assertCallbacksReleasedForFetcher:fetcher];
 
   [self assertSmallUploadFetchNotificationsWithCounter:fnctr];
-  
+
   WAIT_FOR_START_STOP_NOTIFICATION_EXPECTATIONS();
 
   XCTAssertEqual(fnctr.fetchStarted, 2);
@@ -361,7 +352,7 @@ static void TestProgressBlock(GTMSessionUploadFetcher *fetcher,
 
 - (void)testSmallDataProviderWithUnknownFileLengthChunkedUploadFetch {
   if (!_isServerRunning) return;
-  
+
   CREATE_START_STOP_NOTIFICATION_EXPECTATIONS(2, 2);
 
   FetcherNotificationsCounter *fnctr = [[FetcherNotificationsCounter alloc] init];
@@ -390,11 +381,10 @@ static void TestProgressBlock(GTMSessionUploadFetcher *fetcher,
   fetcher.useBackgroundSession = NO;
   fetcher.allowLocalhostRequest = YES;
 
-  NSString *expectedUserAgent = [NSString stringWithFormat:@"%@ (GTMSUF/1)",
-                                 GTMFetcherStandardUserAgentString(nil)];
+  NSString *expectedUserAgent =
+      [NSString stringWithFormat:@"%@ (GTMSUF/1)", GTMFetcherStandardUserAgentString(nil)];
   XCTAssertEqualObjects([fetcher.request.allHTTPHeaderFields valueForKey:@"User-Agent"],
-                        expectedUserAgent,
-                        @"%@", fetcher.request.allHTTPHeaderFields);
+                        expectedUserAgent, @"%@", fetcher.request.allHTTPHeaderFields);
 
   XCTestExpectation *expectation = [self expectationWithDescription:@"fetched"];
   [fetcher beginFetchWithCompletionHandler:^(NSData *data, NSError *error) {
@@ -407,7 +397,7 @@ static void TestProgressBlock(GTMSessionUploadFetcher *fetcher,
   [self assertCallbacksReleasedForFetcher:fetcher];
 
   [self assertSmallUploadFetchNotificationsWithCounter:fnctr];
-  
+
   WAIT_FOR_START_STOP_NOTIFICATION_EXPECTATIONS();
 
   XCTAssertEqual(fnctr.fetchStarted, 2);
@@ -421,7 +411,7 @@ static void TestProgressBlock(GTMSessionUploadFetcher *fetcher,
 
 - (void)testSmallDataProviderChunkedErrorUploadFetch {
   if (!_isServerRunning) return;
-  
+
   CREATE_START_STOP_NOTIFICATION_EXPECTATIONS(1, 1);
 
   FetcherNotificationsCounter *fnctr = [[FetcherNotificationsCounter alloc] init];
@@ -435,10 +425,10 @@ static void TestProgressBlock(GTMSessionUploadFetcher *fetcher,
   [fetcher setUploadDataLength:(int64_t)smallData.length
                       provider:^(int64_t offset, int64_t length,
                                  GTMSessionUploadFetcherDataProviderResponse response) {
-    // Fail to provide NSData.
-    NSError *error = [NSError errorWithDomain:@"domain" code:-123 userInfo:nil];
-    response(nil, kGTMSessionUploadFetcherUnknownFileSize, error);
-  }];
+                        // Fail to provide NSData.
+                        NSError *error = [NSError errorWithDomain:@"domain" code:-123 userInfo:nil];
+                        response(nil, kGTMSessionUploadFetcherUnknownFileSize, error);
+                      }];
 
   // The unit tests run in a process without a signature, so they are not allowed to
   // use background sessions.
@@ -447,13 +437,13 @@ static void TestProgressBlock(GTMSessionUploadFetcher *fetcher,
 
   XCTestExpectation *expectation = [self expectationWithDescription:@"fetched"];
   [fetcher beginFetchWithCompletionHandler:^(NSData *data, NSError *error) {
-      XCTAssertNil(data);
-      XCTAssertEqual(error.code, -123);
-      [expectation fulfill];
+    XCTAssertNil(data);
+    XCTAssertEqual(error.code, -123);
+    [expectation fulfill];
   }];
   [self waitForExpectationsWithTimeout:_timeoutInterval handler:nil];
   [self assertCallbacksReleasedForFetcher:fetcher];
-  
+
   WAIT_FOR_START_STOP_NOTIFICATION_EXPECTATIONS();
 
   XCTAssertEqual(fnctr.fetchStarted, 1);
@@ -478,18 +468,13 @@ static void TestProgressBlock(GTMSessionUploadFetcher *fetcher,
 
 - (void)assertBigUploadFetchNotificationsWithCounter:(FetcherNotificationsCounter *)fnctr {
   // These are for the big upload tests that require no resume or retry fetches.
-  NSArray *expectedURLStrings = @[ @"/gettysburgaddress.txt.upload",
-                                   @"/gettysburgaddress.txt.upload",
-                                   @"/gettysburgaddress.txt.upload" ];
-  NSArray *expectedCommands = @[ @"upload",
-                                 @"upload",
-                                 @"upload, finalize" ];
-  NSArray *expectedOffsets = @[ @0,
-                                @75000,
-                                @150000 ];
-  NSArray *expectedLengths = @[ @75000,
-                                @75000,
-                                @49000 ];
+  NSArray *expectedURLStrings = @[
+    @"/gettysburgaddress.txt.upload", @"/gettysburgaddress.txt.upload",
+    @"/gettysburgaddress.txt.upload"
+  ];
+  NSArray *expectedCommands = @[ @"upload", @"upload", @"upload, finalize" ];
+  NSArray *expectedOffsets = @[ @0, @75000, @150000 ];
+  NSArray *expectedLengths = @[ @75000, @75000, @49000 ];
   XCTAssertEqualObjects(fnctr.uploadChunkRequestPaths, expectedURLStrings);
   XCTAssertEqualObjects(fnctr.uploadChunkCommands, expectedCommands);
   XCTAssertEqualObjects(fnctr.uploadChunkOffsets, expectedOffsets);
@@ -547,17 +532,17 @@ static void TestProgressBlock(GTMSessionUploadFetcher *fetcher,
 
   XCTestExpectation *expectation = [self expectationWithDescription:@"fetched"];
   [fetcher beginFetchWithCompletionHandler:^(NSData *data, NSError *error) {
-      XCTAssertEqualObjects(data, [self gettysburgAddress]);
-      XCTAssertNil(error);
-      XCTAssertEqual(fetcher.statusCode, (NSInteger)200);
-      [expectation fulfill];
+    XCTAssertEqualObjects(data, [self gettysburgAddress]);
+    XCTAssertNil(error);
+    XCTAssertEqual(fetcher.statusCode, (NSInteger)200);
+    [expectation fulfill];
   }];
 
   [self waitForExpectationsWithTimeout:_timeoutInterval handler:nil];
   [self assertCallbacksReleasedForFetcher:fetcher];
 
   [self assertBigUploadFetchNotificationsWithCounter:fnctr];
-  
+
   WAIT_FOR_START_STOP_NOTIFICATION_EXPECTATIONS();
 
   XCTAssertEqual(fnctr.fetchStarted, 4);
@@ -589,17 +574,17 @@ static void TestProgressBlock(GTMSessionUploadFetcher *fetcher,
 
   XCTestExpectation *expectation = [self expectationWithDescription:@"fetched"];
   [fetcher beginFetchWithCompletionHandler:^(NSData *data, NSError *error) {
-      XCTAssertEqualObjects(data, [self gettysburgAddress]);
-      XCTAssertNil(error);
-      XCTAssertEqual(fetcher.statusCode, (NSInteger)200);
-      [expectation fulfill];
+    XCTAssertEqualObjects(data, [self gettysburgAddress]);
+    XCTAssertNil(error);
+    XCTAssertEqual(fetcher.statusCode, (NSInteger)200);
+    [expectation fulfill];
   }];
 
   [self waitForExpectationsWithTimeout:_timeoutInterval handler:nil];
   [self assertCallbacksReleasedForFetcher:fetcher];
 
   [self assertBigUploadFetchNotificationsWithCounter:fnctr];
-  
+
   WAIT_FOR_START_STOP_NOTIFICATION_EXPECTATIONS();
 
   XCTAssertEqual(fnctr.fetchStarted, 4);
@@ -632,18 +617,19 @@ static void TestProgressBlock(GTMSessionUploadFetcher *fetcher,
 
   XCTestExpectation *expectation = [self expectationWithDescription:@"completion handler"];
   [fetcher beginFetchWithCompletionHandler:^(NSData *data, NSError *error) {
-      XCTAssertEqualObjects(data, [self gettysburgAddress]);
-      XCTAssertNil(error);
-      XCTAssertEqual(fetcher.statusCode, (NSInteger)200);
-      [expectation fulfill];
+    XCTAssertEqualObjects(data, [self gettysburgAddress]);
+    XCTAssertNil(error);
+    XCTAssertEqual(fetcher.statusCode, (NSInteger)200);
+    [expectation fulfill];
   }];
 
   [self waitForExpectationsWithTimeout:_timeoutInterval handler:nil];
   [self assertCallbacksReleasedForFetcher:fetcher];
 
-  NSArray *expectedURLStrings = @[ @"/gettysburgaddress.txt.upload",
-                                   @"/gettysburgaddress.txt.upload",
-                                   @"/gettysburgaddress.txt.upload" ];
+  NSArray *expectedURLStrings = @[
+    @"/gettysburgaddress.txt.upload", @"/gettysburgaddress.txt.upload",
+    @"/gettysburgaddress.txt.upload"
+  ];
   NSArray *expectedCommands = @[ @"upload", @"upload", @"upload, finalize" ];
   NSArray *expectedOffsets = @[ @0, @66666, @133332 ];
   NSArray *expectedLengths = @[ @66666, @66666, @65668 ];
@@ -655,8 +641,8 @@ static void TestProgressBlock(GTMSessionUploadFetcher *fetcher,
   // The final Content-Length should be the residual bytes considering the granularity;
   // the final offset should be a multiple of the granularity.
   int64_t lastOffset = ((NSNumber *)fnctr.uploadChunkOffsets.lastObject).longLongValue;
-  XCTAssertTrue(lastOffset > 0 && (lastOffset % kGranularity) == 0,
-                @"%lld not a multiple of %lld", lastOffset, kGranularity);
+  XCTAssertTrue(lastOffset > 0 && (lastOffset % kGranularity) == 0, @"%lld not a multiple of %lld",
+                lastOffset, kGranularity);
   int64_t lastLength = ((NSNumber *)fnctr.uploadChunkLengths.lastObject).longLongValue;
   XCTAssertEqual(lastLength, (int64_t)(kBigUploadDataLength % kGranularity));
 
@@ -692,10 +678,10 @@ static void TestProgressBlock(GTMSessionUploadFetcher *fetcher,
 
   XCTestExpectation *expectation = [self expectationWithDescription:@"completion handler"];
   [fetcher beginFetchWithCompletionHandler:^(NSData *data, NSError *error) {
-      XCTAssertEqualObjects(data, [self gettysburgAddress]);
-      XCTAssertNil(error);
-      XCTAssertEqual(fetcher.statusCode, (NSInteger)200);
-      [expectation fulfill];
+    XCTAssertEqualObjects(data, [self gettysburgAddress]);
+    XCTAssertNil(error);
+    XCTAssertEqual(fetcher.statusCode, (NSInteger)200);
+    [expectation fulfill];
   }];
 
   [self waitForExpectationsWithTimeout:_timeoutInterval handler:nil];
@@ -710,7 +696,7 @@ static void TestProgressBlock(GTMSessionUploadFetcher *fetcher,
   XCTAssertEqualObjects(fnctr.uploadChunkCommands, expectedCommands);
   XCTAssertEqualObjects(fnctr.uploadChunkOffsets, expectedOffsets);
   XCTAssertEqualObjects(fnctr.uploadChunkLengths, expectedLengths);
-  
+
   WAIT_FOR_START_STOP_NOTIFICATION_EXPECTATIONS();
 
   XCTAssertEqual(fnctr.fetchStarted, 2);
@@ -761,11 +747,11 @@ static void TestProgressBlock(GTMSessionUploadFetcher *fetcher,
 #pragma clang diagnostic push
 #pragma clang diagnostic ignored "-Warc-retain-cycles"
   fetcher.retryEnabled = YES;
-  fetcher.retryBlock = ^(BOOL suggestedWillRetry, NSError *error,
-                         GTMSessionFetcherRetryResponse response) {
-    BOOL shouldRetry = shouldRetryUpload(fetcher, suggestedWillRetry, error);
-    response(shouldRetry);
-  };
+  fetcher.retryBlock =
+      ^(BOOL suggestedWillRetry, NSError *error, GTMSessionFetcherRetryResponse response) {
+        BOOL shouldRetry = shouldRetryUpload(fetcher, suggestedWillRetry, error);
+        response(shouldRetry);
+      };
 #pragma clang diagnostic pop
 
   XCTestExpectation *expectation = [self expectationWithDescription:@"completion handler"];
@@ -777,7 +763,7 @@ static void TestProgressBlock(GTMSessionUploadFetcher *fetcher,
   }];
   [self waitForExpectationsWithTimeout:_timeoutInterval handler:nil];
   [self assertCallbacksReleasedForFetcher:fetcher];
-  
+
   WAIT_FOR_START_STOP_NOTIFICATION_EXPECTATIONS();
 
   // Check that we uploaded the expected chunks.
@@ -820,27 +806,26 @@ static void TestProgressBlock(GTMSessionUploadFetcher *fetcher,
                                                                  error:&fileHandleError];
   NSURLRequest *request = [self validUploadFileRequest];
   GTMSessionUploadFetcher *fetcher =
-    [GTMSessionUploadFetcher uploadFetcherWithRequest:request
-                                       uploadMIMEType:@"text/plain"
-                                            chunkSize:kGTMSessionUploadFetcherStandardChunkSize
-                                       fetcherService:_service];
+      [GTMSessionUploadFetcher uploadFetcherWithRequest:request
+                                         uploadMIMEType:@"text/plain"
+                                              chunkSize:kGTMSessionUploadFetcherStandardChunkSize
+                                         fetcherService:_service];
   fetcher.uploadFileHandle = fileHandle;
   fetcher.useBackgroundSession = NO;
   fetcher.allowLocalhostRequest = YES;
 
   XCTestExpectation *expectation = [self expectationWithDescription:@"completion handler"];
   [fetcher beginFetchWithCompletionHandler:^(NSData *data, NSError *error) {
-      XCTAssertEqualObjects(data, [self gettysburgAddress]);
-      XCTAssertNil(error);
-      XCTAssertEqual(fetcher.statusCode, (NSInteger)200);
-      [expectation fulfill];
+    XCTAssertEqualObjects(data, [self gettysburgAddress]);
+    XCTAssertNil(error);
+    XCTAssertEqual(fetcher.statusCode, (NSInteger)200);
+    [expectation fulfill];
   }];
 
   // Add four minutes for the timeout of the huge upload test.
-  [self waitForExpectationsWithTimeout:_timeoutInterval + (4 * 60)
-                               handler:nil];
+  [self waitForExpectationsWithTimeout:_timeoutInterval + (4 * 60) handler:nil];
   [self assertCallbacksReleasedForFetcher:fetcher];
-  
+
   WAIT_FOR_START_STOP_NOTIFICATION_EXPECTATIONS();
 
   // Chunk length is constrained to a sane buffer size.
@@ -869,7 +854,7 @@ static void TestProgressBlock(GTMSessionUploadFetcher *fetcher,
   NSURL *bigFileURL = [self bigFileToUploadURLWithBaseName:NSStringFromSelector(_cmd)];
   NSString *filename =
       [NSString stringWithFormat:@"gettysburgaddress.txt.upload?bytesReceived=%lld",
-       (int64_t)kBigUploadDataLength - 9000];
+                                 (int64_t)kBigUploadDataLength - 9000];
   NSURL *uploadLocationURL = [_testServer localURLForFile:filename];
 
   GTMSessionUploadFetcher *fetcher =
@@ -883,22 +868,21 @@ static void TestProgressBlock(GTMSessionUploadFetcher *fetcher,
 
   XCTestExpectation *expectation = [self expectationWithDescription:@"completion handler"];
   [fetcher beginFetchWithCompletionHandler:^(NSData *data, NSError *error) {
-      XCTAssertEqualObjects(data, [self gettysburgAddress]);
-      XCTAssertNil(error);
+    XCTAssertEqualObjects(data, [self gettysburgAddress]);
+    XCTAssertNil(error);
 
-      NSURLRequest *lastChunkRequest = fetcher.lastChunkRequest;
-      NSDictionary *lastChunkRequestHdrs = [lastChunkRequest allHTTPHeaderFields];
+    NSURLRequest *lastChunkRequest = fetcher.lastChunkRequest;
+    NSDictionary *lastChunkRequestHdrs = [lastChunkRequest allHTTPHeaderFields];
 
-      XCTAssertEqual([[lastChunkRequestHdrs objectForKey:@"Content-Length"] intValue], 4000);
-      XCTAssertEqualObjects([lastChunkRequestHdrs objectForKey:@"X-Goog-Upload-Offset"],
-                            @"195000");
-      XCTAssertEqualObjects([lastChunkRequestHdrs objectForKey:@"X-Goog-Upload-Command"],
-                            @"upload, finalize");
-      [expectation fulfill];
+    XCTAssertEqual([[lastChunkRequestHdrs objectForKey:@"Content-Length"] intValue], 4000);
+    XCTAssertEqualObjects([lastChunkRequestHdrs objectForKey:@"X-Goog-Upload-Offset"], @"195000");
+    XCTAssertEqualObjects([lastChunkRequestHdrs objectForKey:@"X-Goog-Upload-Command"],
+                          @"upload, finalize");
+    [expectation fulfill];
   }];
   [self waitForExpectationsWithTimeout:_timeoutInterval handler:nil];
   [self assertCallbacksReleasedForFetcher:fetcher];
-  
+
   WAIT_FOR_START_STOP_NOTIFICATION_EXPECTATIONS();
 
   XCTAssertEqual(fnctr.fetchStarted, 3);
@@ -932,13 +916,13 @@ static void TestProgressBlock(GTMSessionUploadFetcher *fetcher,
 
   XCTestExpectation *expectation = [self expectationWithDescription:@"completion handler"];
   [fetcher beginFetchWithCompletionHandler:^(NSData *data, NSError *error) {
-      XCTAssertEqualObjects(data, [self gettysburgAddress]);
-      XCTAssertNil(error);
-      [expectation fulfill];
+    XCTAssertEqualObjects(data, [self gettysburgAddress]);
+    XCTAssertNil(error);
+    [expectation fulfill];
   }];
   [self waitForExpectationsWithTimeout:_timeoutInterval handler:nil];
   [self assertCallbacksReleasedForFetcher:fetcher];
-  
+
   WAIT_FOR_START_STOP_NOTIFICATION_EXPECTATIONS();
 
   XCTAssertEqual(fnctr.fetchStarted, 1);
@@ -979,7 +963,7 @@ static void TestProgressBlock(GTMSessionUploadFetcher *fetcher,
   }];
   [self waitForExpectationsWithTimeout:_timeoutInterval handler:nil];
   [self assertCallbacksReleasedForFetcher:fetcher];
-  
+
   WAIT_FOR_START_STOP_NOTIFICATION_EXPECTATIONS();
 
   XCTAssertEqual(fnctr.fetchStarted, 1);
@@ -1013,13 +997,13 @@ static void TestProgressBlock(GTMSessionUploadFetcher *fetcher,
 
   XCTestExpectation *expectation = [self expectationWithDescription:@"completion handler"];
   [fetcher beginFetchWithCompletionHandler:^(NSData *data, NSError *error) {
-      XCTAssertEqualObjects(data, [NSData data]);
-      XCTAssertEqual(error.code, (NSInteger)501);
-      [expectation fulfill];
+    XCTAssertEqualObjects(data, [NSData data]);
+    XCTAssertEqual(error.code, (NSInteger)501);
+    [expectation fulfill];
   }];
   [self waitForExpectationsWithTimeout:_timeoutInterval handler:nil];
   [self assertCallbacksReleasedForFetcher:fetcher];
-  
+
   WAIT_FOR_START_STOP_NOTIFICATION_EXPECTATIONS();
 
   XCTAssertEqual(fnctr.fetchStarted, 1);
@@ -1038,15 +1022,15 @@ static void TestProgressBlock(GTMSessionUploadFetcher *fetcher,
   // Like the previous, but we upload in a single chunk, needed for an out-of-process upload.
   FetcherNotificationsCounter *fnctr = [[FetcherNotificationsCounter alloc] init];
 
-  NSURL *emptyFileURL =
-      [self fileToUploadURLWithData:[NSData data] baseName:NSStringFromSelector(_cmd)];
+  NSURL *emptyFileURL = [self fileToUploadURLWithData:[NSData data]
+                                             baseName:NSStringFromSelector(_cmd)];
 
   NSURLRequest *request = [self validUploadFileRequest];
   GTMSessionUploadFetcher *fetcher =
-  [GTMSessionUploadFetcher uploadFetcherWithRequest:request
-                                     uploadMIMEType:@"text/plain"
-                                          chunkSize:kGTMSessionUploadFetcherStandardChunkSize
-                                     fetcherService:_service];
+      [GTMSessionUploadFetcher uploadFetcherWithRequest:request
+                                         uploadMIMEType:@"text/plain"
+                                              chunkSize:kGTMSessionUploadFetcherStandardChunkSize
+                                         fetcherService:_service];
   fetcher.uploadFileURL = emptyFileURL;
   fetcher.useBackgroundSession = NO;
   fetcher.allowLocalhostRequest = YES;
@@ -1062,7 +1046,7 @@ static void TestProgressBlock(GTMSessionUploadFetcher *fetcher,
 
   [self waitForExpectationsWithTimeout:_timeoutInterval handler:nil];
   [self assertCallbacksReleasedForFetcher:fetcher];
-  
+
   WAIT_FOR_START_STOP_NOTIFICATION_EXPECTATIONS();
 
   // Check that we uploaded the expected chunks.
@@ -1095,10 +1079,10 @@ static void TestProgressBlock(GTMSessionUploadFetcher *fetcher,
 
   NSURLRequest *request = [self validUploadFileRequest];
   GTMSessionUploadFetcher *fetcher =
-  [GTMSessionUploadFetcher uploadFetcherWithRequest:request
-                                     uploadMIMEType:@"text/plain"
-                                          chunkSize:kGTMSessionUploadFetcherStandardChunkSize
-                                     fetcherService:_service];
+      [GTMSessionUploadFetcher uploadFetcherWithRequest:request
+                                         uploadMIMEType:@"text/plain"
+                                              chunkSize:kGTMSessionUploadFetcherStandardChunkSize
+                                         fetcherService:_service];
   fetcher.uploadFileURL = nonExistingFileURL;
   fetcher.useBackgroundSession = NO;
   fetcher.allowLocalhostRequest = YES;
@@ -1113,7 +1097,7 @@ static void TestProgressBlock(GTMSessionUploadFetcher *fetcher,
 
   [self waitForExpectationsWithTimeout:_timeoutInterval handler:nil];
   [self assertCallbacksReleasedForFetcher:fetcher];
-  
+
   WAIT_FOR_START_STOP_NOTIFICATION_EXPECTATIONS();
 
   // Check that we uploaded the expected chunks.
@@ -1152,14 +1136,14 @@ static void TestProgressBlock(GTMSessionUploadFetcher *fetcher,
 
   XCTestExpectation *expectation = [self expectationWithDescription:@"completion handler"];
   [fetcher beginFetchWithCompletionHandler:^(NSData *data, NSError *error) {
-      XCTAssertEqualObjects(data, [self gettysburgAddress]);
-      XCTAssertNil(error);
-      XCTAssertEqual(fetcher.statusCode, (NSInteger)200);
-      [expectation fulfill];
+    XCTAssertEqualObjects(data, [self gettysburgAddress]);
+    XCTAssertNil(error);
+    XCTAssertEqual(fetcher.statusCode, (NSInteger)200);
+    [expectation fulfill];
   }];
   [self waitForExpectationsWithTimeout:_timeoutInterval handler:nil];
   [self assertCallbacksReleasedForFetcher:fetcher];
-  
+
   WAIT_FOR_START_STOP_NOTIFICATION_EXPECTATIONS();
 
   [self assertBigUploadFetchNotificationsWithCounter:fnctr];
@@ -1187,19 +1171,19 @@ static void TestProgressBlock(GTMSessionUploadFetcher *fetcher,
   [fetcher setUploadDataLength:(int64_t)bigData.length
                       provider:^(int64_t offset, int64_t length,
                                  GTMSessionUploadFetcherDataProviderResponse response) {
-      NSRange range = NSMakeRange((NSUInteger)offset, (NSUInteger)length);
-      NSData *responseData = [bigData subdataWithRange:range];
-      response(responseData, kGTMSessionUploadFetcherUnknownFileSize, nil);
-  }];
+                        NSRange range = NSMakeRange((NSUInteger)offset, (NSUInteger)length);
+                        NSData *responseData = [bigData subdataWithRange:range];
+                        response(responseData, kGTMSessionUploadFetcherUnknownFileSize, nil);
+                      }];
   fetcher.useBackgroundSession = NO;
   fetcher.allowLocalhostRequest = YES;
 
   XCTestExpectation *expectation = [self expectationWithDescription:@"completion handler"];
   [fetcher beginFetchWithCompletionHandler:^(NSData *data, NSError *error) {
-      XCTAssertEqualObjects(data, [self gettysburgAddress]);
-      XCTAssertNil(error);
-      XCTAssertEqual(fetcher.statusCode, (NSInteger)200);
-      [expectation fulfill];
+    XCTAssertEqualObjects(data, [self gettysburgAddress]);
+    XCTAssertNil(error);
+    XCTAssertEqual(fetcher.statusCode, (NSInteger)200);
+    [expectation fulfill];
   }];
   [self waitForExpectationsWithTimeout:_timeoutInterval handler:nil];
   [self assertCallbacksReleasedForFetcher:fetcher];
@@ -1231,16 +1215,16 @@ static void TestProgressBlock(GTMSessionUploadFetcher *fetcher,
   [fetcher setUploadDataLength:(int64_t)bigData.length
                       provider:^(int64_t offset, int64_t length,
                                  GTMSessionUploadFetcherDataProviderResponse response) {
-    NSRange range = NSMakeRange((NSUInteger)offset, (NSUInteger)length);
-    NSData *responseData = [bigData subdataWithRange:range];
-    response(responseData, kGTMSessionUploadFetcherUnknownFileSize, nil);
-  }];
+                        NSRange range = NSMakeRange((NSUInteger)offset, (NSUInteger)length);
+                        NSData *responseData = [bigData subdataWithRange:range];
+                        response(responseData, kGTMSessionUploadFetcherUnknownFileSize, nil);
+                      }];
   fetcher.useBackgroundSession = NO;
   fetcher.allowLocalhostRequest = YES;
   fetcher.cancellationHandler =
       ^(GTMSessionFetcher *cancellationFetcher, NSData *data, NSError *error) {
-    XCTFail("Success should not call cancellation handler.");
-  };
+        XCTFail("Success should not call cancellation handler.");
+      };
 
   XCTestExpectation *expectation = [self expectationWithDescription:@"completion handler"];
   [fetcher beginFetchWithCompletionHandler:^(NSData *data, NSError *error) {
@@ -1253,7 +1237,7 @@ static void TestProgressBlock(GTMSessionUploadFetcher *fetcher,
   [self assertCallbacksReleasedForFetcher:fetcher];
   // Success should clear the cancellationHandler.
   XCTAssertNil(fetcher.cancellationHandler);
-  
+
   WAIT_FOR_START_STOP_NOTIFICATION_EXPECTATIONS();
 
   [self assertBigUploadFetchNotificationsWithCounter:fnctr];
@@ -1279,19 +1263,19 @@ static void TestProgressBlock(GTMSessionUploadFetcher *fetcher,
   [fetcher setUploadDataLength:(int64_t)bigData.length
                       provider:^(int64_t offset, int64_t length,
                                  GTMSessionUploadFetcherDataProviderResponse response) {
-    NSRange range = NSMakeRange((NSUInteger)offset, (NSUInteger)length);
-    NSData *responseData = [bigData subdataWithRange:range];
-    response(responseData, kGTMSessionUploadFetcherUnknownFileSize, nil);
-  }];
+                        NSRange range = NSMakeRange((NSUInteger)offset, (NSUInteger)length);
+                        NSData *responseData = [bigData subdataWithRange:range];
+                        response(responseData, kGTMSessionUploadFetcherUnknownFileSize, nil);
+                      }];
   fetcher.useBackgroundSession = NO;
   fetcher.allowLocalhostRequest = YES;
   XCTestExpectation *expectation = [self expectationWithDescription:@"cancelled"];
   fetcher.cancellationHandler =
       ^(GTMSessionFetcher *cancellationFetcher, NSData *data, NSError *error) {
-    // Should be nil as we cancel before allowing any thing to happen.
-    XCTAssertNil(cancellationFetcher);
-    [expectation fulfill];
-  };
+        // Should be nil as we cancel before allowing any thing to happen.
+        XCTAssertNil(cancellationFetcher);
+        [expectation fulfill];
+      };
 
   [fetcher beginFetchWithCompletionHandler:^(NSData *data, NSError *error) {
     XCTFail("Completion should not fire as fetcher is immediately cancelled.");
@@ -1301,7 +1285,7 @@ static void TestProgressBlock(GTMSessionUploadFetcher *fetcher,
   [self assertCallbacksReleasedForFetcher:fetcher];
   // Immediate fire should clear out cancellation handler.
   XCTAssertNil(fetcher.cancellationHandler);
-  
+
   WAIT_FOR_START_STOP_NOTIFICATION_EXPECTATIONS();
 }
 
@@ -1341,7 +1325,7 @@ static void TestProgressBlock(GTMSessionUploadFetcher *fetcher,
   }];
   [self waitForExpectationsWithTimeout:_timeoutInterval handler:nil];
   [self assertCallbacksReleasedForFetcher:fetcher];
-  
+
   WAIT_FOR_START_STOP_NOTIFICATION_EXPECTATIONS();
 
   [self assertBigUploadFetchNotificationsWithCounter:fnctr];
@@ -1372,53 +1356,35 @@ static void TestProgressBlock(GTMSessionUploadFetcher *fetcher,
 
   // Add a property to the fetcher that our progress callback will look for to
   // know when to pause and resume the upload
-  fetcher.sendProgressBlock = ^(int64_t bytesSent, int64_t totalBytesSent,
-                                int64_t totalBytesExpectedToSend) {
+  fetcher.sendProgressBlock =
+      ^(int64_t bytesSent, int64_t totalBytesSent, int64_t totalBytesExpectedToSend) {
 #pragma clang diagnostic push
 #pragma clang diagnostic ignored "-Warc-retain-cycles"
-    TestProgressBlock(fetcher, bytesSent, totalBytesSent, totalBytesExpectedToSend);
+        TestProgressBlock(fetcher, bytesSent, totalBytesSent, totalBytesExpectedToSend);
 #pragma clang diagnostic pop
-  };
-  [fetcher setProperty:@20000
-                forKey:kPauseAtKey];
+      };
+  [fetcher setProperty:@20000 forKey:kPauseAtKey];
 
   XCTestExpectation *expectation = [self expectationWithDescription:@"completion handler"];
   [fetcher beginFetchWithCompletionHandler:^(NSData *data, NSError *error) {
-      XCTAssertEqualObjects(data, [self gettysburgAddress]);
-      XCTAssertNil(error);
-      XCTAssertEqual(fetcher.statusCode, (NSInteger)200);
-      [expectation fulfill];
+    XCTAssertEqualObjects(data, [self gettysburgAddress]);
+    XCTAssertNil(error);
+    XCTAssertEqual(fetcher.statusCode, (NSInteger)200);
+    [expectation fulfill];
   }];
 
   [self waitForExpectationsWithTimeout:_timeoutInterval handler:nil];
   [self assertCallbacksReleasedForFetcher:fetcher];
-  
+
   WAIT_FOR_START_STOP_NOTIFICATION_EXPECTATIONS();
 
   NSArray *expectedURLStrings = @[
-    @"/gettysburgaddress.txt.upload",
-    @"/gettysburgaddress.txt.upload",
-    @"/gettysburgaddress.txt.upload",
-    @"/gettysburgaddress.txt.upload"
+    @"/gettysburgaddress.txt.upload", @"/gettysburgaddress.txt.upload",
+    @"/gettysburgaddress.txt.upload", @"/gettysburgaddress.txt.upload"
   ];
-  NSArray *expectedCommands = @[
-    @"upload",
-    @"query",
-    @"upload",
-    @"upload, finalize"
-  ];
-  NSArray *expectedOffsets = @[
-    @0,
-    @0,
-    @75000,
-    @150000
-  ];
-  NSArray *expectedLengths = @[
-    @75000,
-    @0,
-    @75000,
-    @49000
-  ];
+  NSArray *expectedCommands = @[ @"upload", @"query", @"upload", @"upload, finalize" ];
+  NSArray *expectedOffsets = @[ @0, @0, @75000, @150000 ];
+  NSArray *expectedLengths = @[ @75000, @0, @75000, @49000 ];
   XCTAssertEqualObjects(fnctr.uploadChunkRequestPaths, expectedURLStrings);
   XCTAssertEqualObjects(fnctr.uploadChunkCommands, expectedCommands);
   XCTAssertEqualObjects(fnctr.uploadChunkOffsets, expectedOffsets);
@@ -1446,69 +1412,51 @@ static void TestProgressBlock(GTMSessionUploadFetcher *fetcher,
   [fetcher setUploadDataLength:kGTMSessionUploadFetcherUnknownFileSize
                       provider:^(int64_t offset, int64_t length,
                                  GTMSessionUploadFetcherDataProviderResponse response) {
-      length = MIN(length, (int64_t)bigData.length);
-      NSRange range = NSMakeRange((NSUInteger)offset, (NSUInteger)length);
-      NSData *responseData = [bigData subdataWithRange:range];
+                        length = MIN(length, (int64_t)bigData.length);
+                        NSRange range = NSMakeRange((NSUInteger)offset, (NSUInteger)length);
+                        NSData *responseData = [bigData subdataWithRange:range];
 
-      int64_t fileLength = 0;
-      if (offset) {
-        fileLength = (int64_t)bigData.length;
-      }
-      response(responseData, fileLength, nil);
-  }];
+                        int64_t fileLength = 0;
+                        if (offset) {
+                          fileLength = (int64_t)bigData.length;
+                        }
+                        response(responseData, fileLength, nil);
+                      }];
 
   fetcher.useBackgroundSession = NO;
   fetcher.allowLocalhostRequest = YES;
 
   // Add a property to the fetcher that our progress callback will look for to
   // know when to pause and resume the upload
-  fetcher.sendProgressBlock = ^(int64_t bytesSent, int64_t totalBytesSent,
-                                int64_t totalBytesExpectedToSend) {
+  fetcher.sendProgressBlock =
+      ^(int64_t bytesSent, int64_t totalBytesSent, int64_t totalBytesExpectedToSend) {
 #pragma clang diagnostic push
 #pragma clang diagnostic ignored "-Warc-retain-cycles"
-    TestProgressBlock(fetcher, bytesSent, totalBytesSent, totalBytesExpectedToSend);
+        TestProgressBlock(fetcher, bytesSent, totalBytesSent, totalBytesExpectedToSend);
 #pragma clang diagnostic pop
-  };
-  [fetcher setProperty:@20000
-                forKey:kPauseAtKey];
+      };
+  [fetcher setProperty:@20000 forKey:kPauseAtKey];
 
   XCTestExpectation *expectation = [self expectationWithDescription:@"completion handler"];
   [fetcher beginFetchWithCompletionHandler:^(NSData *data, NSError *error) {
-      XCTAssertEqualObjects(data, [self gettysburgAddress]);
-      XCTAssertNil(error);
-      XCTAssertEqual(fetcher.statusCode, (NSInteger)200);
-      [expectation fulfill];
+    XCTAssertEqualObjects(data, [self gettysburgAddress]);
+    XCTAssertNil(error);
+    XCTAssertEqual(fetcher.statusCode, (NSInteger)200);
+    [expectation fulfill];
   }];
 
   [self waitForExpectationsWithTimeout:_timeoutInterval handler:nil];
   [self assertCallbacksReleasedForFetcher:fetcher];
-  
+
   WAIT_FOR_START_STOP_NOTIFICATION_EXPECTATIONS();
 
   NSArray *expectedURLStrings = @[
-    @"/gettysburgaddress.txt.upload",
-    @"/gettysburgaddress.txt.upload",
-    @"/gettysburgaddress.txt.upload",
-    @"/gettysburgaddress.txt.upload"
+    @"/gettysburgaddress.txt.upload", @"/gettysburgaddress.txt.upload",
+    @"/gettysburgaddress.txt.upload", @"/gettysburgaddress.txt.upload"
   ];
-  NSArray *expectedCommands = @[
-    @"upload",
-    @"query",
-    @"upload",
-    @"upload, finalize"
-  ];
-  NSArray *expectedOffsets = @[
-    @0,
-    @0,
-    @75000,
-    @150000
-  ];
-  NSArray *expectedLengths = @[
-    @75000,
-    @0,
-    @75000,
-    @49000
-  ];
+  NSArray *expectedCommands = @[ @"upload", @"query", @"upload", @"upload, finalize" ];
+  NSArray *expectedOffsets = @[ @0, @0, @75000, @150000 ];
+  NSArray *expectedLengths = @[ @75000, @0, @75000, @49000 ];
   XCTAssertEqualObjects(fnctr.uploadChunkRequestPaths, expectedURLStrings);
   XCTAssertEqualObjects(fnctr.uploadChunkCommands, expectedCommands);
   XCTAssertEqualObjects(fnctr.uploadChunkOffsets, expectedOffsets);
@@ -1540,28 +1488,27 @@ static void TestProgressBlock(GTMSessionUploadFetcher *fetcher,
 
   // Add a property to the fetcher that our progress callback will look for to
   // know when to cancel the upload
-  fetcher.sendProgressBlock = ^(int64_t bytesSent, int64_t totalBytesSent,
-                                int64_t totalBytesExpectedToSend) {
+  fetcher.sendProgressBlock =
+      ^(int64_t bytesSent, int64_t totalBytesSent, int64_t totalBytesExpectedToSend) {
 #pragma clang diagnostic push
 #pragma clang diagnostic ignored "-Warc-retain-cycles"
-    TestProgressBlock(fetcher, bytesSent, totalBytesSent, totalBytesExpectedToSend);
+        TestProgressBlock(fetcher, bytesSent, totalBytesSent, totalBytesExpectedToSend);
 #pragma clang diagnostic pop
-  };
-  [fetcher setProperty:@20000
-                forKey:kCancelAtKey];
+      };
+  [fetcher setProperty:@20000 forKey:kCancelAtKey];
   XCTestExpectation *expectation = [self expectationWithDescription:@"cancelled"];
   fetcher.cancellationHandler =
       ^(GTMSessionFetcher *cancellationFetcher, NSData *data, NSError *error) {
-    XCTAssertNotNil(cancellationFetcher);
-    [expectation fulfill];
-  };
+        XCTAssertNotNil(cancellationFetcher);
+        [expectation fulfill];
+      };
 
   [fetcher beginFetchWithCompletionHandler:^(NSData *data, NSError *error) {
-      XCTFail(@"Canceled fetcher should not have called back");
+    XCTFail(@"Canceled fetcher should not have called back");
   }];
   [self waitForExpectationsWithTimeout:_timeoutInterval handler:nil];
   [self assertCallbacksReleasedForFetcher:fetcher];
-  
+
   WAIT_FOR_START_STOP_NOTIFICATION_EXPECTATIONS();
 
   XCTAssertEqual(fnctr.fetchStarted, 3);
@@ -1585,19 +1532,19 @@ static void TestProgressBlock(GTMSessionUploadFetcher *fetcher,
   FetcherNotificationsCounter *fnctr = [[FetcherNotificationsCounter alloc] init];
 
   BOOL (^shouldRetryUpload)(GTMSessionUploadFetcher *, BOOL, NSError *) =
-        ^BOOL(GTMSessionUploadFetcher *fetcher, BOOL suggestedWillRetry, NSError *error) {
-      // Change this fetch's request (and future requests) to have the original URL,
-      // not the one with status=503 appended.
-      NSURL *origURL = [fetcher propertyForKey:kOriginalURLKey];
+      ^BOOL(GTMSessionUploadFetcher *fetcher, BOOL suggestedWillRetry, NSError *error) {
+        // Change this fetch's request (and future requests) to have the original URL,
+        // not the one with status=503 appended.
+        NSURL *origURL = [fetcher propertyForKey:kOriginalURLKey];
 
-      NSMutableURLRequest *mutableRequest = [fetcher mutableRequestForTesting];
-      mutableRequest.URL = origURL;
-      fetcher.uploadLocationURL = origURL;
+        NSMutableURLRequest *mutableRequest = [fetcher mutableRequestForTesting];
+        mutableRequest.URL = origURL;
+        fetcher.uploadLocationURL = origURL;
 
-      [fetcher setProperty:nil forKey:kOriginalURLKey];
+        [fetcher setProperty:nil forKey:kOriginalURLKey];
 
-      return suggestedWillRetry;  // do the retry fetch; it should succeed now
-  };
+        return suggestedWillRetry;  // do the retry fetch; it should succeed now
+      };
 
   NSURLRequest *request = [self validUploadFileRequest];
   NSData *bigData = [self bigUploadData];
@@ -1612,57 +1559,44 @@ static void TestProgressBlock(GTMSessionUploadFetcher *fetcher,
 #pragma clang diagnostic push
 #pragma clang diagnostic ignored "-Warc-retain-cycles"
   fetcher.retryEnabled = YES;
-  fetcher.retryBlock = ^(BOOL suggestedWillRetry, NSError *error,
-                         GTMSessionFetcherRetryResponse response) {
-    BOOL shouldRetry = shouldRetryUpload(fetcher, suggestedWillRetry, error);
-    response(shouldRetry);
-  };
+  fetcher.retryBlock =
+      ^(BOOL suggestedWillRetry, NSError *error, GTMSessionFetcherRetryResponse response) {
+        BOOL shouldRetry = shouldRetryUpload(fetcher, suggestedWillRetry, error);
+        response(shouldRetry);
+      };
 
-  fetcher.sendProgressBlock = ^(int64_t bytesSent, int64_t totalBytesSent,
-                                int64_t totalBytesExpectedToSend) {
-    TestProgressBlock(fetcher, bytesSent, totalBytesSent, totalBytesExpectedToSend);
-  };
+  fetcher.sendProgressBlock =
+      ^(int64_t bytesSent, int64_t totalBytesSent, int64_t totalBytesExpectedToSend) {
+        TestProgressBlock(fetcher, bytesSent, totalBytesSent, totalBytesExpectedToSend);
+      };
 #pragma clang diagnostic pop
 
   // Add a property to the fetcher that our progress callback will look for to
   // know when to retry the upload.
-  [fetcher setProperty:@40000
-                forKey:kRetryAtKey];
+  [fetcher setProperty:@40000 forKey:kRetryAtKey];
 
   fnctr = [[FetcherNotificationsCounter alloc] init];
 
   XCTestExpectation *expectation = [self expectationWithDescription:@"completion handler"];
   [fetcher beginFetchWithCompletionHandler:^(NSData *data, NSError *error) {
-      XCTAssertEqualObjects(data, [self gettysburgAddress]);
-      XCTAssertNil(error);
-      XCTAssertEqual(fetcher.statusCode, (NSInteger)200);
-      [expectation fulfill];
+    XCTAssertEqualObjects(data, [self gettysburgAddress]);
+    XCTAssertNil(error);
+    XCTAssertEqual(fetcher.statusCode, (NSInteger)200);
+    [expectation fulfill];
   }];
   [self waitForExpectationsWithTimeout:_timeoutInterval handler:nil];
   [self assertCallbacksReleasedForFetcher:fetcher];
-  
+
   WAIT_FOR_START_STOP_NOTIFICATION_EXPECTATIONS();
 
-  NSArray *expectedURLStrings = @[ @"/gettysburgaddress.txt.upload",
-                                   @"/gettysburgaddress.txt.upload",
-                                   @"/gettysburgaddress.txt.upload",
-                                   @"/gettysburgaddress.txt.upload",
-                                   @"/gettysburgaddress.txt.upload" ];
-  NSArray *expectedCommands = @[ @"upload",
-                                 @"upload",
-                                 @"query",
-                                 @"upload",
-                                 @"upload, finalize" ];
-  NSArray *expectedOffsets = @[ @0,
-                                @75000,
-                                @0,
-                                @75000,
-                                @150000 ];
-  NSArray *expectedLengths = @[ @75000,
-                                @75000,
-                                @0,
-                                @75000,
-                                @49000 ];
+  NSArray *expectedURLStrings = @[
+    @"/gettysburgaddress.txt.upload", @"/gettysburgaddress.txt.upload",
+    @"/gettysburgaddress.txt.upload", @"/gettysburgaddress.txt.upload",
+    @"/gettysburgaddress.txt.upload"
+  ];
+  NSArray *expectedCommands = @[ @"upload", @"upload", @"query", @"upload", @"upload, finalize" ];
+  NSArray *expectedOffsets = @[ @0, @75000, @0, @75000, @150000 ];
+  NSArray *expectedLengths = @[ @75000, @75000, @0, @75000, @49000 ];
   XCTAssertEqualObjects(fnctr.uploadChunkRequestPaths, expectedURLStrings);
   XCTAssertEqualObjects(fnctr.uploadChunkCommands, expectedCommands);
   XCTAssertEqualObjects(fnctr.uploadChunkOffsets, expectedOffsets);

--- a/Source/UnitTests/GTMSessionFetcherCookieTest.m
+++ b/Source/UnitTests/GTMSessionFetcherCookieTest.m
@@ -49,7 +49,7 @@ static NSHTTPCookie *CookieWithProps(NSString *discard, NSString *domain, NSStri
   NSURL *subdomainURL = [NSURL URLWithString:@"http://frogbreath.example.com"];
 
   NSArray *foundCookies = [cookieStorage cookiesForURL:fullURL];
-  XCTAssertEqual(foundCookies.count, (NSUInteger) 0);
+  XCTAssertEqual(foundCookies.count, (NSUInteger)0);
 
   // Make two unique cookies
   NSHTTPCookie *testCookie1 =
@@ -118,8 +118,8 @@ static NSHTTPCookie *CookieWithProps(NSString *discard, NSString *domain, NSStri
   NSHTTPCookie *testCookie2 =
       CookieWithProps(@"TRUE", @"myexample.com", @"myexample", @"/", @"cook5=gnu");
 
-  [cookieStorage setCookies:@[ testCookie1a, testCookie1b, testCookie1c, testCookie1d,
-                               testCookie2 ]];
+  [cookieStorage
+      setCookies:@[ testCookie1a, testCookie1b, testCookie1c, testCookie1d, testCookie2 ]];
 
   // example.com retrieves the first two
   NSURL *subdomainURL = [NSURL URLWithString:@"http://example.com"];

--- a/Source/UnitTests/GTMSessionFetcherFetchingTest.h
+++ b/Source/UnitTests/GTMSessionFetcherFetchingTest.h
@@ -14,9 +14,9 @@
  */
 
 #import <XCTest/XCTest.h>
+#import <stdlib.h>
 #import <sys/sysctl.h>
 #import <unistd.h>
-#import <stdlib.h>
 
 #import "GTMSessionFetcherTestServer.h"
 #if SWIFT_PACKAGE
@@ -59,21 +59,18 @@ extern NSString *const kGTMGettysburgFileName;
 //
 // Returns a localhost:port URL for the test file.
 - (NSString *)localURLStringToTestFileName:(NSString *)name;
-- (NSString *)localURLStringToTestFileName:(NSString *)name
-                                parameters:(NSDictionary *)params;
+- (NSString *)localURLStringToTestFileName:(NSString *)name parameters:(NSDictionary *)params;
 
 // Utility method for making a request with the object's timeout.
 - (NSMutableURLRequest *)requestWithURLString:(NSString *)urlString;
 
 @end
 
-
 @interface GTMSessionFetcher (FetchingTest)
 // During testing only, we may want to modify the request being fetched
 // after beginFetch has been called.
 - (GTM_NULLABLE NSMutableURLRequest *)mutableRequestForTesting;
 @end
-
 
 // Authorization testing.
 @interface TestAuthorizer : NSObject <GTMFetcherAuthorizationProtocol>
@@ -95,11 +92,11 @@ extern NSString *const kGTMGettysburgFileName;
 // and ends.
 @class SubstituteUIApplicationTaskInfo;
 
-typedef void (^SubstituteUIApplicationExpirationCallback)
-    (NSUInteger numberOfBackgroundTasksToExpire,
-     NSArray <SubstituteUIApplicationTaskInfo *> * _Nullable tasksFailingToExpire);
+typedef void (^SubstituteUIApplicationExpirationCallback)(
+    NSUInteger numberOfBackgroundTasksToExpire,
+    NSArray<SubstituteUIApplicationTaskInfo *> *_Nullable tasksFailingToExpire);
 
-@interface SubstituteUIApplication : NSObject<GTMUIApplicationProtocol>
+@interface SubstituteUIApplication : NSObject <GTMUIApplicationProtocol>
 
 - (UIBackgroundTaskIdentifier)beginBackgroundTaskWithName:(nullable NSString *)taskName
                                         expirationHandler:(nullable dispatch_block_t)handler;
@@ -114,7 +111,6 @@ extern NSString *const kSubUIAppBackgroundTaskEnded;
 
 #endif  // GTM_BACKGROUND_TASK_FETCHING
 
-
 @interface FetcherNotificationsCounter : NSObject
 @property(nonatomic) int fetchStarted;
 @property(nonatomic) int fetchStopped;
@@ -125,18 +121,17 @@ extern NSString *const kSubUIAppBackgroundTaskEnded;
 @property(nonatomic) int retryDelayStopped;
 @property(nonatomic) int uploadLocationObtained;
 
-@property(nonatomic) NSMutableArray *uploadChunkRequestPaths; // of NSString
-@property(nonatomic) NSMutableArray *uploadChunkCommands; // of NSString
-@property(nonatomic) NSMutableArray *uploadChunkOffsets; // of NSUInteger
-@property(nonatomic) NSMutableArray *uploadChunkLengths; // of NSUInteger
+@property(nonatomic) NSMutableArray *uploadChunkRequestPaths;  // of NSString
+@property(nonatomic) NSMutableArray *uploadChunkCommands;      // of NSString
+@property(nonatomic) NSMutableArray *uploadChunkOffsets;       // of NSUInteger
+@property(nonatomic) NSMutableArray *uploadChunkLengths;       // of NSUInteger
 
-@property(nonatomic) NSMutableArray *fetchersStartedDescriptions; // of NSString
-@property(nonatomic) NSMutableArray *fetchersStoppedDescriptions; // of NSString
+@property(nonatomic) NSMutableArray *fetchersStartedDescriptions;  // of NSString
+@property(nonatomic) NSMutableArray *fetchersStoppedDescriptions;  // of NSString
 
 @property(nonatomic) NSMutableArray *backgroundTasksStarted;  // of boxed UIBackgroundTaskIdentifier
-@property(nonatomic) NSMutableArray *backgroundTasksEnded;  // of boxed UIBackgroundTaskIdentifier
+@property(nonatomic) NSMutableArray *backgroundTasksEnded;    // of boxed UIBackgroundTaskIdentifier
 
 @end
 
 GTM_ASSUME_NONNULL_END
-

--- a/Source/UnitTests/GTMSessionFetcherFetchingTest.m
+++ b/Source/UnitTests/GTMSessionFetcherFetchingTest.m
@@ -29,21 +29,21 @@ NSString *const kGTMGettysburgFileName = @"gettysburgaddress.txt";
 
 // Helper macro to create fetcher start/stop notification expectations. These use alloc/init
 // directly to prevent them being waited for by wait helper methods on XCTestCase.
-#define CREATE_START_STOP_NOTIFICATION_EXPECTATIONS(START_COUNT, STOP_COUNT) \
-    XCTestExpectation *fetcherStartedExpectation__ = \
-        [[XCTNSNotificationExpectation alloc] initWithName:kGTMSessionFetcherStartedNotification]; \
-    XCTestExpectation *fetcherStoppedExpectation__ = \
-        [[XCTNSNotificationExpectation alloc] initWithName:kGTMSessionFetcherStoppedNotification]; \
-    fetcherStartedExpectation__.expectedFulfillmentCount = (START_COUNT); \
-    fetcherStartedExpectation__.assertForOverFulfill = YES; \
-    fetcherStoppedExpectation__.expectedFulfillmentCount = (STOP_COUNT); \
-    fetcherStoppedExpectation__.assertForOverFulfill = YES;
+#define CREATE_START_STOP_NOTIFICATION_EXPECTATIONS(START_COUNT, STOP_COUNT)                     \
+  XCTestExpectation *fetcherStartedExpectation__ =                                               \
+      [[XCTNSNotificationExpectation alloc] initWithName:kGTMSessionFetcherStartedNotification]; \
+  XCTestExpectation *fetcherStoppedExpectation__ =                                               \
+      [[XCTNSNotificationExpectation alloc] initWithName:kGTMSessionFetcherStoppedNotification]; \
+  fetcherStartedExpectation__.expectedFulfillmentCount = (START_COUNT);                          \
+  fetcherStartedExpectation__.assertForOverFulfill = YES;                                        \
+  fetcherStoppedExpectation__.expectedFulfillmentCount = (STOP_COUNT);                           \
+  fetcherStoppedExpectation__.assertForOverFulfill = YES;
 
 // Helper macro to wait on the notification expectations created by the CREATE_START_STOP macro.
 // Using -[XCTestCase waitForExpectations...] methods will NOT wait for them.
-#define WAIT_FOR_START_STOP_NOTIFICATION_EXPECTATIONS() \
-    [self waitForExpectations:@[ fetcherStartedExpectation__, fetcherStoppedExpectation__ ] \
-                      timeout:5.0];
+#define WAIT_FOR_START_STOP_NOTIFICATION_EXPECTATIONS()                                   \
+  [self waitForExpectations:@[ fetcherStartedExpectation__, fetcherStoppedExpectation__ ] \
+                    timeout:5.0];
 
 @interface GTMSessionFetcher (ExposedForTesting)
 + (GTM_NULLABLE NSURL *)redirectURLWithOriginalRequestURL:(GTM_NULLABLE NSURL *)originalRequestURL
@@ -113,34 +113,36 @@ NSString *const kGTMGettysburgFileName = @"gettysburgaddress.txt";
   // Swift Pacage Manager does not support resources distribution currently,
   // therefore the "gettysburgaddress.txt" file must be copied manually to the test bundle.
   static dispatch_once_t onceToken;
-    dispatch_once(&onceToken, ^{
-      NSString *gettysburg = @""\
-      "Four score and seven years ago our fathers brought forth on this continent, a"\
-      "new nation, conceived in liberty, and dedicated to the proposition that all men"\
-      "are created equal.";
+  dispatch_once(&onceToken, ^{
+    NSString *gettysburg =
+        @""
+         "Four score and seven years ago our fathers brought forth on this continent, a"
+         "new nation, conceived in liberty, and dedicated to the proposition that all men"
+         "are created equal.";
 
-      NSString * resourcePath = [testBundle resourcePath];
-      XCTAssertNotNil(resourcePath);
+    NSString *resourcePath = [testBundle resourcePath];
+    XCTAssertNotNil(resourcePath);
 
-      if (![[NSFileManager defaultManager] fileExistsAtPath:resourcePath]) {
-          NSError *createDirectoryError = nil;
-          if (![[NSFileManager defaultManager] createDirectoryAtPath:resourcePath
-                                         withIntermediateDirectories:true
-                                                          attributes:nil
-                                                               error:&createDirectoryError]) {
-            XCTFail("Failed to create the Resources directory, error: %@", createDirectoryError);
-          }
+    if (![[NSFileManager defaultManager] fileExistsAtPath:resourcePath]) {
+      NSError *createDirectoryError = nil;
+      if (![[NSFileManager defaultManager] createDirectoryAtPath:resourcePath
+                                     withIntermediateDirectories:true
+                                                      attributes:nil
+                                                           error:&createDirectoryError]) {
+        XCTFail("Failed to create the Resources directory, error: %@", createDirectoryError);
       }
+    }
 
-      NSString *gettysburgPath = [resourcePath stringByAppendingPathComponent:@"gettysburgaddress.txt"];
-      NSError *writeError = nil;
-      if (![gettysburg writeToFile:gettysburgPath
-                        atomically:true
-                          encoding:NSUTF8StringEncoding
-                             error:&writeError]) {
-        XCTFail("Failed to write `gettysburgaddress.txt` bundle Resource, error: %@", writeError);
-      }
-    });
+    NSString *gettysburgPath =
+        [resourcePath stringByAppendingPathComponent:@"gettysburgaddress.txt"];
+    NSError *writeError = nil;
+    if (![gettysburg writeToFile:gettysburgPath
+                      atomically:true
+                        encoding:NSUTF8StringEncoding
+                           error:&writeError]) {
+      XCTFail("Failed to write `gettysburgaddress.txt` bundle Resource, error: %@", writeError);
+    }
+  });
 #endif
 
   NSString *docFolder = [testBundle resourcePath];
@@ -156,8 +158,8 @@ NSString *const kGTMGettysburgFileName = @"gettysburgaddress.txt";
 
 - (NSURL *)temporaryFileURLWithBaseName:(NSString *)baseName {
   static int counter = 0;
-  NSString *fileName = [NSString stringWithFormat:@"GTMFetcherTest_%@_%@_%d",
-                        baseName, [NSDate date], ++counter];
+  NSString *fileName =
+      [NSString stringWithFormat:@"GTMFetcherTest_%@_%@_%d", baseName, [NSDate date], ++counter];
   NSURL *tempURL = [NSURL fileURLWithPath:NSTemporaryDirectory()];
   NSURL *fileURL = [tempURL URLByAppendingPathComponent:fileName];
   return fileURL;
@@ -189,16 +191,15 @@ NSString *const kGTMGettysburgFileName = @"gettysburgaddress.txt";
   return localURLString;
 }
 
-- (NSString *)localURLStringToTestFileName:(NSString *)name
-                                parameters:(NSDictionary *)params {
+- (NSString *)localURLStringToTestFileName:(NSString *)name parameters:(NSDictionary *)params {
   NSString *localURLString = [self localURLStringToTestFileName:name];
 
   // Add any parameters from the dictionary.
   if (params.count) {
     NSMutableArray *array = [NSMutableArray array];
     for (NSString *key in params) {
-      [array addObject:[NSString stringWithFormat:@"%@=%@",
-                        key, [[params objectForKey:key] description]]];
+      [array addObject:[NSString stringWithFormat:@"%@=%@", key,
+                                                  [[params objectForKey:key] description]]];
     }
     NSString *paramsStr = [array componentsJoinedByString:@"&"];
     localURLString = [localURLString stringByAppendingFormat:@"?%@", paramsStr];
@@ -277,8 +278,7 @@ NSString *const kGTMGettysburgFileName = @"gettysburgaddress.txt";
   XCTAssertEqualObjects(data, gettysburgAddress,
                         @"Failed to retrieve Gettysburg Address."
                         @"  %d bytes, status:%d request:%@ error:%@",
-                        (int)data.length, (int)fetcher.statusCode,
-                        fetcher.request, error);
+                        (int)data.length, (int)fetcher.statusCode, fetcher.request, error);
   XCTAssertNotNil(fetcher.response);
   XCTAssertNotNil(fetcher.request, @"Missing request");
   XCTAssertEqual(fetcher.statusCode, (NSInteger)200, @"%@", fetcher.request);
@@ -304,70 +304,68 @@ NSString *const kGTMGettysburgFileName = @"gettysburgaddress.txt";
   __block NSCachedURLResponse *proposedResponseToCache;
   fetcher.willCacheURLResponseBlock = ^(NSCachedURLResponse *responseProposed,
                                         GTMSessionFetcherWillCacheURLResponseResponse response) {
-      proposedResponseToCache = responseProposed;
-      response(responseProposed);
+    proposedResponseToCache = responseProposed;
+    response(responseProposed);
   };
 
   __block NSURLResponse *initialResponse;
-  fetcher.didReceiveResponseBlock = ^(NSURLResponse *response,
-                                      GTMSessionFetcherDidReceiveResponseDispositionBlock dispositionBlock) {
-      XCTAssertNil(initialResponse);
-      initialResponse = response;
-      dispositionBlock(NSURLSessionResponseAllow);
-  };
+  fetcher.didReceiveResponseBlock =
+      ^(NSURLResponse *response,
+        GTMSessionFetcherDidReceiveResponseDispositionBlock dispositionBlock) {
+        XCTAssertNil(initialResponse);
+        initialResponse = response;
+        dispositionBlock(NSURLSessionResponseAllow);
+      };
 
-  fetcher.willRedirectBlock = ^(NSHTTPURLResponse *redirectResponse,
-                                NSURLRequest *redirectRequest,
+  fetcher.willRedirectBlock = ^(NSHTTPURLResponse *redirectResponse, NSURLRequest *redirectRequest,
                                 GTMSessionFetcherWillRedirectResponse response) {
-      XCTFail(@"redirect not expected");
+    XCTFail(@"redirect not expected");
   };
 
   __block BOOL wasConfigBlockCalled = NO;
-  fetcher.configurationBlock = ^(GTMSessionFetcher *configFetcher,
-                                 NSURLSessionConfiguration *config) {
-    wasConfigBlockCalled = YES;
+  fetcher.configurationBlock =
+      ^(GTMSessionFetcher *configFetcher, NSURLSessionConfiguration *config) {
+        wasConfigBlockCalled = YES;
 #pragma clang diagnostic push
 #pragma clang diagnostic ignored "-Warc-retain-cycles"
-    XCTAssertEqual(configFetcher, fetcher);
+        XCTAssertEqual(configFetcher, fetcher);
 #pragma clang diagnostic pop
-  };
+      };
 
   XCTestExpectation *expectation = [self expectationWithDescription:localURLString];
   NSString *cookieExpected = [NSString stringWithFormat:@"TestCookie=%@", kGTMGettysburgFileName];
   [fetcher beginFetchWithCompletionHandler:^(NSData *data, NSError *error) {
-      [self assertSuccessfulGettysburgFetchWithFetcher:fetcher
-                                                  data:data
-                                                 error:error];
+    [self assertSuccessfulGettysburgFetchWithFetcher:fetcher data:data error:error];
 
-      // No cookies should be sent with our first request.  Check what cookies the server found.
-      NSDictionary *responseHeaders = [(NSHTTPURLResponse *)fetcher.response allHeaderFields];
-      NSString *cookiesSent = [responseHeaders objectForKey:@"FoundCookies"];
-      XCTAssertNil(cookiesSent, @"Cookies sent unexpectedly: %@", cookiesSent);
+    // No cookies should be sent with our first request.  Check what cookies the server found.
+    NSDictionary *responseHeaders = [(NSHTTPURLResponse *)fetcher.response allHeaderFields];
+    NSString *cookiesSent = [responseHeaders objectForKey:@"FoundCookies"];
+    XCTAssertNil(cookiesSent, @"Cookies sent unexpectedly: %@", cookiesSent);
 
-      // Cookies should have been set by the response; specifically, TestCookie
-      // should be set to the name of the file requested.
-      NSString *cookiesSetString = [responseHeaders objectForKey:@"Set-Cookie"];
-      XCTAssertEqualObjects(cookiesSetString, cookieExpected);
+    // Cookies should have been set by the response; specifically, TestCookie
+    // should be set to the name of the file requested.
+    NSString *cookiesSetString = [responseHeaders objectForKey:@"Set-Cookie"];
+    XCTAssertEqualObjects(cookiesSetString, cookieExpected);
 
-      // A cookie should've been set.
-      cookieStorage = fetcher.configuration.HTTPCookieStorage;
-      NSURL *localhostURL = [NSURL URLWithString:@"http://localhost/"];
-      NSArray *cookies = [cookieStorage cookiesForURL:localhostURL];
-      XCTAssertEqual(cookies.count, (NSUInteger)1);
-      NSHTTPCookie *firstCookie = cookies.firstObject;
-      XCTAssertEqualObjects([firstCookie value], @"gettysburgaddress.txt");
+    // A cookie should've been set.
+    cookieStorage = fetcher.configuration.HTTPCookieStorage;
+    NSURL *localhostURL = [NSURL URLWithString:@"http://localhost/"];
+    NSArray *cookies = [cookieStorage cookiesForURL:localhostURL];
+    XCTAssertEqual(cookies.count, (NSUInteger)1);
+    NSHTTPCookie *firstCookie = cookies.firstObject;
+    XCTAssertEqualObjects([firstCookie value], @"gettysburgaddress.txt");
 
-      // The initial response should be the final response;
-      XCTAssertEqualObjects(initialResponse, fetcher.response);
+    // The initial response should be the final response;
+    XCTAssertEqualObjects(initialResponse, fetcher.response);
 
-      // The response should've been cached.  See the comment above at the declaration of
-      // proposedResponseToCache
-      if (proposedResponseToCache) {
-        XCTAssertEqualObjects(proposedResponseToCache.response.URL, fetcher.response.URL);
-        XCTAssertEqualObjects([(NSHTTPURLResponse *)proposedResponseToCache.response allHeaderFields],
-                              [(NSHTTPURLResponse *)fetcher.response allHeaderFields]);
-      }
-      [expectation fulfill];
+    // The response should've been cached.  See the comment above at the declaration of
+    // proposedResponseToCache
+    if (proposedResponseToCache) {
+      XCTAssertEqualObjects(proposedResponseToCache.response.URL, fetcher.response.URL);
+      XCTAssertEqualObjects([(NSHTTPURLResponse *)proposedResponseToCache.response allHeaderFields],
+                            [(NSHTTPURLResponse *)fetcher.response allHeaderFields]);
+    }
+    [expectation fulfill];
   }];
   [self waitForExpectationsWithTimeout:_timeoutInterval handler:nil];
   [self assertCallbacksReleasedForFetcher:fetcher];
@@ -385,26 +383,26 @@ NSString *const kGTMGettysburgFileName = @"gettysburgaddress.txt";
   // TODO(seh): Shouldn't be needed; without it the cookie isn't being received by the test server.
   // b/17646646
   [fetcher setRequestValue:cookieExpected forHTTPHeaderField:@"Cookie"];
-  fetcher.configurationBlock = ^(GTMSessionFetcher *configFetcher,
-                                 NSURLSessionConfiguration *config) {
-      wasConfigBlockCalled = YES;
+  fetcher.configurationBlock =
+      ^(GTMSessionFetcher *configFetcher, NSURLSessionConfiguration *config) {
+        wasConfigBlockCalled = YES;
 #pragma clang diagnostic push
 #pragma clang diagnostic ignored "-Warc-retain-cycles"
-      XCTAssertEqual(configFetcher, fetcher);
+        XCTAssertEqual(configFetcher, fetcher);
 #pragma clang diagnostic pop
-      XCTAssertEqualObjects(config.HTTPCookieStorage, cookieStorage);
-  };
+        XCTAssertEqualObjects(config.HTTPCookieStorage, cookieStorage);
+      };
 
   expectation = [self expectationWithDescription:@"Cookies found"];
   [fetcher beginFetchWithCompletionHandler:^(NSData *data, NSError *error) {
-      XCTAssertEqualObjects(data, [self gettysburgAddress], @"Unexpected data.");
+    XCTAssertEqualObjects(data, [self gettysburgAddress], @"Unexpected data.");
 
-      // The cookie set previously should be sent with this request.  See what cookies the
-      // http server found.
-      NSDictionary *allHeaderFields = [(NSHTTPURLResponse *)fetcher.response allHeaderFields];
-      NSString *cookiesSent = [allHeaderFields objectForKey:@"FoundCookies"];
-      XCTAssertEqualObjects(cookiesSent, cookieExpected);
-      [expectation fulfill];
+    // The cookie set previously should be sent with this request.  See what cookies the
+    // http server found.
+    NSDictionary *allHeaderFields = [(NSHTTPURLResponse *)fetcher.response allHeaderFields];
+    NSString *cookiesSent = [allHeaderFields objectForKey:@"FoundCookies"];
+    XCTAssertEqualObjects(cookiesSent, cookieExpected);
+    [expectation fulfill];
   }];
   [self waitForExpectationsWithTimeout:_timeoutInterval handler:nil];
 
@@ -456,27 +454,27 @@ NSString *const kGTMGettysburgFileName = @"gettysburgaddress.txt";
   XCTestExpectation *expirationExp = [self expectationWithDescription:@"expired"];
 
   NSNotificationCenter *nc = [NSNotificationCenter defaultCenter];
-  id notification = [nc addObserverForName:kSubUIAppBackgroundTaskBegan
-                                    object:nil
-                                     queue:nil
-                                usingBlock:^(NSNotification *note) {
-    SubstituteUIApplication *app = [GTMSessionFetcher substituteUIApplication];
-    dispatch_async(dispatch_get_main_queue(), ^{
-      [app expireAllBackgroundTasksWithCallback:^(
-            NSUInteger numberOfBackgroundTasksToExpire,
-            NSArray<SubstituteUIApplicationTaskInfo *> *tasksFailingToExpire) {
-        XCTAssertEqual(numberOfBackgroundTasksToExpire, (NSUInteger)1);
-        XCTAssertEqual(tasksFailingToExpire.count, (NSUInteger)0, @"%@", tasksFailingToExpire);
-        [expirationExp fulfill];
-      }];
-    });
-  }];
+  id notification =
+      [nc addObserverForName:kSubUIAppBackgroundTaskBegan
+                      object:nil
+                       queue:nil
+                  usingBlock:^(NSNotification *note) {
+                    SubstituteUIApplication *app = [GTMSessionFetcher substituteUIApplication];
+                    dispatch_async(dispatch_get_main_queue(), ^{
+                      [app expireAllBackgroundTasksWithCallback:^(
+                               NSUInteger numberOfBackgroundTasksToExpire,
+                               NSArray<SubstituteUIApplicationTaskInfo *> *tasksFailingToExpire) {
+                        XCTAssertEqual(numberOfBackgroundTasksToExpire, (NSUInteger)1);
+                        XCTAssertEqual(tasksFailingToExpire.count, (NSUInteger)0, @"%@",
+                                       tasksFailingToExpire);
+                        [expirationExp fulfill];
+                      }];
+                    });
+                  }];
 
   XCTestExpectation *expectation = [self expectationWithDescription:localURLString];
   [fetcher beginFetchWithCompletionHandler:^(NSData *data, NSError *error) {
-    [self assertSuccessfulGettysburgFetchWithFetcher:fetcher
-                                                data:data
-                                               error:error];
+    [self assertSuccessfulGettysburgFetchWithFetcher:fetcher data:data error:error];
     [expectation fulfill];
   }];
   [self waitForExpectationsWithTimeout:_timeoutInterval handler:nil];
@@ -529,11 +527,9 @@ NSString *const kGTMGettysburgFileName = @"gettysburgaddress.txt";
 
   XCTestExpectation *expectation = [self expectationWithDescription:localURLString];
   [fetcher beginFetchWithCompletionHandler:^(NSData *data, NSError *error) {
-      XCTAssertNil(data);
-      [self assertSuccessfulGettysburgFetchWithFetcher:fetcher
-                                                  data:accumulatedData
-                                                 error:error];
-      [expectation fulfill];
+    XCTAssertNil(data);
+    [self assertSuccessfulGettysburgFetchWithFetcher:fetcher data:accumulatedData error:error];
+    [expectation fulfill];
   }];
   [self waitForExpectationsWithTimeout:_timeoutInterval handler:nil];
   [self assertCallbacksReleasedForFetcher:fetcher];
@@ -573,19 +569,18 @@ NSString *const kGTMGettysburgFileName = @"gettysburgaddress.txt";
   GTMSessionFetcher *fetcher = [self fetcherWithURLString:badURLString];
   XCTestExpectation *expectation = [self expectationWithDescription:badURLString];
   [fetcher beginFetchWithCompletionHandler:^(NSData *data, NSError *error) {
-      if (data) {
-        NSString *str = [[NSString alloc] initWithData:data
-                                              encoding:NSUTF8StringEncoding];
-        XCTAssertNil(data, @"Unexpected data: %@", str);
-      }
-      XCTAssertNotNil(error);
-      XCTAssertEqual(fetcher.statusCode, (NSInteger)0);
+    if (data) {
+      NSString *str = [[NSString alloc] initWithData:data encoding:NSUTF8StringEncoding];
+      XCTAssertNil(data, @"Unexpected data: %@", str);
+    }
+    XCTAssertNotNil(error);
+    XCTAssertEqual(fetcher.statusCode, (NSInteger)0);
 
-      NSNumber *retriesDone = error.userInfo[kGTMSessionFetcherNumberOfRetriesDoneKey];
-      NSNumber *elapsedInterval = error.userInfo[kGTMSessionFetcherElapsedIntervalWithRetriesKey];
-      XCTAssertNil(retriesDone);
-      XCTAssertNil(elapsedInterval);
-      [expectation fulfill];
+    NSNumber *retriesDone = error.userInfo[kGTMSessionFetcherNumberOfRetriesDoneKey];
+    NSNumber *elapsedInterval = error.userInfo[kGTMSessionFetcherElapsedIntervalWithRetriesKey];
+    XCTAssertNil(retriesDone);
+    XCTAssertNil(elapsedInterval);
+    [expectation fulfill];
   }];
   [self waitForExpectationsWithTimeout:_timeoutInterval handler:nil];
   [self assertCallbacksReleasedForFetcher:fetcher];
@@ -594,31 +589,30 @@ NSString *const kGTMGettysburgFileName = @"gettysburgaddress.txt";
   // Fetch requesting a specific status code from our http server.
   //
   NSString *statusURLString = [self localURLStringToTestFileName:kGTMGettysburgFileName
-                                                      parameters:@{ @"status": @"400" }];
+                                                      parameters:@{@"status" : @"400"}];
 
   fetcher = [self fetcherWithURLString:statusURLString];
   expectation = [self expectationWithDescription:statusURLString];
   [fetcher beginFetchWithCompletionHandler:^(NSData *data, NSError *error) {
-      NSString *statusStr = [[self->_testServer class] JSONBodyStringForStatus:400];
-      NSData *errorBodyData = [statusStr dataUsingEncoding:NSUTF8StringEncoding];
-      XCTAssertEqualObjects(data, errorBodyData);
+    NSString *statusStr = [[self->_testServer class] JSONBodyStringForStatus:400];
+    NSData *errorBodyData = [statusStr dataUsingEncoding:NSUTF8StringEncoding];
+    XCTAssertEqualObjects(data, errorBodyData);
 
-      XCTAssertNotNil(error);
-      XCTAssertEqual(fetcher.statusCode, (NSInteger)400, @"%@", error);
+    XCTAssertNotNil(error);
+    XCTAssertEqual(fetcher.statusCode, (NSInteger)400, @"%@", error);
 
-      NSString *statusDataContentType =
-          [error.userInfo objectForKey:kGTMSessionFetcherStatusDataContentTypeKey];
-      XCTAssertEqualObjects(statusDataContentType, @"application/json");
+    NSString *statusDataContentType =
+        [error.userInfo objectForKey:kGTMSessionFetcherStatusDataContentTypeKey];
+    XCTAssertEqualObjects(statusDataContentType, @"application/json");
 
-      NSData *statusData = [error.userInfo objectForKey:kGTMSessionFetcherStatusDataKey];
-      XCTAssertNotNil(statusData, @"Missing data in error");
-      if (statusData) {
-        NSString *dataStr = [[NSString alloc] initWithData:statusData
-                                                  encoding:NSUTF8StringEncoding];
-        NSString *expectedStr = [[self->_testServer class] JSONBodyStringForStatus:400];
-        XCTAssertEqualObjects(dataStr, expectedStr, @"Expected JSON status data");
-      }
-      [expectation fulfill];
+    NSData *statusData = [error.userInfo objectForKey:kGTMSessionFetcherStatusDataKey];
+    XCTAssertNotNil(statusData, @"Missing data in error");
+    if (statusData) {
+      NSString *dataStr = [[NSString alloc] initWithData:statusData encoding:NSUTF8StringEncoding];
+      NSString *expectedStr = [[self->_testServer class] JSONBodyStringForStatus:400];
+      XCTAssertEqualObjects(dataStr, expectedStr, @"Expected JSON status data");
+    }
+    [expectation fulfill];
   }];
   [self waitForExpectationsWithTimeout:_timeoutInterval handler:nil];
   [self assertCallbacksReleasedForFetcher:fetcher];
@@ -688,18 +682,16 @@ NSString *const kGTMGettysburgFileName = @"gettysburgaddress.txt";
   const int kBodyLength = 133;
   NSString *localURLString =
       [self localURLStringToTestFileName:kGTMGettysburgFileName
-                              parameters:@{ @"requestBodyLength": [@(kBodyLength) stringValue] }];
+                              parameters:@{@"requestBodyLength" : [@(kBodyLength) stringValue]}];
   GTMSessionFetcher *fetcher = [self fetcherWithURLString:localURLString];
 
   fetcher.bodyData = [GTMSessionFetcherTestServer generatedBodyDataWithLength:kBodyLength];
 
   XCTestExpectation *expectation = [self expectationWithDescription:localURLString];
   [fetcher beginFetchWithCompletionHandler:^(NSData *data, NSError *error) {
-      // We'll verify we fetched from the server the actual data on disk.
-      [self assertSuccessfulGettysburgFetchWithFetcher:fetcher
-                                                  data:data
-                                                 error:error];
-      [expectation fulfill];
+    // We'll verify we fetched from the server the actual data on disk.
+    [self assertSuccessfulGettysburgFetchWithFetcher:fetcher data:data error:error];
+    [expectation fulfill];
   }];
   [self waitForExpectationsWithTimeout:_timeoutInterval handler:nil];
   [self assertCallbacksReleasedForFetcher:fetcher];
@@ -743,9 +735,7 @@ NSString *const kGTMGettysburgFileName = @"gettysburgaddress.txt";
   XCTestExpectation *finishExpectation =
       [self expectationWithDescription:@"testCallbackQueue main"];
   [fetcher beginFetchWithCompletionHandler:^(NSData *data, NSError *error) {
-    [self assertSuccessfulGettysburgFetchWithFetcher:fetcher
-                                                data:data
-                                               error:error];
+    [self assertSuccessfulGettysburgFetchWithFetcher:fetcher data:data error:error];
     XCTAssertTrue([NSThread isMainThread], @"Unexpected queue %s",
                   dispatch_queue_get_label(DISPATCH_CURRENT_QUEUE_LABEL));
     [finishExpectation fulfill];
@@ -762,18 +752,14 @@ NSString *const kGTMGettysburgFileName = @"gettysburgaddress.txt";
   dispatch_queue_t bgQueue = dispatch_get_global_queue(DISPATCH_QUEUE_PRIORITY_HIGH, 0);
   fetcher.callbackQueue = bgQueue;
 
-  finishExpectation =
-      [self expectationWithDescription:@"testCallbackQueue specific"];
+  finishExpectation = [self expectationWithDescription:@"testCallbackQueue specific"];
   [fetcher beginFetchWithCompletionHandler:^(NSData *data, NSError *error) {
-    [self assertSuccessfulGettysburgFetchWithFetcher:fetcher
-                                                data:data
-                                               error:error];
+    [self assertSuccessfulGettysburgFetchWithFetcher:fetcher data:data error:error];
     BOOL areSame = (strcmp(dispatch_queue_get_label(bgQueue),
                            dispatch_queue_get_label(DISPATCH_CURRENT_QUEUE_LABEL)) == 0);
     XCTAssert(areSame, @"Unexpected queue: %s ≠ %s",
               dispatch_queue_get_label(DISPATCH_CURRENT_QUEUE_LABEL),
-              dispatch_queue_get_label(bgQueue)
-              );
+              dispatch_queue_get_label(bgQueue));
     [finishExpectation fulfill];
   }];
   [self waitForExpectationsWithTimeout:_timeoutInterval handler:nil];
@@ -800,23 +786,21 @@ NSString *const kGTMGettysburgFileName = @"gettysburgaddress.txt";
   const int kBodyLength = 1024 * 1024;
   NSString *localURLString =
       [self localURLStringToTestFileName:kGTMGettysburgFileName
-                              parameters:@{ @"requestBodyLength" : @(kBodyLength) }];
+                              parameters:@{@"requestBodyLength" : @(kBodyLength)}];
 
   GTMSessionFetcher *fetcher = [self fetcherWithURLString:localURLString];
 
   fetcher.bodyStreamProvider = ^(GTMSessionFetcherBodyStreamProviderResponse response) {
-      NSData *bodyData = [GTMSessionFetcherTestServer generatedBodyDataWithLength:kBodyLength];
-      NSInputStream *stream = [NSInputStream inputStreamWithData:bodyData];
-      response(stream);
+    NSData *bodyData = [GTMSessionFetcherTestServer generatedBodyDataWithLength:kBodyLength];
+    NSInputStream *stream = [NSInputStream inputStreamWithData:bodyData];
+    response(stream);
   };
 
   XCTestExpectation *expectation = [self expectationWithDescription:localURLString];
   [fetcher beginFetchWithCompletionHandler:^(NSData *data, NSError *error) {
-      // We'll verify we fetched from the server the actual data on disk.
-      [self assertSuccessfulGettysburgFetchWithFetcher:fetcher
-                                                  data:data
-                                                 error:error];
-      [expectation fulfill];
+    // We'll verify we fetched from the server the actual data on disk.
+    [self assertSuccessfulGettysburgFetchWithFetcher:fetcher data:data error:error];
+    [expectation fulfill];
   }];
   [self waitForExpectationsWithTimeout:_timeoutInterval handler:nil];
   [self assertCallbacksReleasedForFetcher:fetcher];
@@ -857,7 +841,7 @@ NSString *const kGTMGettysburgFileName = @"gettysburgaddress.txt";
   const int kBodyLength = 1024 * 1024;
   NSString *localURLString =
       [self localURLStringToTestFileName:kGTMGettysburgFileName
-                              parameters:@{ @"requestBodyLength" : @(kBodyLength) }];
+                              parameters:@{@"requestBodyLength" : @(kBodyLength)}];
 
   NSMutableURLRequest *request = [self requestWithURLString:localURLString];
   NSData *bodyData = [GTMSessionFetcherTestServer generatedBodyDataWithLength:kBodyLength];
@@ -869,11 +853,9 @@ NSString *const kGTMGettysburgFileName = @"gettysburgaddress.txt";
 
   XCTestExpectation *expectation = [self expectationWithDescription:localURLString];
   [fetcher beginFetchWithCompletionHandler:^(NSData *data, NSError *error) {
-      // We'll verify we fetched from the server the actual data on disk.
-      [self assertSuccessfulGettysburgFetchWithFetcher:fetcher
-                                                  data:data
-                                                 error:error];
-      [expectation fulfill];
+    // We'll verify we fetched from the server the actual data on disk.
+    [self assertSuccessfulGettysburgFetchWithFetcher:fetcher data:data error:error];
+    [expectation fulfill];
   }];
   [self waitForExpectationsWithTimeout:_timeoutInterval handler:nil];
   [self assertCallbacksReleasedForFetcher:fetcher];
@@ -902,9 +884,9 @@ NSString *const kGTMGettysburgFileName = @"gettysburgaddress.txt";
   if (!_isServerRunning) return;
 
 #if TARGET_OS_TV || TARGET_OS_IPHONE
-  #define EXPECTED_COUNT 2
+#define EXPECTED_COUNT 2
 #else
-  #define EXPECTED_COUNT 3
+#define EXPECTED_COUNT 3
 #endif
 
   CREATE_START_STOP_NOTIFICATION_EXPECTATIONS(EXPECTED_COUNT, EXPECTED_COUNT);
@@ -927,12 +909,10 @@ NSString *const kGTMGettysburgFileName = @"gettysburgaddress.txt";
                                 password:@"password"];
   XCTestExpectation *expectation = [self expectationWithDescription:@"basic authentication"];
   [fetcher beginFetchWithCompletionHandler:^(NSData *data, NSError *error) {
-      // We'll verify we fetched from the server the actual data on disk.
-      [self assertSuccessfulGettysburgFetchWithFetcher:fetcher
-                                                  data:data
-                                                 error:error];
-      XCTAssertEqual(self->_testServer.lastHTTPAuthenticationType, kGTMHTTPAuthenticationTypeBasic);
-      [expectation fulfill];
+    // We'll verify we fetched from the server the actual data on disk.
+    [self assertSuccessfulGettysburgFetchWithFetcher:fetcher data:data error:error];
+    XCTAssertEqual(self->_testServer.lastHTTPAuthenticationType, kGTMHTTPAuthenticationTypeBasic);
+    [expectation fulfill];
   }];
   [self waitForExpectationsWithTimeout:_timeoutInterval handler:nil];
   [self assertCallbacksReleasedForFetcher:fetcher];
@@ -951,12 +931,10 @@ NSString *const kGTMGettysburgFileName = @"gettysburgaddress.txt";
                                 password:@"password"];
   expectation = [self expectationWithDescription:@"digest authentication"];
   [fetcher beginFetchWithCompletionHandler:^(NSData *data, NSError *error) {
-      // We'll verify we fetched from the server the actual data on disk.
-      [self assertSuccessfulGettysburgFetchWithFetcher:fetcher
-                                                  data:data
-                                                 error:error];
-      XCTAssertEqual(self->_testServer.lastHTTPAuthenticationType, kGTMHTTPAuthenticationTypeDigest);
-      [expectation fulfill];
+    // We'll verify we fetched from the server the actual data on disk.
+    [self assertSuccessfulGettysburgFetchWithFetcher:fetcher data:data error:error];
+    XCTAssertEqual(self->_testServer.lastHTTPAuthenticationType, kGTMHTTPAuthenticationTypeDigest);
+    [expectation fulfill];
   }];
   [self waitForExpectationsWithTimeout:_timeoutInterval handler:nil];
   [self assertCallbacksReleasedForFetcher:fetcher];
@@ -978,10 +956,10 @@ NSString *const kGTMGettysburgFileName = @"gettysburgaddress.txt";
                                 password:@"password"];
   expectation = [self expectationWithDescription:@"bad credential"];
   [fetcher beginFetchWithCompletionHandler:^(NSData *data, NSError *error) {
-      XCTAssertNil(data);
-      XCTAssertEqual(error.code, (NSInteger)NSURLErrorCancelled, @"%@", error);
-      XCTAssertEqual(self->_testServer.lastHTTPAuthenticationType, kGTMHTTPAuthenticationTypeInvalid);
-      [expectation fulfill];
+    XCTAssertNil(data);
+    XCTAssertEqual(error.code, (NSInteger)NSURLErrorCancelled, @"%@", error);
+    XCTAssertEqual(self->_testServer.lastHTTPAuthenticationType, kGTMHTTPAuthenticationTypeInvalid);
+    [expectation fulfill];
   }];
   [self waitForExpectationsWithTimeout:_timeoutInterval handler:nil];
   [self assertCallbacksReleasedForFetcher:fetcher];
@@ -1015,9 +993,9 @@ NSString *const kGTMGettysburgFileName = @"gettysburgaddress.txt";
 
   // Basic Authentication.
   NSURLCredential *goodCredential =
-    [NSURLCredential credentialWithUser:@"frogman"
-                               password:@"padhopper"
-                            persistence:NSURLCredentialPersistenceNone];
+      [NSURLCredential credentialWithUser:@"frogman"
+                                 password:@"padhopper"
+                              persistence:NSURLCredentialPersistenceNone];
 
   [_testServer setHTTPAuthenticationType:kGTMHTTPAuthenticationTypeBasic
                                 username:goodCredential.user
@@ -1033,19 +1011,17 @@ NSString *const kGTMGettysburgFileName = @"gettysburgaddress.txt";
 
   // All we're testing is that the code path for use of the challenge block is exercised;
   // actual behavior of the disposition is up to NSURLSession and the test server.
-  fetcher.challengeBlock = ^(GTMSessionFetcher *blockFetcher,
-                             NSURLAuthenticationChallenge *challenge,
-                             GTMSessionFetcherChallengeDispositionBlock dispositionBlock) {
-    dispositionBlock(NSURLSessionAuthChallengeUseCredential, goodCredential);
+  fetcher.challengeBlock =
+      ^(GTMSessionFetcher *blockFetcher, NSURLAuthenticationChallenge *challenge,
+        GTMSessionFetcherChallengeDispositionBlock dispositionBlock) {
+        dispositionBlock(NSURLSessionAuthChallengeUseCredential, goodCredential);
 
-    [calledChallengeDisposition fulfill];
-  };
+        [calledChallengeDisposition fulfill];
+      };
 
   XCTestExpectation *expectation = [self expectationWithDescription:@"completion handler"];
   [fetcher beginFetchWithCompletionHandler:^(NSData *data, NSError *error) {
-    [self assertSuccessfulGettysburgFetchWithFetcher:fetcher
-                                                data:data
-                                               error:error];
+    [self assertSuccessfulGettysburgFetchWithFetcher:fetcher data:data error:error];
     XCTAssertEqual(self->_testServer.lastHTTPAuthenticationType, kGTMHTTPAuthenticationTypeBasic);
     [expectation fulfill];
   }];
@@ -1083,18 +1059,17 @@ NSString *const kGTMGettysburgFileName = @"gettysburgaddress.txt";
   // Fetch a live, authorized URL.
   //
   NSString *authedURLString = [self localURLStringToTestFileName:kGTMGettysburgFileName
-                                                      parameters:@{ @"oauth2": @"good" }];
+                                                      parameters:@{@"oauth2" : @"good"}];
 
   GTMSessionFetcher *fetcher = [self fetcherWithURLString:authedURLString];
   fetcher.authorizer = [TestAuthorizer syncAuthorizer];
   XCTestExpectation *expectation = [self expectationWithDescription:@"synchronous authorizer"];
   [fetcher beginFetchWithCompletionHandler:^(NSData *data, NSError *error) {
-      NSString *authHdr =
-          [fetcher.request.allHTTPHeaderFields objectForKey:@"Authorization"];
-      XCTAssertEqualObjects(authHdr, kGoodBearerValue);
-      XCTAssertEqualObjects(data, [self gettysburgAddress]);
-      XCTAssertNil(error, @"unexpected error");
-      [expectation fulfill];
+    NSString *authHdr = [fetcher.request.allHTTPHeaderFields objectForKey:@"Authorization"];
+    XCTAssertEqualObjects(authHdr, kGoodBearerValue);
+    XCTAssertEqualObjects(data, [self gettysburgAddress]);
+    XCTAssertNil(error, @"unexpected error");
+    [expectation fulfill];
   }];
   [self waitForExpectationsWithTimeout:_timeoutInterval handler:nil];
   [self assertCallbacksReleasedForFetcher:fetcher];
@@ -1106,12 +1081,11 @@ NSString *const kGTMGettysburgFileName = @"gettysburgaddress.txt";
   fetcher.authorizer = [TestAuthorizer asyncAuthorizer];
   expectation = [self expectationWithDescription:@"asynchronous authorizer"];
   [fetcher beginFetchWithCompletionHandler:^(NSData *data, NSError *error) {
-      NSString *authHdr =
-          [fetcher.request.allHTTPHeaderFields objectForKey:@"Authorization"];
-      XCTAssertEqualObjects(authHdr, kGoodBearerValue);
-      XCTAssertEqualObjects(data, [self gettysburgAddress]);
-      XCTAssertNil(error, @"unexpected error");
-      [expectation fulfill];
+    NSString *authHdr = [fetcher.request.allHTTPHeaderFields objectForKey:@"Authorization"];
+    XCTAssertEqualObjects(authHdr, kGoodBearerValue);
+    XCTAssertEqualObjects(data, [self gettysburgAddress]);
+    XCTAssertNil(error, @"unexpected error");
+    [expectation fulfill];
   }];
   [self waitForExpectationsWithTimeout:_timeoutInterval handler:nil];
   [self assertCallbacksReleasedForFetcher:fetcher];
@@ -1124,8 +1098,7 @@ NSString *const kGTMGettysburgFileName = @"gettysburgaddress.txt";
   ((TestAuthorizer *)fetcher.authorizer).willFailWithError = YES;
   expectation = [self expectationWithDescription:@"asynchronous authorizer error"];
   [fetcher beginFetchWithCompletionHandler:^(NSData *data, NSError *error) {
-    NSString *authHdr =
-      [fetcher.request.allHTTPHeaderFields objectForKey:@"Authorization"];
+    NSString *authHdr = [fetcher.request.allHTTPHeaderFields objectForKey:@"Authorization"];
     XCTAssertNil(authHdr);
     XCTAssertNil(data);
     XCTAssertNotNil(error);
@@ -1138,22 +1111,22 @@ NSString *const kGTMGettysburgFileName = @"gettysburgaddress.txt";
   // Fetch with an expired sync authorizer, no retry allowed.
   //
   authedURLString = [self localURLStringToTestFileName:kGTMGettysburgFileName
-                                            parameters:@{ @"oauth2": @"good" }];
+                                            parameters:@{@"oauth2" : @"good"}];
 
   fetcher = [self fetcherWithURLString:authedURLString];
   fetcher.authorizer = [TestAuthorizer expiredSyncAuthorizer];
-  fetcher.retryBlock = ^(BOOL suggestedWillRetry, NSError *error,
-                         GTMSessionFetcherRetryResponse response) {
-      XCTAssertEqual(error.code, (NSInteger)401, @"%@", error);
-      response(NO);
-  };
+  fetcher.retryBlock =
+      ^(BOOL suggestedWillRetry, NSError *error, GTMSessionFetcherRetryResponse response) {
+        XCTAssertEqual(error.code, (NSInteger)401, @"%@", error);
+        response(NO);
+      };
 
   expectation = [self expectationWithDescription:@"expired synchronous authorizer no retry"];
   [fetcher beginFetchWithCompletionHandler:^(NSData *data, NSError *error) {
-      NSString *authHdr = [fetcher.request.allHTTPHeaderFields objectForKey:@"Authorization"];
-      XCTAssertNil(authHdr);
-      XCTAssertEqual(error.code, (NSInteger)401, @"%@", error);
-      [expectation fulfill];
+    NSString *authHdr = [fetcher.request.allHTTPHeaderFields objectForKey:@"Authorization"];
+    XCTAssertNil(authHdr);
+    XCTAssertEqual(error.code, (NSInteger)401, @"%@", error);
+    [expectation fulfill];
   }];
   [self waitForExpectationsWithTimeout:_timeoutInterval handler:nil];
   [self assertCallbacksReleasedForFetcher:fetcher];
@@ -1162,23 +1135,22 @@ NSString *const kGTMGettysburgFileName = @"gettysburgaddress.txt";
   // Fetch with an expired async authorizer, no retry allowed.
   //
   authedURLString = [self localURLStringToTestFileName:kGTMGettysburgFileName
-                                            parameters:@{ @"oauth2": @"good" }];
+                                            parameters:@{@"oauth2" : @"good"}];
 
   fetcher = [self fetcherWithURLString:authedURLString];
   fetcher.authorizer = [TestAuthorizer expiredAsyncAuthorizer];
-  fetcher.retryBlock = ^(BOOL suggestedWillRetry, NSError *error,
-                         GTMSessionFetcherRetryResponse response) {
-      XCTAssertEqual(error.code, (NSInteger)401, @"%@", error);
-      response(NO);
-  };
+  fetcher.retryBlock =
+      ^(BOOL suggestedWillRetry, NSError *error, GTMSessionFetcherRetryResponse response) {
+        XCTAssertEqual(error.code, (NSInteger)401, @"%@", error);
+        response(NO);
+      };
 
   expectation = [self expectationWithDescription:@"expired asynchronous authorizer no retry"];
   [fetcher beginFetchWithCompletionHandler:^(NSData *data, NSError *error) {
-      NSString *authHdr =
-          [fetcher.request.allHTTPHeaderFields objectForKey:@"Authorization"];
-      XCTAssertNil(authHdr);
-      XCTAssertEqual(error.code, (NSInteger)401, @"%@", error);
-      [expectation fulfill];
+    NSString *authHdr = [fetcher.request.allHTTPHeaderFields objectForKey:@"Authorization"];
+    XCTAssertNil(authHdr);
+    XCTAssertEqual(error.code, (NSInteger)401, @"%@", error);
+    [expectation fulfill];
   }];
   [self waitForExpectationsWithTimeout:_timeoutInterval handler:nil];
   [self assertCallbacksReleasedForFetcher:fetcher];
@@ -1188,19 +1160,19 @@ NSString *const kGTMGettysburgFileName = @"gettysburgaddress.txt";
   //
   fetcher = [self fetcherWithURLString:authedURLString];
   fetcher.authorizer = [TestAuthorizer expiredSyncAuthorizer];
-  fetcher.retryBlock = ^(BOOL suggestedWillRetry, NSError *error,
-                         GTMSessionFetcherRetryResponse response) {
-      XCTAssertEqual(error.code, (NSInteger)401, @"%@", error);
-      response(YES);
-  };
+  fetcher.retryBlock =
+      ^(BOOL suggestedWillRetry, NSError *error, GTMSessionFetcherRetryResponse response) {
+        XCTAssertEqual(error.code, (NSInteger)401, @"%@", error);
+        response(YES);
+      };
 
   expectation = [self expectationWithDescription:@"expired synchronous authorizer auto refresh"];
   [fetcher beginFetchWithCompletionHandler:^(NSData *data, NSError *error) {
-      NSString *authHdr = [fetcher.request.allHTTPHeaderFields objectForKey:@"Authorization"];
-      XCTAssertEqualObjects(authHdr, kGoodBearerValue);
-      XCTAssertEqualObjects(data, [self gettysburgAddress]);
-      XCTAssertNil(error);
-      [expectation fulfill];
+    NSString *authHdr = [fetcher.request.allHTTPHeaderFields objectForKey:@"Authorization"];
+    XCTAssertEqualObjects(authHdr, kGoodBearerValue);
+    XCTAssertEqualObjects(data, [self gettysburgAddress]);
+    XCTAssertNil(error);
+    [expectation fulfill];
   }];
   [self waitForExpectationsWithTimeout:_timeoutInterval handler:nil];
   [self assertCallbacksReleasedForFetcher:fetcher];
@@ -1210,20 +1182,19 @@ NSString *const kGTMGettysburgFileName = @"gettysburgaddress.txt";
   //
   fetcher = [self fetcherWithURLString:authedURLString];
   fetcher.authorizer = [TestAuthorizer expiredAsyncAuthorizer];
-  fetcher.retryBlock = ^(BOOL suggestedWillRetry, NSError *error,
-                         GTMSessionFetcherRetryResponse response) {
-    XCTAssertEqual(error.code, (NSInteger)401, @"%@", error);
-    response(YES);
-  };
+  fetcher.retryBlock =
+      ^(BOOL suggestedWillRetry, NSError *error, GTMSessionFetcherRetryResponse response) {
+        XCTAssertEqual(error.code, (NSInteger)401, @"%@", error);
+        response(YES);
+      };
 
   expectation = [self expectationWithDescription:@"expired asynchronous authorizer auto refresh"];
   [fetcher beginFetchWithCompletionHandler:^(NSData *data, NSError *error) {
-      NSString *authHdr =
-          [fetcher.request.allHTTPHeaderFields objectForKey:@"Authorization"];
-      XCTAssertEqualObjects(authHdr, kGoodBearerValue);
-      XCTAssertEqualObjects(data, [self gettysburgAddress]);
-      XCTAssertNil(error);
-      [expectation fulfill];
+    NSString *authHdr = [fetcher.request.allHTTPHeaderFields objectForKey:@"Authorization"];
+    XCTAssertEqualObjects(authHdr, kGoodBearerValue);
+    XCTAssertEqualObjects(data, [self gettysburgAddress]);
+    XCTAssertNil(error);
+    [expectation fulfill];
   }];
   [self waitForExpectationsWithTimeout:_timeoutInterval handler:nil];
   [self assertCallbacksReleasedForFetcher:fetcher];
@@ -1265,7 +1236,7 @@ NSString *const kGTMGettysburgFileName = @"gettysburgaddress.txt";
   // Fetch our test file.  Ensure the body survives the redirection.
   //
   const int kBodyLength = 137;
-  NSDictionary *params = @{ @"requestBodyLength" : [@(kBodyLength) stringValue] };
+  NSDictionary *params = @{@"requestBodyLength" : [@(kBodyLength) stringValue]};
   NSString *localURLString = [self localURLStringToTestFileName:kGTMGettysburgFileName
                                                      parameters:params];
 
@@ -1273,41 +1244,39 @@ NSString *const kGTMGettysburgFileName = @"gettysburgaddress.txt";
   fetcher.bodyData = [GTMSessionFetcherTestServer generatedBodyDataWithLength:kBodyLength];
 
   XCTestExpectation *redirectExpectation = [self expectationWithDescription:@"redirect called"];
-  fetcher.willRedirectBlock = ^(NSHTTPURLResponse *redirectResponse,
-                                NSURLRequest *redirectRequest,
+  fetcher.willRedirectBlock = ^(NSHTTPURLResponse *redirectResponse, NSURLRequest *redirectRequest,
                                 GTMSessionFetcherWillRedirectResponse response) {
-      XCTAssert(![redirectResponse.URL.host isEqual:redirectRequest.URL.host] ||
-                ![redirectResponse.URL.port isEqual:redirectRequest.URL.port]);
-      response(redirectRequest);
-      [redirectExpectation fulfill];
+    XCTAssert(![redirectResponse.URL.host isEqual:redirectRequest.URL.host] ||
+              ![redirectResponse.URL.port isEqual:redirectRequest.URL.port]);
+    response(redirectRequest);
+    [redirectExpectation fulfill];
   };
 
   XCTestExpectation *expectation = [self expectationWithDescription:@"completion handler"];
   [fetcher beginFetchWithCompletionHandler:^(NSData *data, NSError *error) {
-      [self assertSuccessfulGettysburgFetchWithFetcher:fetcher
-                                                  data:data
-                                                 error:error];
-      // Check that a redirect was performed
-      NSURL *requestURL = [NSURL URLWithString:localURLString];
-      NSURL *responseURL = fetcher.response.URL;
-      XCTAssertTrue(![requestURL.host isEqual:responseURL.host] ||
-                    ![requestURL.port isEqual:responseURL.port], @"failed to redirect");
+    [self assertSuccessfulGettysburgFetchWithFetcher:fetcher data:data error:error];
+    // Check that a redirect was performed
+    NSURL *requestURL = [NSURL URLWithString:localURLString];
+    NSURL *responseURL = fetcher.response.URL;
+    XCTAssertTrue(
+        ![requestURL.host isEqual:responseURL.host] || ![requestURL.port isEqual:responseURL.port],
+        @"failed to redirect");
 
-      // Cookies should have been set by the response; specifically, TestCookie
-      // should be set to the name of the file requested.
-      NSDictionary *responseHeaders = [(NSHTTPURLResponse *)fetcher.response allHeaderFields];
-      NSString *cookiesSetString = [responseHeaders objectForKey:@"Set-Cookie"];
-      NSString *cookieExpected = [NSString stringWithFormat:@"TestCookie=%@", kGTMGettysburgFileName];
-      XCTAssertEqualObjects(cookiesSetString, cookieExpected);
+    // Cookies should have been set by the response; specifically, TestCookie
+    // should be set to the name of the file requested.
+    NSDictionary *responseHeaders = [(NSHTTPURLResponse *)fetcher.response allHeaderFields];
+    NSString *cookiesSetString = [responseHeaders objectForKey:@"Set-Cookie"];
+    NSString *cookieExpected = [NSString stringWithFormat:@"TestCookie=%@", kGTMGettysburgFileName];
+    XCTAssertEqualObjects(cookiesSetString, cookieExpected);
 
-      // A cookie should've been set.
-      NSHTTPCookieStorage *cookieStorage = fetcher.configuration.HTTPCookieStorage;
-      NSURL *localhostURL = [NSURL URLWithString:@"http://localhost/"];
-      NSArray *cookies = [cookieStorage cookiesForURL:localhostURL];
-      XCTAssertEqual(cookies.count, (NSUInteger)1);
-      NSHTTPCookie *firstCookie = cookies.firstObject;
-      XCTAssertEqualObjects([firstCookie value], @"gettysburgaddress.txt");
-      [expectation fulfill];
+    // A cookie should've been set.
+    NSHTTPCookieStorage *cookieStorage = fetcher.configuration.HTTPCookieStorage;
+    NSURL *localhostURL = [NSURL URLWithString:@"http://localhost/"];
+    NSArray *cookies = [cookieStorage cookiesForURL:localhostURL];
+    XCTAssertEqual(cookies.count, (NSUInteger)1);
+    NSHTTPCookie *firstCookie = cookies.firstObject;
+    XCTAssertEqualObjects([firstCookie value], @"gettysburgaddress.txt");
+    [expectation fulfill];
   }];
   [self waitForExpectationsWithTimeout:_timeoutInterval handler:nil];
   [self assertCallbacksReleasedForFetcher:fetcher];
@@ -1349,7 +1318,7 @@ NSString *const kGTMGettysburgFileName = @"gettysburgaddress.txt";
   // Fetch our test file.  Ensure the body survives the redirection.
   //
   const int kBodyLength = 137;
-  NSDictionary *params = @{ @"requestBodyLength" : [@(kBodyLength) stringValue] };
+  NSDictionary *params = @{@"requestBodyLength" : [@(kBodyLength) stringValue]};
   NSString *localURLString = [self localURLStringToTestFileName:kGTMGettysburgFileName
                                                      parameters:params];
 
@@ -1357,8 +1326,7 @@ NSString *const kGTMGettysburgFileName = @"gettysburgaddress.txt";
   fetcher.bodyData = [GTMSessionFetcherTestServer generatedBodyDataWithLength:kBodyLength];
 
   XCTestExpectation *redirectExpectation = [self expectationWithDescription:@"redirect block"];
-  fetcher.willRedirectBlock = ^(NSHTTPURLResponse *redirectResponse,
-                                NSURLRequest *redirectRequest,
+  fetcher.willRedirectBlock = ^(NSHTTPURLResponse *redirectResponse, NSURLRequest *redirectRequest,
                                 GTMSessionFetcherWillRedirectResponse response) {
     XCTAssert(![redirectResponse.URL.host isEqual:redirectRequest.URL.host] ||
               ![redirectResponse.URL.port isEqual:redirectRequest.URL.port]);
@@ -1371,8 +1339,9 @@ NSString *const kGTMGettysburgFileName = @"gettysburgaddress.txt";
     // Check that a redirect was performed
     NSURL *requestURL = [NSURL URLWithString:localURLString];
     NSURL *responseURL = fetcher.response.URL;
-    XCTAssertFalse(![requestURL.host isEqual:responseURL.host] ||
-                   ![requestURL.port isEqual:responseURL.port], @"did not receive redirect");
+    XCTAssertFalse(
+        ![requestURL.host isEqual:responseURL.host] || ![requestURL.port isEqual:responseURL.port],
+        @"did not receive redirect");
 
     XCTAssertEqualObjects(error.domain, kGTMBridgeFetcherStatusDomain);
     XCTAssertEqual(error.code, 302, @"expect HTTP 302 status code error when cancelling redirect.");
@@ -1424,7 +1393,7 @@ NSString *const kGTMGettysburgFileName = @"gettysburgaddress.txt";
   FetcherNotificationsCounter *fnctr = [[FetcherNotificationsCounter alloc] init];
 
   NSString *invalidFileURLString = [self localURLStringToTestFileName:kGTMGettysburgFileName
-                                                           parameters:@{ @"status": @"503" }];
+                                                           parameters:@{@"status" : @"503"}];
 
   __block GTMSessionFetcher *fetcher;
 
@@ -1441,12 +1410,11 @@ NSString *const kGTMGettysburgFileName = @"gettysburgaddress.txt";
                                pow(2.0, fetcher.retryCount), fetcher.nextRetryInterval);
 
     NSData *statusData = [error.userInfo objectForKey:kGTMSessionFetcherStatusDataKey];
-    NSString *dataStr = [[NSString alloc] initWithData:statusData
-                                              encoding:NSUTF8StringEncoding];
+    NSString *dataStr = [[NSString alloc] initWithData:statusData encoding:NSUTF8StringEncoding];
     NSInteger code = error.code;
     if (code == 503) {
       NSString *statusDataContentType =
-        [error.userInfo objectForKey:kGTMSessionFetcherStatusDataContentTypeKey];
+          [error.userInfo objectForKey:kGTMSessionFetcherStatusDataContentTypeKey];
       XCTAssertEqualObjects(statusDataContentType, @"application/json");
       NSString *expectedStr = [[self->_testServer class] JSONBodyStringForStatus:503];
       XCTAssertEqualObjects(dataStr, expectedStr);
@@ -1455,39 +1423,39 @@ NSString *const kGTMGettysburgFileName = @"gettysburgaddress.txt";
   };
 
   // Block for retrying and changing the request to one that will succeed.
-  GTMSessionFetcherRetryBlock fixRequestBlock = ^(BOOL suggestedWillRetry, NSError *error,
-                                                  GTMSessionFetcherRetryResponse response) {
-      XCTAssertEqualWithAccuracy(fetcher.nextRetryInterval, pow(2.0, fetcher.retryCount), 0.001,
-                                 @"Unexpected next retry interval (expected %f, was %f)",
-                                 pow(2.0, fetcher.retryCount), fetcher.nextRetryInterval);
+  GTMSessionFetcherRetryBlock fixRequestBlock =
+      ^(BOOL suggestedWillRetry, NSError *error, GTMSessionFetcherRetryResponse response) {
+        XCTAssertEqualWithAccuracy(fetcher.nextRetryInterval, pow(2.0, fetcher.retryCount), 0.001,
+                                   @"Unexpected next retry interval (expected %f, was %f)",
+                                   pow(2.0, fetcher.retryCount), fetcher.nextRetryInterval);
 
-      // Fix it - change the request to a URL which does not have a status value
-      NSString *urlString = [self localURLStringToTestFileName:kGTMGettysburgFileName];
-      NSMutableURLRequest *mutableRequest = [fetcher mutableRequestForTesting];
-      mutableRequest.URL = [NSURL URLWithString:urlString];
+        // Fix it - change the request to a URL which does not have a status value
+        NSString *urlString = [self localURLStringToTestFileName:kGTMGettysburgFileName];
+        NSMutableURLRequest *mutableRequest = [fetcher mutableRequestForTesting];
+        mutableRequest.URL = [NSURL URLWithString:urlString];
 
-      response(YES);  // Do the retry fetch; it should succeed now.
-  };
+        response(YES);  // Do the retry fetch; it should succeed now.
+      };
 
   //
   // Test: retry until timeout, then expect failure with status code.
   //
   fetcher = [self fetcherForRetryWithURLString:invalidFileURLString
                                     retryBlock:countRetriesBlock
-                              maxRetryInterval:5.0 // retry intervals of 1, 2, 4
+                              maxRetryInterval:5.0  // retry intervals of 1, 2, 4
                                       userData:@1000];
   XCTestExpectation *expectation = [self expectationWithDescription:@"retry timeout completion"];
   [fetcher beginFetchWithCompletionHandler:^(NSData *data, NSError *error) {
-      XCTAssertNotNil(data, @"error data is expected");
-      XCTAssertEqual(fetcher.statusCode, (NSInteger)503);
-      XCTAssertEqual(fetcher.retryCount, (NSUInteger)3);
+    XCTAssertNotNil(data, @"error data is expected");
+    XCTAssertEqual(fetcher.statusCode, (NSInteger)503);
+    XCTAssertEqual(fetcher.retryCount, (NSUInteger)3);
 
-      NSNumber *retriesDone = error.userInfo[kGTMSessionFetcherNumberOfRetriesDoneKey];
-      NSNumber *elapsedInterval = error.userInfo[kGTMSessionFetcherElapsedIntervalWithRetriesKey];
-      XCTAssertEqual(retriesDone.integerValue, 3);
-      XCTAssertGreaterThan(elapsedInterval.doubleValue, 0);
-      [expectation fulfill];
-   }];
+    NSNumber *retriesDone = error.userInfo[kGTMSessionFetcherNumberOfRetriesDoneKey];
+    NSNumber *elapsedInterval = error.userInfo[kGTMSessionFetcherElapsedIntervalWithRetriesKey];
+    XCTAssertEqual(retriesDone.integerValue, 3);
+    XCTAssertGreaterThan(elapsedInterval.doubleValue, 0);
+    [expectation fulfill];
+  }];
   [self waitForExpectationsWithTimeout:_timeoutInterval handler:nil];
   [self assertCallbacksReleasedForFetcher:fetcher];
 
@@ -1496,22 +1464,22 @@ NSString *const kGTMGettysburgFileName = @"gettysburgaddress.txt";
   // after first retry
   //
   NSString *timeoutFileURLString = [self localURLStringToTestFileName:kGTMGettysburgFileName
-                                                           parameters:@{ @"sleep": @"10" }];
+                                                           parameters:@{@"sleep" : @"10"}];
   fetcher = [self fetcherForRetryWithURLString:timeoutFileURLString
                                     retryBlock:countRetriesBlock
-                              maxRetryInterval:5.0 // retry interval of 1, then exceed 3*max timout
+                              maxRetryInterval:5.0  // retry interval of 1, then exceed 3*max timout
                                       userData:@1000];
   expectation = [self expectationWithDescription:@"retry server sleep completion"];
   [fetcher beginFetchWithCompletionHandler:^(NSData *data, NSError *error) {
-      XCTAssertNil(data, @"error data unexpected");
-      XCTAssertEqual(fetcher.statusCode, (NSInteger)408, @"%@", error);
-      XCTAssertEqual(fetcher.retryCount, (NSUInteger)1);
+    XCTAssertNil(data, @"error data unexpected");
+    XCTAssertEqual(fetcher.statusCode, (NSInteger)408, @"%@", error);
+    XCTAssertEqual(fetcher.retryCount, (NSUInteger)1);
 
-      NSNumber *retriesDone = error.userInfo[kGTMSessionFetcherNumberOfRetriesDoneKey];
-      NSNumber *elapsedInterval = error.userInfo[kGTMSessionFetcherElapsedIntervalWithRetriesKey];
-      XCTAssertEqual(retriesDone.integerValue, 1);
-      XCTAssertGreaterThan(elapsedInterval.doubleValue, 0);
-      [expectation fulfill];
+    NSNumber *retriesDone = error.userInfo[kGTMSessionFetcherNumberOfRetriesDoneKey];
+    NSNumber *elapsedInterval = error.userInfo[kGTMSessionFetcherElapsedIntervalWithRetriesKey];
+    XCTAssertEqual(retriesDone.integerValue, 1);
+    XCTAssertGreaterThan(elapsedInterval.doubleValue, 0);
+    [expectation fulfill];
   }];
   [self waitForExpectationsWithTimeout:_timeoutInterval handler:nil];
   [self assertCallbacksReleasedForFetcher:fetcher];
@@ -1521,19 +1489,19 @@ NSString *const kGTMGettysburgFileName = @"gettysburgaddress.txt";
   //
   fetcher = [self fetcherForRetryWithURLString:invalidFileURLString
                                     retryBlock:countRetriesBlock
-                              maxRetryInterval:10.0 // retry intervals of 1, 2, 4, 8
+                              maxRetryInterval:10.0  // retry intervals of 1, 2, 4, 8
                                       userData:@2];
   expectation = [self expectationWithDescription:@"retry twice completion"];
   [fetcher beginFetchWithCompletionHandler:^(NSData *data, NSError *error) {
-      XCTAssertNotNil(data);
-      XCTAssertEqual(fetcher.statusCode, (NSInteger)503, @"%@", error);
-      XCTAssertEqual(fetcher.retryCount, (NSUInteger)2);
+    XCTAssertNotNil(data);
+    XCTAssertEqual(fetcher.statusCode, (NSInteger)503, @"%@", error);
+    XCTAssertEqual(fetcher.retryCount, (NSUInteger)2);
 
-      NSNumber *retriesDone = error.userInfo[kGTMSessionFetcherNumberOfRetriesDoneKey];
-      NSNumber *elapsedInterval = error.userInfo[kGTMSessionFetcherElapsedIntervalWithRetriesKey];
-      XCTAssertEqual(retriesDone.integerValue, 2);
-      XCTAssertGreaterThan(elapsedInterval.doubleValue, 0);
-      [expectation fulfill];
+    NSNumber *retriesDone = error.userInfo[kGTMSessionFetcherNumberOfRetriesDoneKey];
+    NSNumber *elapsedInterval = error.userInfo[kGTMSessionFetcherElapsedIntervalWithRetriesKey];
+    XCTAssertEqual(retriesDone.integerValue, 2);
+    XCTAssertGreaterThan(elapsedInterval.doubleValue, 0);
+    [expectation fulfill];
   }];
   [self waitForExpectationsWithTimeout:_timeoutInterval handler:nil];
   [self assertCallbacksReleasedForFetcher:fetcher];
@@ -1548,10 +1516,10 @@ NSString *const kGTMGettysburgFileName = @"gettysburgaddress.txt";
                                       userData:@1000];
   expectation = [self expectationWithDescription:@"retry fix URL"];
   [fetcher beginFetchWithCompletionHandler:^(NSData *data, NSError *error) {
-      XCTAssertNotNil(data);
-      XCTAssertEqual(fetcher.statusCode, (NSInteger)200);
-      XCTAssertEqual(fetcher.retryCount, (NSUInteger)1);
-      [expectation fulfill];
+    XCTAssertNotNil(data);
+    XCTAssertEqual(fetcher.statusCode, (NSInteger)200);
+    XCTAssertEqual(fetcher.retryCount, (NSUInteger)1);
+    [expectation fulfill];
   }];
   [self waitForExpectationsWithTimeout:_timeoutInterval handler:nil];
   [self assertCallbacksReleasedForFetcher:fetcher];
@@ -1600,32 +1568,31 @@ NSString *const kGTMGettysburgFileName = @"gettysburgaddress.txt";
   NSString *validURLString = [self localURLStringToTestFileName:kGTMGettysburgFileName];
   GTMSessionFetcher *fetcher = [self fetcherWithURLString:validURLString];
   fetcher.destinationFileURL = destFileURL;
-  fetcher.downloadProgressBlock = ^(int64_t bytesWritten,
-                                    int64_t totalBytesWritten,
-                                    int64_t totalBytesExpectedToWrite) {
-    // Verify the parameters are reasonable.
-    XCTAssertTrue(bytesWritten > 0 && bytesWritten <= origLength, @"%lld", bytesWritten);
-    XCTAssertTrue(totalBytesWritten > 0 && totalBytesWritten <= origLength,
-                  @"%lld", totalBytesWritten);
-    XCTAssertEqual(totalBytesExpectedToWrite, origLength);
+  fetcher.downloadProgressBlock =
+      ^(int64_t bytesWritten, int64_t totalBytesWritten, int64_t totalBytesExpectedToWrite) {
+        // Verify the parameters are reasonable.
+        XCTAssertTrue(bytesWritten > 0 && bytesWritten <= origLength, @"%lld", bytesWritten);
+        XCTAssertTrue(totalBytesWritten > 0 && totalBytesWritten <= origLength, @"%lld",
+                      totalBytesWritten);
+        XCTAssertEqual(totalBytesExpectedToWrite, origLength);
 
-    // Total bytes written should increase monotonically.
-    XCTAssertTrue(totalBytesWritten > totalWritten,
-                  @"%lld !> %lld", totalBytesWritten, totalWritten);
-    totalWritten = totalBytesWritten;
-  };
+        // Total bytes written should increase monotonically.
+        XCTAssertTrue(totalBytesWritten > totalWritten, @"%lld !> %lld", totalBytesWritten,
+                      totalWritten);
+        totalWritten = totalBytesWritten;
+      };
 
   XCTestExpectation *expectation = [self expectationWithDescription:@"completion handler"];
   [fetcher beginFetchWithCompletionHandler:^(NSData *data, NSError *error) {
-      XCTAssertNil(data);
-      XCTAssertNil(error);
+    XCTAssertNil(data);
+    XCTAssertNil(error);
 
-      NSString *fetchedContents = [NSString stringWithContentsOfURL:destFileURL
-                                                           encoding:NSUTF8StringEncoding
-                                                              error:NULL];
-      XCTAssertEqualObjects(fetchedContents, origContents);
-      XCTAssertEqual(totalWritten, origLength, @"downloadProgressBlock not called");
-      [expectation fulfill];
+    NSString *fetchedContents = [NSString stringWithContentsOfURL:destFileURL
+                                                         encoding:NSUTF8StringEncoding
+                                                            error:NULL];
+    XCTAssertEqualObjects(fetchedContents, origContents);
+    XCTAssertEqual(totalWritten, origLength, @"downloadProgressBlock not called");
+    [expectation fulfill];
   }];
   [self waitForExpectationsWithTimeout:_timeoutInterval handler:nil];
   [self assertCallbacksReleasedForFetcher:fetcher];
@@ -1665,22 +1632,22 @@ NSString *const kGTMGettysburgFileName = @"gettysburgaddress.txt";
   // Get the original file's contents.
   NSString *origContents = [[NSString alloc] initWithData:[self gettysburgAddress]
                                                  encoding:NSUTF8StringEncoding];
-  NSString *escapedContents =
-      [origContents stringByAddingPercentEncodingWithAllowedCharacters:
-       [NSCharacterSet URLQueryAllowedCharacterSet]];
+  NSString *escapedContents = [origContents
+      stringByAddingPercentEncodingWithAllowedCharacters:[NSCharacterSet
+                                                             URLQueryAllowedCharacterSet]];
   NSString *validDataURLString = [NSString stringWithFormat:@"data:,%@", escapedContents];
   GTMSessionFetcher *fetcher = [self fetcherWithURLString:validDataURLString];
   fetcher.destinationFileURL = destFileURL;
   XCTestExpectation *expectation = [self expectationWithDescription:@"completion handler"];
   [fetcher beginFetchWithCompletionHandler:^(NSData *data, NSError *error) {
-      XCTAssertNil(data);
-      XCTAssertNil(error);
+    XCTAssertNil(data);
+    XCTAssertNil(error);
 
-      NSString *fetchedContents = [NSString stringWithContentsOfURL:destFileURL
-                                                           encoding:NSUTF8StringEncoding
-                                                              error:NULL];
-      XCTAssertEqualObjects(fetchedContents, origContents);
-      [expectation fulfill];
+    NSString *fetchedContents = [NSString stringWithContentsOfURL:destFileURL
+                                                         encoding:NSUTF8StringEncoding
+                                                            error:NULL];
+    XCTAssertEqualObjects(fetchedContents, origContents);
+    [expectation fulfill];
   }];
   [self waitForExpectationsWithTimeout:_timeoutInterval handler:nil];
   [self assertCallbacksReleasedForFetcher:fetcher];
@@ -1716,59 +1683,57 @@ NSString *const kGTMGettysburgFileName = @"gettysburgaddress.txt";
 
   __block int64_t totalWritten = 0;
   NSString *invalidURLString = [self localURLStringToTestFileName:kGTMGettysburgFileName
-                                                       parameters:@{ @"status": @"400" }];
+                                                       parameters:@{@"status" : @"400"}];
   NSString *statusStr = [[_testServer class] JSONBodyStringForStatus:400];
   NSURL *destFileURL = [self temporaryFileURLWithBaseName:NSStringFromSelector(_cmd)];
 
   GTMSessionFetcher *fetcher = [self fetcherWithURLString:invalidURLString];
   fetcher.destinationFileURL = destFileURL;
-  fetcher.downloadProgressBlock = ^(int64_t bytesWritten,
-                                    int64_t totalBytesWritten,
-                                    int64_t totalBytesExpectedToWrite) {
-      // Verify the parameters are reasonable.
-      XCTAssertTrue(totalBytesWritten > 0 && totalBytesWritten <= (int64_t)statusStr.length,
-                    @"%lld", totalBytesWritten);
+  fetcher.downloadProgressBlock =
+      ^(int64_t bytesWritten, int64_t totalBytesWritten, int64_t totalBytesExpectedToWrite) {
+        // Verify the parameters are reasonable.
+        XCTAssertTrue(totalBytesWritten > 0 && totalBytesWritten <= (int64_t)statusStr.length,
+                      @"%lld", totalBytesWritten);
 
-      // Total bytes written should increase monotonically.
-      XCTAssertTrue(totalBytesWritten > totalWritten,
-                    @"%lld !> %lld", totalBytesWritten, totalWritten);
-      totalWritten = totalBytesWritten;
-  };
+        // Total bytes written should increase monotonically.
+        XCTAssertTrue(totalBytesWritten > totalWritten, @"%lld !> %lld", totalBytesWritten,
+                      totalWritten);
+        totalWritten = totalBytesWritten;
+      };
 
   XCTestExpectation *expectation = [self expectationWithDescription:@"completion handler"];
   [fetcher beginFetchWithCompletionHandler:^(NSData *data, NSError *error) {
-      XCTAssertNil(data);
+    XCTAssertNil(data);
 
-      // errorData gets set with http status error only when the client error is nil.
-      // on iOS 8, client error gets returned with URLSession:task:didCompleteWithError:
-      // on iOS 9 and up, client error is nil and the http status error with errorData
-      // gets set in finishWithError:shouldRetry:
-      if (error.domain == kGTMSessionFetcherStatusDomain) {
-        NSData *errorData = error.userInfo[kGTMSessionFetcherStatusDataKey];
-        XCTAssertNotNil(errorData);
-        XCTAssertEqual(errorData.length, (NSUInteger)totalWritten,
-                       @"The length of error data should match the size of totalBytesWritten.");
-        XCTAssertNotNil(error.userInfo[kGTMSessionFetcherStatusDataContentTypeKey]);
-      }
+    // errorData gets set with http status error only when the client error is nil.
+    // on iOS 8, client error gets returned with URLSession:task:didCompleteWithError:
+    // on iOS 9 and up, client error is nil and the http status error with errorData
+    // gets set in finishWithError:shouldRetry:
+    if (error.domain == kGTMSessionFetcherStatusDomain) {
+      NSData *errorData = error.userInfo[kGTMSessionFetcherStatusDataKey];
+      XCTAssertNotNil(errorData);
+      XCTAssertEqual(errorData.length, (NSUInteger)totalWritten,
+                     @"The length of error data should match the size of totalBytesWritten.");
+      XCTAssertNotNil(error.userInfo[kGTMSessionFetcherStatusDataContentTypeKey]);
+    }
 
-      // Check for two error codes because of the discrepancy between iOS 8 and iOS 9 plus
-      // described above
-      BOOL isExpectedCode = (error.code == NSURLErrorFileDoesNotExist || error.code == 400);
-      XCTAssertTrue(isExpectedCode, @"%@", error);
+    // Check for two error codes because of the discrepancy between iOS 8 and iOS 9 plus
+    // described above
+    BOOL isExpectedCode = (error.code == NSURLErrorFileDoesNotExist || error.code == 400);
+    XCTAssertTrue(isExpectedCode, @"%@", error);
 
-      // The file should not be copied to the destination URL on status 400 and higher.
-      BOOL fileExists = [destFileURL checkResourceIsReachableAndReturnError:NULL];
-      XCTAssertFalse(fileExists, @"%@ -- %@", error, destFileURL.path);
+    // The file should not be copied to the destination URL on status 400 and higher.
+    BOOL fileExists = [destFileURL checkResourceIsReachableAndReturnError:NULL];
+    XCTAssertFalse(fileExists, @"%@ -- %@", error, destFileURL.path);
 
-      if (error.code == 400) {
-        // Check the body JSON of the status code response.
-        XCTAssertEqual(totalWritten, (int64_t)statusStr.length,
-                       @"downloadProgressBlock not called");
-      } else {
-        // If the error was NSURLErrorFileDoesNotExist sometimes downloadProgressBlock was
-        // called so totalWritten > 0, sometimes not.
-      }
-      [expectation fulfill];
+    if (error.code == 400) {
+      // Check the body JSON of the status code response.
+      XCTAssertEqual(totalWritten, (int64_t)statusStr.length, @"downloadProgressBlock not called");
+    } else {
+      // If the error was NSURLErrorFileDoesNotExist sometimes downloadProgressBlock was
+      // called so totalWritten > 0, sometimes not.
+    }
+    [expectation fulfill];
   }];
 
   [self waitForExpectationsWithTimeout:_timeoutInterval handler:nil];
@@ -1817,8 +1782,10 @@ NSString *const kGTMGettysburgFileName = @"gettysburgaddress.txt";
 
   WAIT_FOR_START_STOP_NOTIFICATION_EXPECTATIONS();
 
-  XCTAssertEqual(fnctr.fetchStarted, kFetcherCreationCount, @"%@", fnctr.fetchersStartedDescriptions);
-  XCTAssertEqual(fnctr.fetchStopped, kFetcherCreationCount, @"%@", fnctr.fetchersStoppedDescriptions);
+  XCTAssertEqual(fnctr.fetchStarted, kFetcherCreationCount, @"%@",
+                 fnctr.fetchersStartedDescriptions);
+  XCTAssertEqual(fnctr.fetchStopped, kFetcherCreationCount, @"%@",
+                 fnctr.fetchersStoppedDescriptions);
   XCTAssertEqual(fnctr.fetchCompletionInvoked, 0);
 #if GTM_BACKGROUND_TASK_FETCHING
   [self waitForBackgroundTaskEndedNotifications:fnctr];
@@ -1841,7 +1808,7 @@ NSString *const kGTMGettysburgFileName = @"gettysburgaddress.txt";
 
   NSURL *destFileURL = [self temporaryFileURLWithBaseName:NSStringFromSelector(_cmd)];
 
-  const int64_t kExpectedResponseLen = 5 * 1024*1024;
+  const int64_t kExpectedResponseLen = 5 * 1024 * 1024;
   NSData *expectedResponseData =
       [GTMSessionFetcherTestServer generatedBodyDataWithLength:kExpectedResponseLen];
 
@@ -1852,25 +1819,27 @@ NSString *const kGTMGettysburgFileName = @"gettysburgaddress.txt";
 
   NSString *validURLString =
       [self localURLStringToTestFileName:kGTMGettysburgFileName
-                              parameters:@{ @"responseBodyLength" : [@(kExpectedResponseLen) stringValue] }];
+                              parameters:@{
+                                @"responseBodyLength" : [@(kExpectedResponseLen) stringValue]
+                              }];
   GTMSessionFetcher *fetcher = [self fetcherWithURLString:validURLString];
   fetcher.destinationFileURL = destFileURL;
-  GTMSessionFetcher* __weak weakFetcher = fetcher;
+  GTMSessionFetcher *__weak weakFetcher = fetcher;
   XCTestExpectation *stopExpectation = [self expectationWithDescription:@"stop fetching"];
-  fetcher.downloadProgressBlock = ^(int64_t bytesWritten,
-                                  int64_t totalBytesWritten,
-                                  int64_t totalBytesExpectedToWrite) {
+  fetcher.downloadProgressBlock = ^(int64_t bytesWritten, int64_t totalBytesWritten,
+                                    int64_t totalBytesExpectedToWrite) {
     // Verify the parameters are reasonable.
     XCTAssertTrue(bytesWritten > 0 && bytesWritten <= kExpectedResponseLen, @"%lld", bytesWritten);
-    XCTAssertTrue(totalBytesWritten > 0 && totalBytesWritten <= kExpectedResponseLen,
-                  @"%lld", totalBytesWritten);
+    XCTAssertTrue(totalBytesWritten > 0 && totalBytesWritten <= kExpectedResponseLen, @"%lld",
+                  totalBytesWritten);
     XCTAssertEqual(totalBytesExpectedToWrite, kExpectedResponseLen);
 
     // Total bytes written should increase monotonically.
-    XCTAssertTrue(totalBytesWritten > totalWritten,
-                  @"%lld !> %lld", totalBytesWritten, totalWritten);
-    
-    if (totalWritten == 0) { // Ensure stopFetching and fulfilling the expectation happens only once
+    XCTAssertTrue(totalBytesWritten > totalWritten, @"%lld !> %lld", totalBytesWritten,
+                  totalWritten);
+
+    if (totalWritten ==
+        0) {  // Ensure stopFetching and fulfilling the expectation happens only once
       dispatch_async(dispatch_get_main_queue(), ^{
         [weakFetcher stopFetching];
         [stopExpectation fulfill];
@@ -1884,7 +1853,7 @@ NSString *const kGTMGettysburgFileName = @"gettysburgaddress.txt";
   __block NSData *resumeData = nil;
   XCTestExpectation *resumeDataExpectation =
       [[XCTestExpectation alloc] initWithDescription:@"resume data"];
-  fetcher.resumeDataBlock = ^(NSData *data){
+  fetcher.resumeDataBlock = ^(NSData *data) {
     resumeData = data;
     [resumeDataExpectation fulfill];
   };
@@ -1919,18 +1888,17 @@ NSString *const kGTMGettysburgFileName = @"gettysburgaddress.txt";
 
   fetcher = [GTMSessionFetcher fetcherWithDownloadResumeData:resumeData];
   fetcher.destinationFileURL = destFileURL;
-  fetcher.downloadProgressBlock = ^(int64_t bytesWritten,
-                                  int64_t totalBytesWritten,
-                                  int64_t totalBytesExpectedToWrite) {
+  fetcher.downloadProgressBlock = ^(int64_t bytesWritten, int64_t totalBytesWritten,
+                                    int64_t totalBytesExpectedToWrite) {
     // Verify the parameters are reasonable.
     XCTAssertTrue(bytesWritten > 0 && bytesWritten <= kExpectedResponseLen, @"%lld", bytesWritten);
-    XCTAssertTrue(totalBytesWritten > 0 && totalBytesWritten <= kExpectedResponseLen,
-                  @"%lld", totalBytesWritten);
+    XCTAssertTrue(totalBytesWritten > 0 && totalBytesWritten <= kExpectedResponseLen, @"%lld",
+                  totalBytesWritten);
     XCTAssertEqual(totalBytesExpectedToWrite, kExpectedResponseLen);
 
     // Total bytes written should increase monotonically.
-    XCTAssertTrue(totalBytesWritten > totalWritten,
-                  @"%lld !> %lld", totalBytesWritten, totalWritten);
+    XCTAssertTrue(totalBytesWritten > totalWritten, @"%lld !> %lld", totalBytesWritten,
+                  totalWritten);
     totalWritten = totalBytesWritten;
   };
   XCTestExpectation *expectation = [self expectationWithDescription:@"completion handler"];
@@ -1974,12 +1942,11 @@ NSString *const kGTMGettysburgFileName = @"gettysburgaddress.txt";
   if (![GTMSessionFetcher appAllowsInsecureRequests]) return;
 
   // file:///Users/.../Resources/gettysburgaddress.txt
-  NSString *fileURLString =
-      [[NSURL fileURLWithPath:[_testServer localPathForFile:kGTMGettysburgFileName]] absoluteString];
+  NSString *fileURLString = [[NSURL
+      fileURLWithPath:[_testServer localPathForFile:kGTMGettysburgFileName]] absoluteString];
 
   // http://localhost:59757/gettysburgaddress.txt
   NSString *localhostURLString = [self localURLStringToTestFileName:kGTMGettysburgFileName];
-
 
   struct TestRecord {
     __unsafe_unretained NSString *urlString;
@@ -1993,17 +1960,17 @@ NSString *const kGTMGettysburgFileName = @"gettysburgaddress.txt";
   const NSUInteger kAllowFileSchemeFlag = 1UL << 2;
 
   struct TestRecord records[] = {
-    { @"http://example.com/",  0,                    kInsecureError },
-    { @"https://example.com/", 0,                    0 },
-    { @"http://example.com/",  kAllowHTTPSchemeFlag, 0 },
-    { @"https://example.com/", kAllowHTTPSchemeFlag, 0 },
-    { localhostURLString,      0,                    kInsecureError },
-    { localhostURLString,      kAllowLocalhostFlag,  0 },
-    { fileURLString,           0,                    kInsecureError },
-    { fileURLString,           kAllowHTTPSchemeFlag, kInsecureError },
-    { fileURLString,           kAllowFileSchemeFlag, 0 },  // file URL allowed by scheme
-    { fileURLString,           kAllowLocalhostFlag,  0 },  // file URL allowed as localhost
-    { NULL, 0, 0 },
+      {@"http://example.com/", 0, kInsecureError},
+      {@"https://example.com/", 0, 0},
+      {@"http://example.com/", kAllowHTTPSchemeFlag, 0},
+      {@"https://example.com/", kAllowHTTPSchemeFlag, 0},
+      {localhostURLString, 0, kInsecureError},
+      {localhostURLString, kAllowLocalhostFlag, 0},
+      {fileURLString, 0, kInsecureError},
+      {fileURLString, kAllowHTTPSchemeFlag, kInsecureError},
+      {fileURLString, kAllowFileSchemeFlag, 0},  // file URL allowed by scheme
+      {fileURLString, kAllowLocalhostFlag, 0},   // file URL allowed as localhost
+      {NULL, 0, 0},
   };
 
   GTMSessionFetcherTestBlock testBlock =
@@ -2027,8 +1994,8 @@ NSString *const kGTMGettysburgFileName = @"gettysburgaddress.txt";
       fetcher.allowLocalhostRequest = YES;
     }
     NSInteger expectedErrorCode = records[i].errorCode;
-    XCTestExpectation *expectation =
-        [self expectationWithDescription:[NSString stringWithFormat:@"completion handler: index %d", i]];
+    XCTestExpectation *expectation = [self
+        expectationWithDescription:[NSString stringWithFormat:@"completion handler: index %d", i]];
     [fetcher beginFetchWithCompletionHandler:^(NSData *data, NSError *error) {
       if (expectedErrorCode == 0) {
         XCTAssertNotNil(data, @"index %i -- %@", i, urlString);
@@ -2092,7 +2059,7 @@ NSString *const kGTMGettysburgFileName = @"gettysburgaddress.txt";
                                                                           tvos(10.0),
                                                                           watchos(3.0)) {
   if (!_isServerRunning) return;
-  
+
   CREATE_START_STOP_NOTIFICATION_EXPECTATIONS(1, 1);
 
   // Fetch a live, invalid URL
@@ -2112,7 +2079,7 @@ NSString *const kGTMGettysburgFileName = @"gettysburgaddress.txt";
   }];
   [self waitForExpectationsWithTimeout:_timeoutInterval handler:nil];
   [self assertCallbacksReleasedForFetcher:fetcher];
-  
+
   WAIT_FOR_START_STOP_NOTIFICATION_EXPECTATIONS();
 
   XCTAssertNotNil(collectedMetrics);
@@ -2204,22 +2171,22 @@ NSString *const kGTMGettysburgFileName = @"gettysburgaddress.txt";
       [[NSHTTPURLResponse alloc] initWithURL:testURL
                                   statusCode:200
                                  HTTPVersion:@"HTTP/1.1"
-                                headerFields:@{ @"Bichon" : @"Frise" }];
+                                headerFields:@{@"Bichon" : @"Frise"}];
   NSError *fakedResultError = nil;
 
-  fetcher.testBlock = ^(GTMSessionFetcher *fetcherToTest,
-                        GTMSessionFetcherTestResponse testResponse) {
-      XCTAssertEqualObjects(fetcherToTest.request.URL, testURL);
-      testResponse(fakedResultResponse, fakedResultData, fakedResultError);
-  };
+  fetcher.testBlock =
+      ^(GTMSessionFetcher *fetcherToTest, GTMSessionFetcherTestResponse testResponse) {
+        XCTAssertEqualObjects(fetcherToTest.request.URL, testURL);
+        testResponse(fakedResultResponse, fakedResultData, fakedResultError);
+      };
 
   XCTestExpectation *expectation = [self expectationWithDescription:@"completion handler"];
   [fetcher beginFetchWithCompletionHandler:^(NSData *data, NSError *error) {
-      XCTAssertNil(fakedResultError);
-      XCTAssertEqualObjects(data, fakedResultData);
-      XCTAssertEqual(fetcher.statusCode, fakedResultResponse.statusCode);
-      XCTAssertEqualObjects(fetcher.responseHeaders[@"Bichon"], @"Frise");
-      [expectation fulfill];
+    XCTAssertNil(fakedResultError);
+    XCTAssertEqualObjects(data, fakedResultData);
+    XCTAssertEqual(fetcher.statusCode, fakedResultResponse.statusCode);
+    XCTAssertEqualObjects(fetcher.responseHeaders[@"Bichon"], @"Frise");
+    [expectation fulfill];
   }];
   [self waitForExpectationsWithTimeout:_timeoutInterval handler:nil];
   [self assertCallbacksReleasedForFetcher:fetcher];
@@ -2266,37 +2233,37 @@ NSString *const kGTMGettysburgFileName = @"gettysburgaddress.txt";
       [[NSHTTPURLResponse alloc] initWithURL:testURL
                                   statusCode:504  // 504 is a retryable error.
                                  HTTPVersion:@"HTTP/1.1"
-                                headerFields:@{ @"Alaskan" : @"Malamute" }];
+                                headerFields:@{@"Alaskan" : @"Malamute"}];
   NSError *fakedResultError =
       [NSError errorWithDomain:kGTMSessionFetcherErrorDomain
                           code:504
-                      userInfo:@{ kGTMSessionFetcherStatusDataKey : @"Oops." }];
+                      userInfo:@{kGTMSessionFetcherStatusDataKey : @"Oops."}];
 
-  fetcher.testBlock = ^(GTMSessionFetcher *fetcherToTest,
-                        GTMSessionFetcherTestResponse testResponse) {
-      XCTAssertEqualObjects(fetcherToTest.request.URL, testURL);
-      testResponse(fakedResultResponse, fakedResultData, fakedResultError);
-  };
+  fetcher.testBlock =
+      ^(GTMSessionFetcher *fetcherToTest, GTMSessionFetcherTestResponse testResponse) {
+        XCTAssertEqualObjects(fetcherToTest.request.URL, testURL);
+        testResponse(fakedResultResponse, fakedResultData, fakedResultError);
+      };
 
   XCTestExpectation *retryExpectation = [self expectationWithDescription:@"retry block"];
   retryExpectation.expectedFulfillmentCount = 3;
-  fetcher.retryBlock = ^(BOOL suggestedWillRetry, NSError *error,
-                         GTMSessionFetcherRetryResponse response) {
-      // Should retry after 1, 2, 4 seconds.
-      response(YES);
-      [retryExpectation fulfill];
-  };
+  fetcher.retryBlock =
+      ^(BOOL suggestedWillRetry, NSError *error, GTMSessionFetcherRetryResponse response) {
+        // Should retry after 1, 2, 4 seconds.
+        response(YES);
+        [retryExpectation fulfill];
+      };
 
   XCTestExpectation *expectation = [self expectationWithDescription:@"completion handler"];
   [fetcher beginFetchWithCompletionHandler:^(NSData *data, NSError *error) {
-      XCTAssertEqualObjects(error.domain, fakedResultError.domain);
-      XCTAssertEqual(error.code, fakedResultError.code, @"%@", error);
-      XCTAssertEqualObjects(error.userInfo[kGTMSessionFetcherStatusDataKey],
-                            fakedResultError.userInfo[kGTMSessionFetcherStatusDataKey]);
-      XCTAssertNil(data);
-      XCTAssertEqual(fetcher.statusCode, fakedResultResponse.statusCode);
-      XCTAssertEqualObjects(fetcher.responseHeaders[@"Alaskan"], @"Malamute");
-      [expectation fulfill];
+    XCTAssertEqualObjects(error.domain, fakedResultError.domain);
+    XCTAssertEqual(error.code, fakedResultError.code, @"%@", error);
+    XCTAssertEqualObjects(error.userInfo[kGTMSessionFetcherStatusDataKey],
+                          fakedResultError.userInfo[kGTMSessionFetcherStatusDataKey]);
+    XCTAssertNil(data);
+    XCTAssertEqual(fetcher.statusCode, fakedResultResponse.statusCode);
+    XCTAssertEqualObjects(fetcher.responseHeaders[@"Alaskan"], @"Malamute");
+    [expectation fulfill];
   }];
   [self waitForExpectationsWithTimeout:_timeoutInterval handler:nil];
   [self assertCallbacksReleasedForFetcher:fetcher];
@@ -2342,76 +2309,75 @@ NSString *const kGTMGettysburgFileName = @"gettysburgaddress.txt";
       [[NSHTTPURLResponse alloc] initWithURL:testURL
                                   statusCode:200
                                  HTTPVersion:@"HTTP/1.1"
-                                headerFields:@{ @"Aussie" : @"Shepherd" }];
+                                headerFields:@{@"Aussie" : @"Shepherd"}];
   NSError *fakedResultError = nil;
 
   __block NSURLAuthenticationChallenge *challengePresented;
-  fetcher.challengeBlock = ^(GTMSessionFetcher *blockFetcher,
-                             NSURLAuthenticationChallenge *challenge,
-                             GTMSessionFetcherChallengeDispositionBlock dispositionBlock) {
-    challengePresented = challenge;
+  fetcher.challengeBlock =
+      ^(GTMSessionFetcher *blockFetcher, NSURLAuthenticationChallenge *challenge,
+        GTMSessionFetcherChallengeDispositionBlock dispositionBlock) {
+        challengePresented = challenge;
 
-    dispositionBlock(NSURLSessionAuthChallengePerformDefaultHandling, nil);
-  };
+        dispositionBlock(NSURLSessionAuthChallengePerformDefaultHandling, nil);
+      };
 
   __block NSURLResponse *initialResponse;
-  fetcher.didReceiveResponseBlock = ^(NSURLResponse *response,
-                                      GTMSessionFetcherDidReceiveResponseDispositionBlock dispositionBlock) {
-      XCTAssertNil(initialResponse);
-      initialResponse = response;
-      dispositionBlock(NSURLSessionResponseAllow);
-  };
+  fetcher.didReceiveResponseBlock =
+      ^(NSURLResponse *response,
+        GTMSessionFetcherDidReceiveResponseDispositionBlock dispositionBlock) {
+        XCTAssertNil(initialResponse);
+        initialResponse = response;
+        dispositionBlock(NSURLSessionResponseAllow);
+      };
 
   __block int64_t bytesSentSum = 0;
   __block int64_t lastTotalBytesSent = 0;
   int64_t expectedTotalBytesWritten = (int64_t)uploadData.length;
 
-  fetcher.sendProgressBlock = ^(int64_t bytesSent,
-                                int64_t totalBytesSent,
-                                int64_t totalBytesExpectedToSend) {
-      bytesSentSum += bytesSent;
-      lastTotalBytesSent = totalBytesSent;
-      XCTAssertEqual(totalBytesExpectedToSend, expectedTotalBytesWritten);
-  };
+  fetcher.sendProgressBlock =
+      ^(int64_t bytesSent, int64_t totalBytesSent, int64_t totalBytesExpectedToSend) {
+        bytesSentSum += bytesSent;
+        lastTotalBytesSent = totalBytesSent;
+        XCTAssertEqual(totalBytesExpectedToSend, expectedTotalBytesWritten);
+      };
 
   __block int64_t bytesReceivedSum = 0;
   __block int64_t lastTotalBytesReceived = 0;
   int64_t expectedTotalBytesReceived = (int64_t)downloadData.length;
 
-  fetcher.receivedProgressBlock = ^(int64_t bytesReceived,
-                                    int64_t totalBytesReceived) {
-      bytesReceivedSum += bytesReceived;
-      lastTotalBytesReceived = totalBytesReceived;
+  fetcher.receivedProgressBlock = ^(int64_t bytesReceived, int64_t totalBytesReceived) {
+    bytesReceivedSum += bytesReceived;
+    lastTotalBytesReceived = totalBytesReceived;
   };
 
   __block NSCachedURLResponse *proposedResponseToCache;
   fetcher.willCacheURLResponseBlock = ^(NSCachedURLResponse *responseProposed,
                                         GTMSessionFetcherWillCacheURLResponseResponse response) {
-      proposedResponseToCache = responseProposed;
-      response(responseProposed);
+    proposedResponseToCache = responseProposed;
+    response(responseProposed);
   };
 
-  fetcher.testBlock = ^(GTMSessionFetcher *fetcherToTest,
-                        GTMSessionFetcherTestResponse testResponse) {
-      testResponse(fakedResultResponse, downloadData, fakedResultError);
-  };
+  fetcher.testBlock =
+      ^(GTMSessionFetcher *fetcherToTest, GTMSessionFetcherTestResponse testResponse) {
+        testResponse(fakedResultResponse, downloadData, fakedResultError);
+      };
 
   XCTestExpectation *expectation = [self expectationWithDescription:@"data completion handler"];
   [fetcher beginFetchWithCompletionHandler:^(NSData *data, NSError *error) {
-      XCTAssertNil(error);
-      XCTAssertEqualObjects(data, downloadData);
+    XCTAssertNil(error);
+    XCTAssertEqualObjects(data, downloadData);
 
-      XCTAssertEqual(bytesSentSum, expectedTotalBytesWritten);
-      XCTAssertEqual(lastTotalBytesSent, expectedTotalBytesWritten);
+    XCTAssertEqual(bytesSentSum, expectedTotalBytesWritten);
+    XCTAssertEqual(lastTotalBytesSent, expectedTotalBytesWritten);
 
-      XCTAssertEqual(bytesReceivedSum, expectedTotalBytesReceived);
-      XCTAssertEqual(lastTotalBytesReceived, expectedTotalBytesReceived);
+    XCTAssertEqual(bytesReceivedSum, expectedTotalBytesReceived);
+    XCTAssertEqual(lastTotalBytesReceived, expectedTotalBytesReceived);
 
-      XCTAssertEqualObjects(challengePresented.protectionSpace.host, testURL.host);
-      XCTAssertEqualObjects(initialResponse, fetcher.response);
+    XCTAssertEqualObjects(challengePresented.protectionSpace.host, testURL.host);
+    XCTAssertEqualObjects(initialResponse, fetcher.response);
 
-      XCTAssertEqualObjects(proposedResponseToCache.response, fetcher.response);
-      [expectation fulfill];
+    XCTAssertEqualObjects(proposedResponseToCache.response, fetcher.response);
+    [expectation fulfill];
   }];
 
   [self waitForExpectationsWithTimeout:_timeoutInterval handler:nil];
@@ -2434,20 +2400,18 @@ NSString *const kGTMGettysburgFileName = @"gettysburgaddress.txt";
   lastTotalBytesSent = 0;
   expectedTotalBytesWritten = (int64_t)uploadData.length;
 
-  fetcher.sendProgressBlock = ^(int64_t bytesWritten,
-                                int64_t totalBytesWritten,
-                                int64_t totalBytesExpectedToWrite) {
-    bytesSentSum += bytesWritten;
-    lastTotalBytesSent = totalBytesWritten;
-    XCTAssertEqual(totalBytesExpectedToWrite, expectedTotalBytesWritten);
-  };
+  fetcher.sendProgressBlock =
+      ^(int64_t bytesWritten, int64_t totalBytesWritten, int64_t totalBytesExpectedToWrite) {
+        bytesSentSum += bytesWritten;
+        lastTotalBytesSent = totalBytesWritten;
+        XCTAssertEqual(totalBytesExpectedToWrite, expectedTotalBytesWritten);
+      };
 
   bytesReceivedSum = 0;
   lastTotalBytesReceived = 0;
   expectedTotalBytesReceived = (int64_t)downloadData.length;
 
-  fetcher.downloadProgressBlock = ^(int64_t bytesDownloaded,
-                                    int64_t totalBytesDownloaded,
+  fetcher.downloadProgressBlock = ^(int64_t bytesDownloaded, int64_t totalBytesDownloaded,
                                     int64_t totalBytesExpectedToDownload) {
     bytesReceivedSum += bytesDownloaded;
     lastTotalBytesReceived = totalBytesDownloaded;
@@ -2455,25 +2419,25 @@ NSString *const kGTMGettysburgFileName = @"gettysburgaddress.txt";
   };
 
   fakedResultError = nil;
-  fetcher.testBlock = ^(GTMSessionFetcher *fetcherToTest,
-                        GTMSessionFetcherTestResponse testResponse) {
-      testResponse(fakedResultResponse, downloadData, fakedResultError);
-  };
+  fetcher.testBlock =
+      ^(GTMSessionFetcher *fetcherToTest, GTMSessionFetcherTestResponse testResponse) {
+        testResponse(fakedResultResponse, downloadData, fakedResultError);
+      };
 
   expectation = [self expectationWithDescription:@"file completion handler"];
   [fetcher beginFetchWithCompletionHandler:^(NSData *data, NSError *error) {
-      XCTAssertNil(error);
-      XCTAssertNil(data);
+    XCTAssertNil(error);
+    XCTAssertNil(data);
 
-      NSData *dataFromFile = [NSData dataWithContentsOfURL:downloadFileURL];
-      XCTAssertEqualObjects(dataFromFile, downloadData);
+    NSData *dataFromFile = [NSData dataWithContentsOfURL:downloadFileURL];
+    XCTAssertEqualObjects(dataFromFile, downloadData);
 
-      XCTAssertEqual(bytesSentSum, expectedTotalBytesWritten);
-      XCTAssertEqual(lastTotalBytesSent, expectedTotalBytesWritten);
+    XCTAssertEqual(bytesSentSum, expectedTotalBytesWritten);
+    XCTAssertEqual(lastTotalBytesSent, expectedTotalBytesWritten);
 
-      XCTAssertEqual(bytesReceivedSum, expectedTotalBytesReceived);
-      XCTAssertEqual(lastTotalBytesReceived, expectedTotalBytesReceived);
-      [expectation fulfill];
+    XCTAssertEqual(bytesReceivedSum, expectedTotalBytesReceived);
+    XCTAssertEqual(lastTotalBytesReceived, expectedTotalBytesReceived);
+    [expectation fulfill];
   }];
 
   [self waitForExpectationsWithTimeout:_timeoutInterval handler:nil];
@@ -2505,32 +2469,31 @@ NSString *const kGTMGettysburgFileName = @"gettysburgaddress.txt";
   lastTotalBytesSent = 0;
   expectedTotalBytesWritten = (int64_t)uploadData.length;
 
-  fetcher.sendProgressBlock = ^(int64_t bytesWritten,
-                                int64_t totalBytesWritten,
-                                int64_t totalBytesExpectedToWrite) {
-    bytesSentSum += bytesWritten;
-    lastTotalBytesSent = totalBytesWritten;
-    XCTAssertEqual(totalBytesExpectedToWrite, expectedTotalBytesWritten);
-  };
+  fetcher.sendProgressBlock =
+      ^(int64_t bytesWritten, int64_t totalBytesWritten, int64_t totalBytesExpectedToWrite) {
+        bytesSentSum += bytesWritten;
+        lastTotalBytesSent = totalBytesWritten;
+        XCTAssertEqual(totalBytesExpectedToWrite, expectedTotalBytesWritten);
+      };
 
   fakedResultError = nil;
-  fetcher.testBlock = ^(GTMSessionFetcher *fetcherToTest,
-                        GTMSessionFetcherTestResponse testResponse) {
-      testResponse(fakedResultResponse, downloadData, fakedResultError);
-  };
+  fetcher.testBlock =
+      ^(GTMSessionFetcher *fetcherToTest, GTMSessionFetcherTestResponse testResponse) {
+        testResponse(fakedResultResponse, downloadData, fakedResultError);
+      };
 
   expectation = [self expectationWithDescription:@"stream completion handler"];
   [fetcher beginFetchWithCompletionHandler:^(NSData *data, NSError *error) {
-      XCTAssertNil(error);
-      XCTAssertNil(data);
-      XCTAssertEqualObjects(accumulatedData, downloadData);
+    XCTAssertNil(error);
+    XCTAssertNil(data);
+    XCTAssertEqualObjects(accumulatedData, downloadData);
 
-      XCTAssertEqual(bytesSentSum, expectedTotalBytesWritten);
-      XCTAssertEqual(lastTotalBytesSent, expectedTotalBytesWritten);
+    XCTAssertEqual(bytesSentSum, expectedTotalBytesWritten);
+    XCTAssertEqual(lastTotalBytesSent, expectedTotalBytesWritten);
 
-      XCTAssertEqual(bytesReceivedSum, expectedTotalBytesReceived);
-      XCTAssertEqual(lastTotalBytesReceived, expectedTotalBytesReceived);
-      [expectation fulfill];
+    XCTAssertEqual(bytesReceivedSum, expectedTotalBytesReceived);
+    XCTAssertEqual(lastTotalBytesReceived, expectedTotalBytesReceived);
+    [expectation fulfill];
   }];
 
   [self waitForExpectationsWithTimeout:_timeoutInterval handler:nil];
@@ -2599,7 +2562,6 @@ NSString *const kGTMGettysburgFileName = @"gettysburgaddress.txt";
                                          url:(NSURL *)testURL
                          generatedDataLength:(NSUInteger)generatedDataLength
                            expectedCallCount:(NSUInteger)expectedCallCount {
-
   CREATE_START_STOP_NOTIFICATION_EXPECTATIONS(1, 1);
 
   NSData *downloadData =
@@ -2609,8 +2571,7 @@ NSString *const kGTMGettysburgFileName = @"gettysburgaddress.txt";
   __block int64_t lastTotalBytesReceived = 0;
   __block int64_t expectedTotalBytesReceived = (int64_t)downloadData.length;
 
-  fetcher.receivedProgressBlock = ^(int64_t bytesReceived,
-                                    int64_t totalBytesReceived) {
+  fetcher.receivedProgressBlock = ^(int64_t bytesReceived, int64_t totalBytesReceived) {
     bytesReceivedSum += bytesReceived;
     lastTotalBytesReceived = totalBytesReceived;
   };
@@ -2626,12 +2587,12 @@ NSString *const kGTMGettysburgFileName = @"gettysburgaddress.txt";
       [[NSHTTPURLResponse alloc] initWithURL:testURL
                                   statusCode:200
                                  HTTPVersion:@"HTTP/1.1"
-                                headerFields:@{ @"Aussie" : @"Shepherd" }];
+                                headerFields:@{@"Aussie" : @"Shepherd"}];
   NSError *fakedResultError = nil;
-  fetcher.testBlock = ^(GTMSessionFetcher *fetcherToTest,
-                        GTMSessionFetcherTestResponse testResponse) {
-    testResponse(fakedResultResponse, downloadData, fakedResultError);
-  };
+  fetcher.testBlock =
+      ^(GTMSessionFetcher *fetcherToTest, GTMSessionFetcherTestResponse testResponse) {
+        testResponse(fakedResultResponse, downloadData, fakedResultError);
+      };
 
   XCTestExpectation *expectation = [self expectationWithDescription:@"stream download fetch"];
   [fetcher beginFetchWithCompletionHandler:^(NSData *data, NSError *error) {
@@ -2673,25 +2634,26 @@ NSString *const kGTMGettysburgFileName = @"gettysburgaddress.txt";
   NSError *fakedResultError =
       [NSError errorWithDomain:kGTMSessionFetcherErrorDomain
                           code:504
-                      userInfo:@{ kGTMSessionFetcherStatusDataKey : @"Oops." }];
+                      userInfo:@{kGTMSessionFetcherStatusDataKey : @"Oops."}];
 
-  fetcher.didReceiveResponseBlock = ^(NSURLResponse *response,
-                                      GTMSessionFetcherDidReceiveResponseDispositionBlock dispositionBlock) {
-      XCTFail(@"didReceiveResponseBlock should not be called.");
-  };
+  fetcher.didReceiveResponseBlock =
+      ^(NSURLResponse *response,
+        GTMSessionFetcherDidReceiveResponseDispositionBlock dispositionBlock) {
+        XCTFail(@"didReceiveResponseBlock should not be called.");
+      };
 
-  fetcher.testBlock = ^(GTMSessionFetcher *fetcherToTest,
-                        GTMSessionFetcherTestResponse testResponse) {
-      XCTAssertEqualObjects(fetcherToTest.request.URL, testURL);
-      testResponse(nil, nil, fakedResultError);
-  };
+  fetcher.testBlock =
+      ^(GTMSessionFetcher *fetcherToTest, GTMSessionFetcherTestResponse testResponse) {
+        XCTAssertEqualObjects(fetcherToTest.request.URL, testURL);
+        testResponse(nil, nil, fakedResultError);
+      };
 
   XCTestExpectation *expectation = [self expectationWithDescription:@"completion handler"];
   [fetcher beginFetchWithCompletionHandler:^(NSData *data, NSError *error) {
-      XCTAssertNotNil(error);
-      XCTAssertNil(data);
-      XCTAssertEqual(fetcher.statusCode, 0);
-      [expectation fulfill];
+    XCTAssertNotNil(error);
+    XCTAssertNil(data);
+    XCTAssertEqual(fetcher.statusCode, 0);
+    [expectation fulfill];
   }];
   [self waitForExpectationsWithTimeout:_timeoutInterval handler:nil];
   [self assertCallbacksReleasedForFetcher:fetcher];
@@ -2729,17 +2691,17 @@ NSString *const kGTMGettysburgFileName = @"gettysburgaddress.txt";
       [[NSHTTPURLResponse alloc] initWithURL:testURL
                                   statusCode:200
                                  HTTPVersion:@"HTTP/1.1"
-                                headerFields:@{ @"Bichon" : @"Frise" }];
+                                headerFields:@{@"Bichon" : @"Frise"}];
   NSError *fakedResultError = nil;
 
   [GTMSessionFetcher setGlobalTestBlock:^(GTMSessionFetcher *fetcherToTest,
                                           GTMSessionFetcherTestResponse testResponse) {
-      if ([fetcherToTest.request.URL.host isEqual:@"test.example.com"]) {
-        testResponse(fakedResultResponse, fakedResultData, fakedResultError);
-      } else {
-        // Actually do the fetch against the test server.
-        testResponse(nil, nil, nil);
-      }
+    if ([fetcherToTest.request.URL.host isEqual:@"test.example.com"]) {
+      testResponse(fakedResultResponse, fakedResultData, fakedResultError);
+    } else {
+      // Actually do the fetch against the test server.
+      testResponse(nil, nil, nil);
+    }
   }];
 
   //
@@ -2747,11 +2709,11 @@ NSString *const kGTMGettysburgFileName = @"gettysburgaddress.txt";
   //
   XCTestExpectation *expectation = [self expectationWithDescription:@"test block fetch"];
   [fetcher beginFetchWithCompletionHandler:^(NSData *data, NSError *error) {
-      XCTAssertNil(fakedResultError);
-      XCTAssertEqualObjects(data, fakedResultData);
-      XCTAssertEqual(fetcher.statusCode, fakedResultResponse.statusCode);
-      XCTAssertEqualObjects(fetcher.responseHeaders[@"Bichon"], @"Frise");
-      [expectation fulfill];
+    XCTAssertNil(fakedResultError);
+    XCTAssertEqualObjects(data, fakedResultData);
+    XCTAssertEqual(fetcher.statusCode, fakedResultResponse.statusCode);
+    XCTAssertEqualObjects(fetcher.responseHeaders[@"Bichon"], @"Frise");
+    [expectation fulfill];
   }];
   [self waitForExpectationsWithTimeout:_timeoutInterval handler:nil];
   [self assertCallbacksReleasedForFetcher:fetcher];
@@ -2766,10 +2728,8 @@ NSString *const kGTMGettysburgFileName = @"gettysburgaddress.txt";
 
   expectation = [self expectationWithDescription:@"http server fetch"];
   [fetcher beginFetchWithCompletionHandler:^(NSData *data, NSError *error) {
-      [self assertSuccessfulGettysburgFetchWithFetcher:fetcher
-                                                  data:data
-                                                 error:error];
-      [expectation fulfill];
+    [self assertSuccessfulGettysburgFetchWithFetcher:fetcher data:data error:error];
+    [expectation fulfill];
   }];
   [self waitForExpectationsWithTimeout:_timeoutInterval handler:nil];
   [self assertCallbacksReleasedForFetcher:fetcher];
@@ -2892,9 +2852,7 @@ NSString *const kGTMGettysburgFileName = @"gettysburgaddress.txt";
 @end
 
 @implementation TestAuthorizer
-@synthesize async = _async,
-            expired = _expired,
-            willFailWithError = _willFailWithError;
+@synthesize async = _async, expired = _expired, willFailWithError = _willFailWithError;
 
 + (instancetype)syncAuthorizer {
   return [[self alloc] init];
@@ -2968,7 +2926,7 @@ NSString *const kGTMGettysburgFileName = @"gettysburgaddress.txt";
 }
 
 - (NSString *)userEmail {
- return @"";
+  return @"";
 }
 
 - (BOOL)primeForRefresh {
@@ -2990,7 +2948,7 @@ NSString *const kSubUIAppBackgroundTaskEnded = @"kSubUIAppBackgroundTaskEnded";
 
 @implementation SubstituteUIApplication {
   UIBackgroundTaskIdentifier _identifier;
-  NSMutableDictionary <NSNumber *, SubstituteUIApplicationTaskInfo *>*_identifierToTaskInfoMap;
+  NSMutableDictionary<NSNumber *, SubstituteUIApplicationTaskInfo *> *_identifierToTaskInfoMap;
 }
 
 UIBackgroundTaskIdentifier gTaskID = 1000;
@@ -3064,16 +3022,15 @@ UIBackgroundTaskIdentifier gTaskID = 1000;
   // We expect that all background tasks ended themselves soon after their handlers were called.
   dispatch_after(dispatch_time(DISPATCH_TIME_NOW, (int64_t)(0.1 * NSEC_PER_SEC)),
                  dispatch_get_main_queue(), ^{
-    NSArray <SubstituteUIApplicationTaskInfo *>* failedToExpire;
-    @synchronized(self) {
-      failedToExpire = self->_identifierToTaskInfoMap.allValues;
-    }
-    handler(count, failedToExpire);
-  });
+                   NSArray<SubstituteUIApplicationTaskInfo *> *failedToExpire;
+                   @synchronized(self) {
+                     failedToExpire = self->_identifierToTaskInfoMap.allValues;
+                   }
+                   handler(count, failedToExpire);
+                 });
 }
 
 @end
-
 
 @implementation SubstituteUIApplicationTaskInfo
 @synthesize taskIdentifier = _taskIdentifier;
@@ -3081,14 +3038,13 @@ UIBackgroundTaskIdentifier gTaskID = 1000;
 @synthesize expirationHandler = _expirationHandler;
 
 - (NSString *)description {
-  return [NSString stringWithFormat:@"<task %lu \"%@\">",
-          (unsigned long)_taskIdentifier, _taskName];
+  return
+      [NSString stringWithFormat:@"<task %lu \"%@\">", (unsigned long)_taskIdentifier, _taskName];
 }
 
 @end
 
 #endif  // GTM_BACKGROUND_TASK_FETCHING
-
 
 @implementation FetcherNotificationsCounter {
   NSDate *_counterCreationDate;
@@ -3097,17 +3053,14 @@ UIBackgroundTaskIdentifier gTaskID = 1000;
 #endif
 }
 
-@synthesize fetchStarted = _fetchStarted,
-            fetchStopped = _fetchStopped,
+@synthesize fetchStarted = _fetchStarted, fetchStopped = _fetchStopped,
             fetchCompletionInvoked = _fetchCompletionInvoked,
             uploadChunkFetchStarted = _uploadChunkFetchStarted,
             uploadChunkFetchStopped = _uploadChunkFetchStopped,
-            retryDelayStarted = _retryDelayStarted,
-            retryDelayStopped = _retryDelayStopped,
+            retryDelayStarted = _retryDelayStarted, retryDelayStopped = _retryDelayStopped,
             uploadLocationObtained = _uploadLocationObtained,
             uploadChunkRequestPaths = _uploadChunkRequestPaths,
-            uploadChunkCommands = _uploadChunkCommands,
-            uploadChunkOffsets = _uploadChunkOffsets,
+            uploadChunkCommands = _uploadChunkCommands, uploadChunkOffsets = _uploadChunkOffsets,
             uploadChunkLengths = _uploadChunkLengths,
             fetchersStartedDescriptions = _fetchersStartedDescriptions,
             fetchersStoppedDescriptions = _fetchersStoppedDescriptions,
@@ -3177,19 +3130,18 @@ UIBackgroundTaskIdentifier gTaskID = 1000;
 - (BOOL)shouldIgnoreNotification:(NSNotification *)note {
   GTMSessionFetcher *fetcher = note.object;
   NSDate *fetcherBeginDate = fetcher.initialBeginFetchDate;
-  BOOL isTooOld = (fetcherBeginDate
-                   && [fetcherBeginDate compare:_counterCreationDate] == NSOrderedAscending);
+  BOOL isTooOld =
+      (fetcherBeginDate && [fetcherBeginDate compare:_counterCreationDate] == NSOrderedAscending);
   return isTooOld;
 }
 
 - (NSString *)descriptionForFetcher:(GTMSessionFetcher *)fetcher {
-  NSString *description = [NSString stringWithFormat:@"fetcher %p %@ %@",
-                           fetcher,
-                           fetcher.comment ?: @"<no comment>",
-                           fetcher.request.URL.absoluteString];
+  NSString *description =
+      [NSString stringWithFormat:@"fetcher %p %@ %@", fetcher, fetcher.comment ?: @"<no comment>",
+                                 fetcher.request.URL.absoluteString];
   if (fetcher.retryCount > 0) {
-    description = [description stringByAppendingFormat:@" retry %lu",
-                   (unsigned long)fetcher.retryCount];
+    description =
+        [description stringByAppendingFormat:@" retry %lu", (unsigned long)fetcher.retryCount];
   }
   return description;
 }
@@ -3249,15 +3201,15 @@ UIBackgroundTaskIdentifier gTaskID = 1000;
     ++_retryDelayStopped;
   }
   NSAssert(_retryDelayStopped <= _retryDelayStarted,
-           @"retry delay notification imbalance: starts=%d stops=%d",
-           (int)_retryDelayStarted, (int)_retryDelayStopped);
+           @"retry delay notification imbalance: starts=%d stops=%d", (int)_retryDelayStarted,
+           (int)_retryDelayStopped);
 }
 
 - (void)uploadLocationObtained:(NSNotification *)note {
   if ([self shouldIgnoreNotification:note]) return;
 
   GTMSessionUploadFetcher *fetcher = note.object;
-#pragma unused (fetcher)  // Unused when NS_BLOCK_ASSERTIONS
+#pragma unused(fetcher)  // Unused when NS_BLOCK_ASSERTIONS
 
   NSAssert(fetcher.uploadLocationURL != nil, @"missing upload location: %@", fetcher);
 

--- a/Source/UnitTests/GTMSessionFetcherTestServer.h
+++ b/Source/UnitTests/GTMSessionFetcherTestServer.h
@@ -44,10 +44,10 @@ typedef enum {
 @property(atomic, copy) NSString *defaultContentType;
 
 // Utilities for users.
-- (NSURL *)localURLForFile:(NSString *)name;            // http://localhost:port/filename
-- (NSURL *)localURLForFileUsingAppend:(NSString *)name; // http://localhost:port/filename
-- (NSURL *)localv6URLForFile:(NSString *)name;          // http://[::1]:port/filename
-- (NSString *)localPathForFile:(NSString *)name;        // docRoot/filename
+- (NSURL *)localURLForFile:(NSString *)name;             // http://localhost:port/filename
+- (NSURL *)localURLForFileUsingAppend:(NSString *)name;  // http://localhost:port/filename
+- (NSURL *)localv6URLForFile:(NSString *)name;           // http://[::1]:port/filename
+- (NSString *)localPathForFile:(NSString *)name;         // docRoot/filename
 
 + (NSString *)JSONBodyStringForStatus:(NSInteger)code;
 + (NSData *)generatedBodyDataWithLength:(NSUInteger)length;

--- a/Source/UnitTests/GTMSessionFetcherTestServer.m
+++ b/Source/UnitTests/GTMSessionFetcherTestServer.m
@@ -41,8 +41,9 @@ static NSString *const kEtag = @"GoodETag";
   NSUInteger prefixLength = prefix.length;
   if (self.length < prefixLength) return NO;
 
-  NSComparisonResult hasPrefixResult =
-      [self compare:prefix options:NSCaseInsensitiveSearch range:NSMakeRange(0, prefixLength)];
+  NSComparisonResult hasPrefixResult = [self compare:prefix
+                                             options:NSCaseInsensitiveSearch
+                                               range:NSMakeRange(0, prefixLength)];
   return hasPrefixResult == NSOrderedSame;
 }
 
@@ -109,7 +110,7 @@ static NSString *const kEtag = @"GoodETag";
 }
 
 - (NSString *)MD5DigestString {
-  NSData* data = [self dataUsingEncoding:NSUTF8StringEncoding];
+  NSData *data = [self dataUsingEncoding:NSUTF8StringEncoding];
 
   unsigned char MD5Digest[CC_MD5_DIGEST_LENGTH];
 #pragma clang diagnostic push
@@ -127,12 +128,12 @@ static NSString *const kEtag = @"GoodETag";
 
 - (NSString *)base64DecodedString {
   NSData *decodedData = [[NSData alloc] initWithBase64EncodedString:self options:0];
-  NSString *decodedString = [[NSString alloc] initWithData:decodedData encoding:NSUTF8StringEncoding];
+  NSString *decodedString = [[NSString alloc] initWithData:decodedData
+                                                  encoding:NSUTF8StringEncoding];
   return decodedString;
 }
 
 @end
-
 
 @interface GTMSessionFetcherTestServer () <GTMHTTPServerDelegate>
 @end
@@ -276,16 +277,15 @@ static NSString *const kEtag = @"GoodETag";
 
   NSMutableDictionary *responseHeaders = [NSMutableDictionary dictionary];
 
-  GTMHTTPResponseMessage *(^sendResponse)(int, NSData *, NSString *) =
-      ^(int status, NSData *data, NSString *contentType){
-      NSAssert(status > 0, @"%d", status);
-      GTMHTTPResponseMessage *response =
-          [GTMHTTPResponseMessage responseWithBody:data
-                                       contentType:contentType
-                                        statusCode:status];
-      [response setHeaderValuesFromDictionary:responseHeaders];
-      return response;
-  };
+  GTMHTTPResponseMessage * (^sendResponse)(int, NSData *, NSString *) =
+      ^(int status, NSData *data, NSString *contentType) {
+        NSAssert(status > 0, @"%d", status);
+        GTMHTTPResponseMessage *response = [GTMHTTPResponseMessage responseWithBody:data
+                                                                        contentType:contentType
+                                                                         statusCode:status];
+        [response setHeaderValuesFromDictionary:responseHeaders];
+        return response;
+      };
 
   _lastHTTPAuthenticationType = kGTMHTTPAuthenticationTypeInvalid;
 
@@ -316,8 +316,7 @@ static NSString *const kEtag = @"GoodETag";
   NSString *uploadGranularityRequest = requestHeaders[@"GTM-Upload-Granularity-Request"];
   NSString *uploadBytesReceivedRequest = [[self class] valueForParameter:@"bytesReceived"
                                                                    query:query];
-  NSString *uploadQueryStatus = [[self class] valueForParameter:@"queryStatus"
-                                                          query:query];
+  NSString *uploadQueryStatus = [[self class] valueForParameter:@"queryStatus" query:query];
 
   NSString *statusStr = [[self class] valueForParameter:@"status" query:query];
   if (statusStr) {
@@ -367,8 +366,8 @@ static NSString *const kEtag = @"GoodETag";
     // Return a location header containing the request path with
     // the ".location" suffix changed to ".upload".
     NSString *pathWithoutLoc = [requestPath stringByDeletingPathExtension];
-    NSString *fullLocation = [NSString stringWithFormat:@"http://%@%@.upload",
-                              host, pathWithoutLoc];
+    NSString *fullLocation =
+        [NSString stringWithFormat:@"http://%@%@.upload", host, pathWithoutLoc];
 
     responseHeaders[@"X-Goog-Upload-URL"] = fullLocation;
     responseHeaders[@"X-Goog-Upload-Control-URL"] = fullLocation;
@@ -427,8 +426,8 @@ static NSString *const kEtag = @"GoodETag";
       BOOL isProperOffset = (_uploadBytesReceived == [xUploadOffset longLongValue]);
       if (!isProperOffset) {
         // This shouldn't happen; a good offset should always be provided.
-        NSLog(@"Unexpected offset (specified %@, expected %lld)",
-              xUploadOffset, _uploadBytesReceived);
+        NSLog(@"Unexpected offset (specified %@, expected %lld)", xUploadOffset,
+              _uploadBytesReceived);
         return sendResponse(503, nil, nil);
       }
 
@@ -469,8 +468,8 @@ static NSString *const kEtag = @"GoodETag";
     NSString *bearerStr = [@"Bearer " stringByAppendingString:authStr];
     if (![authorization isEqual:bearerStr]) {
       // return status 401 Unauthorized
-      NSString *errStr = [NSString stringWithFormat:@"Authorization \"%@\" should be \"%@\"",
-                          authorization, bearerStr];
+      NSString *errStr = [NSString
+          stringWithFormat:@"Authorization \"%@\" should be \"%@\"", authorization, bearerStr];
       NSData *errData = [errStr dataUsingEncoding:NSUTF8StringEncoding];
       return sendResponse(401, errData, @"text/plain");
     }
@@ -500,18 +499,16 @@ static NSString *const kEtag = @"GoodETag";
   if (ifMatch != nil && ![ifMatch isEqual:kEtag]) {
     // there is no match, hence this is an inconsistent PUT or DELETE
     return sendResponse(412, nil, nil);  // precondition failed
-
   }
   if ([ifNoneMatch isEqual:kEtag]) {
     // there is a match, hence this is a repetitive request
     int resultStatus;
     if ([requestMethod isEqual:@"GET"] || [requestMethod isEqual:@"HEAD"]) {
-      resultStatus = 304; // not modified
+      resultStatus = 304;  // not modified
     } else {
-      resultStatus = 412; // precondition failed
+      resultStatus = 412;  // precondition failed
     }
     return sendResponse(resultStatus, nil, nil);
-
   }
   if ([requestMethod isEqual:@"DELETE"]) {
     // it's an object delete; return empty data
@@ -597,7 +594,8 @@ static NSString *const kEtag = @"GoodETag";
   if (cookies.length > 0) {
     responseHeaders[@"FoundCookies"] = cookies;
   }
-  NSString *cookieToSet = [NSString stringWithFormat:@"TestCookie=%@", [requestPath lastPathComponent]];
+  NSString *cookieToSet =
+      [NSString stringWithFormat:@"TestCookie=%@", [requestPath lastPathComponent]];
   responseHeaders[@"Set-Cookie"] = cookieToSet;
 
   // Cookies expected to be set and checked in tests before a redirect.
@@ -624,9 +622,7 @@ static NSString *const kEtag = @"GoodETag";
 - (NSData *)documentDataAtPath:(NSString *)requestPath {
   NSError *readError;
   NSString *docPath = [self localPathForFile:requestPath];
-  NSData *data = [NSData dataWithContentsOfFile:docPath
-                                        options:0
-                                          error:&readError];
+  NSData *data = [NSData dataWithContentsOfFile:docPath options:0 error:&readError];
   if (!data) {
     NSLog(@"Failed to read %@: %@", requestPath, readError);
   }
@@ -646,9 +642,7 @@ static NSString *const kEtag = @"GoodETag";
     NSCharacterSet *endSet = [NSCharacterSet characterSetWithCharactersInString:@"&\n"];
     NSUInteger startOfParam = paramNameRange.location + paramNameRange.length;
     NSRange endSearchRange = NSMakeRange(startOfParam, query.length - startOfParam);
-    NSRange endRange = [query rangeOfCharacterFromSet:endSet
-                                              options:0
-                                                range:endSearchRange];
+    NSRange endRange = [query rangeOfCharacterFromSet:endSet options:0 range:endSearchRange];
     if (endRange.location == NSNotFound) {
       // param goes to end of string
       result = [query substringFromIndex:startOfParam];
@@ -667,15 +661,14 @@ static NSString *const kEtag = @"GoodETag";
 - (void)stopServers {
   if (_server) {
 #if GTMHTTPSERVER_LOG_VERBOSE
-    NSLog(@"Stopped GTMHTTPFetcherTestServer on port %d (docRoot='%@')",
-          _server.port, _docRoot);
+    NSLog(@"Stopped GTMHTTPFetcherTestServer on port %d (docRoot='%@')", _server.port, _docRoot);
 #endif
     _server = nil;
   }
   if (_redirectServer) {
 #if GTMHTTPSERVER_LOG_VERBOSE
-    NSLog(@"Stopped redirect target server on port %d (docRoot='%@')",
-          _redirectServer.port, _docRoot);
+    NSLog(@"Stopped redirect target server on port %d (docRoot='%@')", _redirectServer.port,
+          _docRoot);
 #endif
     _redirectServer = nil;
   }
@@ -688,8 +681,8 @@ static NSString *const kEtag = @"GoodETag";
   NSURL *originalURL = request.URL;
   if (!originalURL) return nil;
 
-  NSURLComponents *urlComponents =
-      [[NSURLComponents alloc] initWithURL:originalURL resolvingAgainstBaseURL:YES];
+  NSURLComponents *urlComponents = [[NSURLComponents alloc] initWithURL:originalURL
+                                                resolvingAgainstBaseURL:YES];
   urlComponents.port = @(_redirectServer.port);
   NSURL *redirectURL = urlComponents.URL;
   return redirectURL;
@@ -701,8 +694,7 @@ static NSString *const kEtag = @"GoodETag";
                                            options:NSJSONReadingMutableContainers
                                              error:&error];
   if (obj == nil) {
-    NSString *jsonStr = [[NSString alloc] initWithData:data
-                                              encoding:NSUTF8StringEncoding];
+    NSString *jsonStr = [[NSString alloc] initWithData:data encoding:NSUTF8StringEncoding];
     NSLog(@"JSON parse error: %@\n  for JSON string: %@", error, jsonStr);
   }
   return obj;
@@ -734,8 +726,7 @@ static NSString *const kEtag = @"GoodETag";
       NSString *const kDigestAuthPrefix = @"Digest ";
       if (![authorization hasCaseInsensitivePrefix:kDigestAuthPrefix]) return NO;
 
-      NSString *authCredentialsString =
-          [authorization substringFromIndex:kDigestAuthPrefix.length];
+      NSString *authCredentialsString = [authorization substringFromIndex:kDigestAuthPrefix.length];
       NSDictionary *digestAuthCredentials =
           [authCredentialsString allDigestAuthorizationHeaderFields];
       NSString *username = digestAuthCredentials[@"username"];
@@ -759,8 +750,8 @@ static NSString *const kEtag = @"GoodETag";
       NSString *clientNonce = digestAuthCredentials[@"cnonce"];
       NSString *qop = digestAuthCredentials[@"qop"];
       NSString *authResponse = digestAuthCredentials[@"response"];
-      NSString *response = [NSString stringWithFormat:@"%@:%@:%@:%@:%@:%@",
-                            ha1, nonce, nonceCount, clientNonce, qop, ha2];
+      NSString *response = [NSString
+          stringWithFormat:@"%@:%@:%@:%@:%@:%@", ha1, nonce, nonceCount, clientNonce, qop, ha2];
       response = [response MD5DigestString];
       return [response isEqual:authResponse];
     }
@@ -791,7 +782,7 @@ static NSString *const kEtag = @"GoodETag";
 
 + (NSData *)trimResponseData:(NSData *)responseData
                byRangeHeader:(NSString *)rangeHeader
-       outContentRangeHeader:(NSString * __autoreleasing *)outContentRangeHeader {
+       outContentRangeHeader:(NSString *__autoreleasing *)outContentRangeHeader {
   NSAssert([rangeHeader hasPrefix:@"bytes="], @"Invalid Range: %@", rangeHeader);
   rangeHeader = [rangeHeader substringFromIndex:@"bytes=".length];
   NSArray *byteRangeStrings = [rangeHeader componentsSeparatedByString:@","];
@@ -816,12 +807,13 @@ static NSString *const kEtag = @"GoodETag";
     } else if ([byteRangeString hasSuffix:@"-"]) {
       // Final bytes beginning at offset
       NSRange offsetRange = NSMakeRange(0, (byteRangeString.length - 1));
-      byteRange.location = (NSUInteger)[[byteRangeString substringWithRange:offsetRange] integerValue];
+      byteRange.location =
+          (NSUInteger)[[byteRangeString substringWithRange:offsetRange] integerValue];
       byteRange.length = responseData.length - byteRange.location;
     } else {
       NSArray *byteOffsets = [byteRangeString componentsSeparatedByString:@"-"];
-      NSAssert(byteOffsets.count == 2,
-               @"Unexpected number of values in byte range, %@", byteRangeString);
+      NSAssert(byteOffsets.count == 2, @"Unexpected number of values in byte range, %@",
+               byteRangeString);
       byteRange.location = (NSUInteger)[byteOffsets[0] integerValue];
       byteRange.length = (NSUInteger)[byteOffsets[1] integerValue] + 1 - byteRange.location;
     }
@@ -834,8 +826,7 @@ static NSString *const kEtag = @"GoodETag";
   // . All except for the first 500 bytes: bytes 500-1233/1234
   // . The last 500 bytes: bytes 734-1233/1234
   *outContentRangeHeader =
-      [NSString stringWithFormat:@"bytes %llu-%llu/%llu",
-                                 (unsigned long long)contentRange.location,
+      [NSString stringWithFormat:@"bytes %llu-%llu/%llu", (unsigned long long)contentRange.location,
                                  (unsigned long long)(NSMaxRange(contentRange) - 1),
                                  (unsigned long long)responseData.length];
   return [responseData subdataWithRange:contentRange];

--- a/Source/UnitTests/GTMSessionFetcherUtilityTest.m
+++ b/Source/UnitTests/GTMSessionFetcherUtilityTest.m
@@ -36,7 +36,6 @@
                           endString:(NSString *)endStr;
 @end
 
-
 @implementation GTMSessionFetcherUtilityTest
 
 #if !STRIP_GTM_FETCH_LOGGING
@@ -138,7 +137,7 @@
 #else
   XCTAssertEqualObjects(result, @"com.google.FetcherMacTests/1.0");
 #endif
-#endif // !SWIFT_PACKAGE
+#endif  // !SWIFT_PACKAGE
 }
 
 - (void)testGTMFetcherStandardVersionString {
@@ -149,14 +148,14 @@
 
 #pragma clang diagnostic push
 #pragma clang diagnostic ignored "-Wunguarded-availability"
-// Disable unguarded availability warning as we can't use the @availability macro until we require
-// all clients to build with Xcode 9 or above.
+  // Disable unguarded availability warning as we can't use the @availability macro until we require
+  // all clients to build with Xcode 9 or above.
   NSOperatingSystemVersion version = [NSProcessInfo processInfo].operatingSystemVersion;
 #pragma clang diagnostic pop
 #if TARGET_OS_IPHONE
   // iOS, tvOS, watchOS
-  NSString *versionStr = [NSString stringWithFormat:@"%ld.%ld",
-                          (long)version.majorVersion, (long)version.minorVersion];
+  NSString *versionStr = [NSString
+      stringWithFormat:@"%ld.%ld", (long)version.majorVersion, (long)version.minorVersion];
   if (version.patchVersion > 0) {
     versionStr = [versionStr stringByAppendingFormat:@".%ld", (long)version.patchVersion];
   }
@@ -176,10 +175,11 @@
   // macOS
   NSString *expected =
       [NSString stringWithFormat:@"com.google.FetcherMacTests/1.0 MacOSX/%ld.%ld.%ld",
-       (long)version.majorVersion, (long)version.minorVersion, (long)version.patchVersion];
+                                 (long)version.majorVersion, (long)version.minorVersion,
+                                 (long)version.patchVersion];
   XCTAssertEqualObjects(result, expected);
 #endif
-#endif // !SWIFT_PACKAGE
+#endif  // !SWIFT_PACKAGE
 }
 
 - (void)testGTMDataFromInputStream {
@@ -217,9 +217,8 @@
   NSURL *tempFileURL = [tempDirURL URLByAppendingPathComponent:NSStringFromSelector(_cmd)
                                                    isDirectory:NO];
   NSError *fileError;
-  XCTAssertTrue([inputData writeToURL:tempFileURL
-                              options:NSDataWritingAtomic
-                                error:&fileError], @"%@", fileError);
+  XCTAssertTrue([inputData writeToURL:tempFileURL options:NSDataWritingAtomic error:&fileError],
+                @"%@", fileError);
 
   inputStream = [NSInputStream inputStreamWithURL:tempFileURL];
   result = GTMDataFromInputStream(inputStream, &streamError);
@@ -227,8 +226,8 @@
   XCTAssertNotEqual(result, inputData);
   XCTAssertNil(streamError);
 
-  XCTAssertTrue([[NSFileManager defaultManager] removeItemAtURL:tempFileURL
-                                                          error:&fileError], @"%@", fileError);
+  XCTAssertTrue([[NSFileManager defaultManager] removeItemAtURL:tempFileURL error:&fileError],
+                @"%@", fileError);
 
   // Test invalid stream.
   inputStream = [NSInputStream inputStreamWithFileAtPath:@"/////"];


### PR DESCRIPTION
GTMSessionFetcher has historically eschewed some Google Objective-C mechanical style mandates. This change runs `clang-format` once over the entire repository to bring the mechanical style into sync with the Google style guide, with the expectation that future code will maintain conformance to the [Google Objective-C style guide](https://google.github.io/styleguide/objcguide.html).

There are no changes beyond the output of running `clang-format`, so this PR contains only automated mechanical changes. This has mangled formatting of a few nested blocks, but cleaning up those blocks will be left for a future PR.

From the repo base directory:
  `find . -name \*.m -exec clang-format --style=Google -i {} \;`
  `find . -name \*.h -exec clang-format --style=Google -i {} \;`