### PR TITLE
Some cleanup after running clang-format for PR #229.

### DIFF
--- a/Source/GTMSessionFetcherService.m
+++ b/Source/GTMSessionFetcherService.m
@@ -102,16 +102,28 @@ NSString *const kGTMSessionFetcherServiceSessionKey = @"kGTMSessionFetcherServic
   NSDate *_stoppedAllFetchersDate;
 }
 
-@synthesize maxRunningFetchersPerHost = _maxRunningFetchersPerHost, configuration = _configuration,
-            configurationBlock = _configurationBlock, cookieStorage = _cookieStorage,
-            userAgent = _userAgent, challengeBlock = _challengeBlock, credential = _credential,
-            proxyCredential = _proxyCredential, allowedInsecureSchemes = _allowedInsecureSchemes,
+// Clang-format likes to cram all @synthesize items onto the fewest lines, rather than one-per.
+// clang-format off
+@synthesize maxRunningFetchersPerHost = _maxRunningFetchersPerHost,
+            configuration = _configuration,
+            configurationBlock = _configurationBlock,
+            cookieStorage = _cookieStorage,
+            userAgent = _userAgent,
+            challengeBlock = _challengeBlock,
+            credential = _credential,
+            proxyCredential = _proxyCredential,
+            allowedInsecureSchemes = _allowedInsecureSchemes,
             allowLocalhostRequest = _allowLocalhostRequest,
             allowInvalidServerCertificates = _allowInvalidServerCertificates,
-            retryEnabled = _retryEnabled, retryBlock = _retryBlock,
-            maxRetryInterval = _maxRetryInterval, minRetryInterval = _minRetryInterval,
-            metricsCollectionBlock = _metricsCollectionBlock, properties = _properties,
-            unusedSessionTimeout = _unusedSessionTimeout, testBlock = _testBlock;
+            retryEnabled = _retryEnabled,
+            retryBlock = _retryBlock,
+            maxRetryInterval = _maxRetryInterval,
+            minRetryInterval = _minRetryInterval,
+            metricsCollectionBlock = _metricsCollectionBlock,
+            properties = _properties,
+            unusedSessionTimeout = _unusedSessionTimeout,
+            testBlock = _testBlock;
+// clang-format on
 
 #if GTM_BACKGROUND_TASK_FETCHING
 @synthesize skipBackgroundTask = _skipBackgroundTask;

--- a/Source/GTMSessionUploadFetcher.m
+++ b/Source/GTMSessionUploadFetcher.m
@@ -1785,11 +1785,16 @@ NSString *const kGTMSessionFetcherUploadLocationObtainedNotification =
 }
 
 // Public properties.
-@synthesize currentOffset = _currentOffset, allowsCellularAccess = _allowsCellularAccess,
-            delegateCompletionHandler = _delegateCompletionHandler, chunkFetcher = _chunkFetcher,
-            lastChunkRequest = _lastChunkRequest, subdataGenerating = _subdataGenerating,
+// clang-format off
+@synthesize currentOffset = _currentOffset,
+            allowsCellularAccess = _allowsCellularAccess,
+            delegateCompletionHandler = _delegateCompletionHandler,
+            chunkFetcher = _chunkFetcher,
+            lastChunkRequest = _lastChunkRequest,
+            subdataGenerating = _subdataGenerating,
             shouldInitiateOffsetQuery = _shouldInitiateOffsetQuery,
             uploadGranularity = _uploadGranularity;
+// clang-format on
 
 // Internal properties.
 @dynamic fetcherInFlight;


### PR DESCRIPTION
- Re-formats `@synthesize` blocks wrapped in clang-format off/on comments, as we generally find them more readable one-per-line.
- Moves some blocks into locals first, to work around clang-format adding terrible indentation.