### PR TITLE
Xcode and SDK version update

### DIFF
--- a/Source/GTMGatherInputStream.h
+++ b/Source/GTMGatherInputStream.h
@@ -24,18 +24,6 @@
 
 #import <Foundation/Foundation.h>
 
-#ifndef GTM_NONNULL
-#if defined(__has_attribute)
-#if __has_attribute(nonnull)
-#define GTM_NONNULL(x) __attribute__((nonnull x))
-#else
-#define GTM_NONNULL(x)
-#endif
-#else
-#define GTM_NONNULL(x)
-#endif
-#endif
-
 // Avoid multiple declaration of this class.
 //
 // Note: This should match the declaration of GTMGatherInputStream in GTMMIMEDocument.m
@@ -45,7 +33,7 @@
 
 @interface GTMGatherInputStream : NSInputStream <NSStreamDelegate>
 
-+ (NSInputStream *)streamWithArray:(NSArray *)dataArray GTM_NONNULL((1));
++ (nonnull instancetype)streamWithArray:(nonnull NSArray *)dataArray;
 
 @end
 

--- a/Source/GTMGatherInputStream.m
+++ b/Source/GTMGatherInputStream.m
@@ -27,11 +27,11 @@
   id<NSStreamDelegate> __weak _delegate;  // Stream delegate, defaults to self.
 }
 
-+ (NSInputStream *)streamWithArray:(NSArray *)dataArray {
-  return [(GTMGatherInputStream *)[self alloc] initWithArray:dataArray];
++ (instancetype)streamWithArray:(NSArray *)dataArray {
+  return [[self alloc] initWithDataArray:dataArray];
 }
 
-- (instancetype)initWithArray:(NSArray *)dataArray {
+- (instancetype)initWithDataArray:(NSArray *)dataArray {
   self = [super init];
   if (self) {
     _dataArray = dataArray;

--- a/Source/GTMMIMEDocument.h
+++ b/Source/GTMMIMEDocument.h
@@ -22,30 +22,12 @@
 
 #import <Foundation/Foundation.h>
 
-#ifndef GTM_DECLARE_GENERICS
-#if __has_feature(objc_generics)
-#define GTM_DECLARE_GENERICS 1
-#else
-#define GTM_DECLARE_GENERICS 0
-#endif
-#endif
-
-#ifndef GTM_NSArrayOf
-#if GTM_DECLARE_GENERICS
-#define GTM_NSArrayOf(value) NSArray<value>
-#define GTM_NSDictionaryOf(key, value) NSDictionary<key, value>
-#else
-#define GTM_NSArrayOf(value) NSArray
-#define GTM_NSDictionaryOf(key, value) NSDictionary
-#endif  // GTM_DECLARE_GENERICS
-#endif  // GTM_NSArrayOf
-
 // GTMMIMEDocumentPart represents a part of a MIME document.
 //
 // +[GTMMIMEDocument MIMEPartsWithBoundary:data:] returns an array of these.
 @interface GTMMIMEDocumentPart : NSObject
 
-@property(nonatomic, readonly, nullable) GTM_NSDictionaryOf(NSString *, NSString *) *headers;
+@property(nonatomic, readonly, nullable) NSDictionary<NSString *, NSString *> *headers;
 @property(nonatomic, readonly, nonnull) NSData *headerData;
 @property(nonatomic, readonly, nonnull) NSData *body;
 @property(nonatomic, readonly) NSUInteger length;
@@ -70,7 +52,7 @@
 // Adds a new part to this mime document with the given headers and body.
 // The headers keys and values should be NSStrings.
 // Adding a part may cause the boundary string to change.
-- (void)addPartWithHeaders:(nonnull GTM_NSDictionaryOf(NSString *, NSString *) *)headers
+- (void)addPartWithHeaders:(nonnull NSDictionary<NSString *, NSString *> *)headers
                       body:(nonnull NSData *)body;
 
 // An inputstream that can be used to efficiently read the contents of the MIME document.
@@ -91,7 +73,7 @@
                     boundary:(NSString *_Nullable *_Nullable)outBoundary;
 
 // Utility method for making a header section, including trailing newlines.
-+ (nonnull NSData *)dataWithHeaders:(nullable GTM_NSDictionaryOf(NSString *, NSString *) *)headers;
++ (nonnull NSData *)dataWithHeaders:(nullable NSDictionary<NSString *, NSString *> *)headers;
 
 #pragma mark - Methods for Parsing a MIME Document
 
@@ -99,9 +81,9 @@
 //
 // Returns an array of GTMMIMEDocumentParts.  Returns nil if no part can
 // be found.
-+ (nullable GTM_NSArrayOf(GTMMIMEDocumentPart *) *)
-    MIMEPartsWithBoundary:(nonnull NSString *)boundary
-                     data:(nonnull NSData *)fullDocumentData;
++ (nullable NSArray<GTMMIMEDocumentPart *> *)MIMEPartsWithBoundary:(nonnull NSString *)boundary
+                                                              data:(nonnull NSData *)
+                                                                       fullDocumentData;
 
 // Utility method for efficiently searching possibly discontiguous NSData
 // for occurrences of target byte. This method does not "flatten" an NSData
@@ -112,10 +94,10 @@
 + (void)searchData:(nonnull NSData *)data
        targetBytes:(const void *_Nonnull)targetBytes
       targetLength:(NSUInteger)targetLength
-      foundOffsets:(GTM_NSArrayOf(NSNumber *) *_Nullable *_Nonnull)outFoundOffsets;
+      foundOffsets:(NSArray<NSNumber *> *_Nullable *_Nonnull)outFoundOffsets;
 
 // Utility method to parse header bytes into an NSDictionary.
-+ (nullable GTM_NSDictionaryOf(NSString *, NSString *) *)headersWithData:(nonnull NSData *)data;
++ (nullable NSDictionary<NSString *, NSString *> *)headersWithData:(nonnull NSData *)data;
 
 // ------ UNIT TESTING ONLY BELOW ------
 
@@ -131,7 +113,7 @@
 + (void)searchData:(nonnull NSData *)data
           targetBytes:(const void *_Nonnull)targetBytes
          targetLength:(NSUInteger)targetLength
-         foundOffsets:(GTM_NSArrayOf(NSNumber *) *_Nullable *_Nonnull)outFoundOffsets
-    foundBlockNumbers:(GTM_NSArrayOf(NSNumber *) *_Nullable *_Nonnull)outFoundBlockNumbers;
+         foundOffsets:(NSArray<NSNumber *> *_Nullable *_Nonnull)outFoundOffsets
+    foundBlockNumbers:(NSArray<NSNumber *> *_Nullable *_Nonnull)outFoundBlockNumbers;
 
 @end

--- a/Source/GTMMIMEDocument.h
+++ b/Source/GTMMIMEDocument.h
@@ -22,18 +22,6 @@
 
 #import <Foundation/Foundation.h>
 
-#ifndef GTM_NONNULL
-#if defined(__has_attribute)
-#if __has_attribute(nonnull)
-#define GTM_NONNULL(x) __attribute__((nonnull x))
-#else
-#define GTM_NONNULL(x)
-#endif
-#else
-#define GTM_NONNULL(x)
-#endif
-#endif
-
 #ifndef GTM_DECLARE_GENERICS
 #if __has_feature(objc_generics)
 #define GTM_DECLARE_GENERICS 1
@@ -57,12 +45,13 @@
 // +[GTMMIMEDocument MIMEPartsWithBoundary:data:] returns an array of these.
 @interface GTMMIMEDocumentPart : NSObject
 
-@property(nonatomic, readonly) GTM_NSDictionaryOf(NSString *, NSString *) * headers;
-@property(nonatomic, readonly) NSData *headerData;
-@property(nonatomic, readonly) NSData *body;
+@property(nonatomic, readonly, nullable) GTM_NSDictionaryOf(NSString *, NSString *) *headers;
+@property(nonatomic, readonly, nonnull) NSData *headerData;
+@property(nonatomic, readonly, nonnull) NSData *body;
 @property(nonatomic, readonly) NSUInteger length;
 
-+ (instancetype)partWithHeaders:(NSDictionary *)headers body:(NSData *)body;
++ (nonnull instancetype)partWithHeaders:(nullable NSDictionary *)headers
+                                   body:(nonnull NSData *)body;
 
 @end
 
@@ -72,24 +61,24 @@
 //
 // When creating a MIME document from parts, this is typically calculated
 // automatically after all parts have been added.
-@property(nonatomic, copy) NSString *boundary;
+@property(nonatomic, copy, null_resettable) NSString *boundary;
 
 #pragma mark - Methods for Creating a MIME Document
 
-+ (instancetype)MIMEDocument;
++ (nonnull instancetype)MIMEDocument;
 
 // Adds a new part to this mime document with the given headers and body.
 // The headers keys and values should be NSStrings.
 // Adding a part may cause the boundary string to change.
-- (void)addPartWithHeaders:(GTM_NSDictionaryOf(NSString *, NSString *) *)headers
-                      body:(NSData *)body GTM_NONNULL((1, 2));
+- (void)addPartWithHeaders:(nonnull GTM_NSDictionaryOf(NSString *, NSString *) *)headers
+                      body:(nonnull NSData *)body;
 
 // An inputstream that can be used to efficiently read the contents of the MIME document.
 //
 // Any parameter may be null if the result is not wanted.
-- (void)generateInputStream:(NSInputStream **)outStream
-                     length:(unsigned long long *)outLength
-                   boundary:(NSString **)outBoundary;
+- (void)generateInputStream:(NSInputStream *_Nullable *_Nullable)outStream
+                     length:(unsigned long long *_Nullable)outLength
+                   boundary:(NSString *_Nullable *_Nullable)outBoundary;
 
 // A dispatch_data_t with the contents of the MIME document.
 //
@@ -97,12 +86,12 @@
 // may be cast directly to NSData *.
 //
 // Any parameter may be null if the result is not wanted.
-- (void)generateDispatchData:(dispatch_data_t *)outDispatchData
-                      length:(unsigned long long *)outLength
-                    boundary:(NSString **)outBoundary;
+- (void)generateDispatchData:(dispatch_data_t _Nullable *_Nullable)outDispatchData
+                      length:(unsigned long long *_Nullable)outLength
+                    boundary:(NSString *_Nullable *_Nullable)outBoundary;
 
 // Utility method for making a header section, including trailing newlines.
-+ (NSData *)dataWithHeaders:(GTM_NSDictionaryOf(NSString *, NSString *) *)headers;
++ (nonnull NSData *)dataWithHeaders:(nullable GTM_NSDictionaryOf(NSString *, NSString *) *)headers;
 
 #pragma mark - Methods for Parsing a MIME Document
 
@@ -110,8 +99,9 @@
 //
 // Returns an array of GTMMIMEDocumentParts.  Returns nil if no part can
 // be found.
-+ (GTM_NSArrayOf(GTMMIMEDocumentPart *) *)MIMEPartsWithBoundary:(NSString *)boundary
-                                                           data:(NSData *)fullDocumentData;
++ (nullable GTM_NSArrayOf(GTMMIMEDocumentPart *) *)
+    MIMEPartsWithBoundary:(nonnull NSString *)boundary
+                     data:(nonnull NSData *)fullDocumentData;
 
 // Utility method for efficiently searching possibly discontiguous NSData
 // for occurrences of target byte. This method does not "flatten" an NSData
@@ -119,29 +109,29 @@
 //
 // The byte offsets of non-overlapping occurrences of the target are returned as
 // NSNumbers in the array.
-+ (void)searchData:(NSData *)data
-       targetBytes:(const void *)targetBytes
++ (void)searchData:(nonnull NSData *)data
+       targetBytes:(const void *_Nonnull)targetBytes
       targetLength:(NSUInteger)targetLength
-      foundOffsets:(GTM_NSArrayOf(NSNumber *) **)outFoundOffsets;
+      foundOffsets:(GTM_NSArrayOf(NSNumber *) *_Nullable *_Nonnull)outFoundOffsets;
 
 // Utility method to parse header bytes into an NSDictionary.
-+ (GTM_NSDictionaryOf(NSString *, NSString *) *)headersWithData:(NSData *)data;
++ (nullable GTM_NSDictionaryOf(NSString *, NSString *) *)headersWithData:(nonnull NSData *)data;
 
 // ------ UNIT TESTING ONLY BELOW ------
 
 // Internal methods, exposed for unit testing only.
 - (void)seedRandomWith:(u_int32_t)seed;
 
-+ (NSUInteger)findBytesWithNeedle:(const unsigned char *)needle
++ (NSUInteger)findBytesWithNeedle:(const unsigned char *_Nonnull)needle
                      needleLength:(NSUInteger)needleLength
-                         haystack:(const unsigned char *)haystack
+                         haystack:(const unsigned char *_Nonnull)haystack
                    haystackLength:(NSUInteger)haystackLength
-                      foundOffset:(NSUInteger *)foundOffset;
+                      foundOffset:(NSUInteger *_Nonnull)foundOffset;
 
-+ (void)searchData:(NSData *)data
-          targetBytes:(const void *)targetBytes
++ (void)searchData:(nonnull NSData *)data
+          targetBytes:(const void *_Nonnull)targetBytes
          targetLength:(NSUInteger)targetLength
-         foundOffsets:(GTM_NSArrayOf(NSNumber *) **)outFoundOffsets
-    foundBlockNumbers:(GTM_NSArrayOf(NSNumber *) **)outFoundBlockNumbers;
+         foundOffsets:(GTM_NSArrayOf(NSNumber *) *_Nullable *_Nonnull)outFoundOffsets
+    foundBlockNumbers:(GTM_NSArrayOf(NSNumber *) *_Nullable *_Nonnull)outFoundBlockNumbers;
 
 @end

--- a/Source/GTMMIMEDocument.m
+++ b/Source/GTMMIMEDocument.m
@@ -470,7 +470,7 @@ static void SearchDataForBytes(NSData *data, const void *targetBytes, NSUInteger
 + (void)searchData:(NSData *)data
        targetBytes:(const void *)targetBytes
       targetLength:(NSUInteger)targetLength
-      foundOffsets:(GTM_NSArrayOf(NSNumber *) **)outFoundOffsets {
+      foundOffsets:(NSArray<NSNumber *> **)outFoundOffsets {
   NSMutableArray *foundOffsets = [NSMutableArray array];
   SearchDataForBytes(data, targetBytes, targetLength, foundOffsets, NULL);
   *outFoundOffsets = foundOffsets;
@@ -482,8 +482,8 @@ static void SearchDataForBytes(NSData *data, const void *targetBytes, NSUInteger
 + (void)searchData:(NSData *)data
           targetBytes:(const void *)targetBytes
          targetLength:(NSUInteger)targetLength
-         foundOffsets:(GTM_NSArrayOf(NSNumber *) **)outFoundOffsets
-    foundBlockNumbers:(GTM_NSArrayOf(NSNumber *) **)outFoundBlockNumbers {
+         foundOffsets:(NSArray<NSNumber *> **)outFoundOffsets
+    foundBlockNumbers:(NSArray<NSNumber *> **)outFoundBlockNumbers {
   NSMutableArray *foundOffsets = [NSMutableArray array];
   NSMutableArray *foundBlockNumbers = [NSMutableArray array];
 

--- a/Source/GTMMIMEDocument.m
+++ b/Source/GTMMIMEDocument.m
@@ -25,7 +25,7 @@
 
 @interface GTMGatherInputStream : NSInputStream <NSStreamDelegate>
 
-+ (NSInputStream *)streamWithArray:(NSArray *)dataArray GTM_NONNULL((1));
++ (nonnull instancetype)streamWithArray:(nonnull NSArray *)dataArray;
 
 @end
 #endif  // GTM_GATHERINPUTSTREAM_DECLARED

--- a/Source/GTMReadMonitorInputStream.h
+++ b/Source/GTMReadMonitorInputStream.h
@@ -15,23 +15,13 @@
 
 #import <Foundation/Foundation.h>
 
-#ifndef GTM_NONNULL
-#if defined(__has_attribute)
-#if __has_attribute(nonnull)
-#define GTM_NONNULL(x) __attribute__((nonnull x))
-#else
-#define GTM_NONNULL(x)
-#endif
-#else
-#define GTM_NONNULL(x)
-#endif
-#endif
+NS_ASSUME_NONNULL_BEGIN
 
 @interface GTMReadMonitorInputStream : NSInputStream <NSStreamDelegate>
 
-+ (instancetype)inputStreamWithStream:(NSInputStream *)input GTM_NONNULL((1));
++ (nonnull instancetype)inputStreamWithStream:(nonnull NSInputStream *)input;
 
-- (instancetype)initWithStream:(NSInputStream *)input GTM_NONNULL((1));
+- (nonnull instancetype)initWithStream:(nonnull NSInputStream *)input;
 
 // The read monitor selector is called when bytes have been read. It should have this signature:
 //
@@ -40,9 +30,11 @@
 //              length:(int64_t)length;
 
 @property(atomic, weak) id readDelegate;
-@property(atomic, assign) SEL readSelector;
+@property(atomic) SEL readSelector;
 
 // Modes for invoking callbacks, when necessary.
-@property(atomic, strong) NSArray *runLoopModes;
+@property(atomic, copy, nullable) NSArray *runLoopModes;
 
 @end
+
+NS_ASSUME_NONNULL_END

--- a/Source/GTMSessionFetcher.h
+++ b/Source/GTMSessionFetcher.h
@@ -330,24 +330,6 @@
 #define GTM_LOG_SESSION_DELEGATE(...)
 #endif
 
-#ifndef GTM_DECLARE_GENERICS
-#if __has_feature(objc_generics)
-#define GTM_DECLARE_GENERICS 1
-#else
-#define GTM_DECLARE_GENERICS 0
-#endif
-#endif
-
-#ifndef GTM_NSArrayOf
-#if GTM_DECLARE_GENERICS
-#define GTM_NSArrayOf(value) NSArray<value>
-#define GTM_NSDictionaryOf(key, value) NSDictionary<key, value>
-#else
-#define GTM_NSArrayOf(value) NSArray
-#define GTM_NSDictionaryOf(key, value) NSDictionary
-#endif  // __has_feature(objc_generics)
-#endif  // GTM_NSArrayOf
-
 // For iOS, the fetcher can declare itself a background task to allow fetches
 // to finish when the app leaves the foreground.
 //
@@ -726,7 +708,7 @@ NSData *_Nullable GTMDataFromInputStream(NSInputStream *inputStream, NSError **o
 
 // Returns an array of currently active fetchers for background sessions,
 // both restarted and newly created ones.
-+ (GTM_NSArrayOf(GTMSessionFetcher *) *)fetchersForBackgroundSessions;
++ (NSArray<GTMSessionFetcher *> *)fetchersForBackgroundSessions;
 
 // Designated initializer.
 //
@@ -792,7 +774,7 @@ NSData *_Nullable GTMDataFromInputStream(NSInputStream *inputStream, NSError **o
 // Additional user-supplied data to encode into the session identifier. Since session identifier
 // length limits are unspecified, this should be kept small. Key names beginning with an underscore
 // are reserved for use by the fetcher.
-@property(atomic, strong, nullable) GTM_NSDictionaryOf(NSString *, NSString *) *sessionUserInfo;
+@property(atomic, strong, nullable) NSDictionary<NSString *, NSString *> *sessionUserInfo;
 
 // The human-readable description to be assigned to the task.
 @property(atomic, copy, nullable) NSString *taskDescription;
@@ -804,7 +786,7 @@ NSData *_Nullable GTMDataFromInputStream(NSInputStream *inputStream, NSError **o
 // The fetcher encodes information used to resume a session in the session identifier.
 // This method, intended for internal use returns the encoded information.  The sessionUserInfo
 // dictionary is stored as identifier metadata.
-- (nullable GTM_NSDictionaryOf(NSString *, NSString *) *)sessionIdentifierMetadata;
+- (nullable NSDictionary<NSString *, NSString *> *)sessionIdentifierMetadata;
 
 #if TARGET_OS_IPHONE && !TARGET_OS_WATCH
 // The app should pass to this method the completion handler passed in the app delegate method
@@ -862,7 +844,7 @@ NSData *_Nullable GTMDataFromInputStream(NSInputStream *inputStream, NSError **o
 //
 // For builds with the iOS 9/OS X 10.11 and later SDKs, this property is required only when
 // the app specifies NSAppTransportSecurity/NSAllowsArbitraryLoads in the main bundle's Info.plist.
-@property(atomic, copy, nullable) GTM_NSArrayOf(NSString *) *allowedInsecureSchemes;
+@property(atomic, copy, nullable) NSArray<NSString *> *allowedInsecureSchemes;
 
 // By default, the fetcher prohibits localhost requests unless this property is set,
 // or the GTM_ALLOW_INSECURE_REQUESTS build flag is set.
@@ -1075,8 +1057,7 @@ NSData *_Nullable GTMDataFromInputStream(NSInputStream *inputStream, NSError **o
 @property(atomic, readonly) NSInteger statusCode;
 
 // Return the http headers from the response.
-@property(atomic, strong, readonly, nullable) GTM_NSDictionaryOf(NSString *, NSString *) *
-    responseHeaders;
+@property(atomic, strong, readonly, nullable) NSDictionary<NSString *, NSString *> *responseHeaders;
 
 // The response, once it's been received.
 @property(atomic, strong, readonly, nullable) NSURLResponse *response;
@@ -1101,13 +1082,13 @@ NSData *_Nullable GTMDataFromInputStream(NSInputStream *inputStream, NSError **o
 @property(atomic, strong, nullable) id userData;
 
 // Stored property values are retained solely for the convenience of the client.
-@property(atomic, copy, nullable) GTM_NSDictionaryOf(NSString *, id) *properties;
+@property(atomic, copy, nullable) NSDictionary<NSString *, id> *properties;
 
 - (void)setProperty:(nullable id)obj
              forKey:(NSString *)key;  // Pass nil for obj to remove the property.
 - (nullable id)propertyForKey:(NSString *)key;
 
-- (void)addPropertiesFromDictionary:(GTM_NSDictionaryOf(NSString *, id) *)dict;
+- (void)addPropertiesFromDictionary:(NSDictionary<NSString *, id> *)dict;
 
 // Comments are useful for logging, so are strongly recommended for each fetcher.
 @property(atomic, copy, nullable) NSString *comment;
@@ -1232,7 +1213,7 @@ NSData *_Nullable GTMDataFromInputStream(NSInputStream *inputStream, NSError **o
 
 // Add the array off cookies to the storage, replacing duplicates.
 // Also removes expired cookies from the storage.
-- (void)setCookies:(nullable GTM_NSArrayOf(NSHTTPCookie *) *)cookies;
+- (void)setCookies:(nullable NSArray<NSHTTPCookie *> *)cookies;
 
 - (void)removeAllCookies;
 

--- a/Source/GTMSessionFetcher.h
+++ b/Source/GTMSessionFetcher.h
@@ -330,27 +330,6 @@
 #define GTM_LOG_SESSION_DELEGATE(...)
 #endif
 
-#ifndef GTM_NULLABLE
-#if __has_feature(nullability)  // Available starting in Xcode 6.3
-#define GTM_NULLABLE_TYPE __nullable
-#define GTM_NONNULL_TYPE __nonnull
-#define GTM_NULLABLE nullable
-#define GTM_NONNULL_DECL nonnull  // GTM_NONNULL is used by GTMDefines.h
-#define GTM_NULL_RESETTABLE null_resettable
-
-#define GTM_ASSUME_NONNULL_BEGIN NS_ASSUME_NONNULL_BEGIN
-#define GTM_ASSUME_NONNULL_END NS_ASSUME_NONNULL_END
-#else
-#define GTM_NULLABLE_TYPE
-#define GTM_NONNULL_TYPE
-#define GTM_NULLABLE
-#define GTM_NONNULL_DECL
-#define GTM_NULL_RESETTABLE
-#define GTM_ASSUME_NONNULL_BEGIN
-#define GTM_ASSUME_NONNULL_END
-#endif  // __has_feature(nullability)
-#endif  // GTM_NULLABLE
-
 #ifndef GTM_DECLARE_GENERICS
 #if __has_feature(objc_generics)
 #define GTM_DECLARE_GENERICS 1
@@ -451,7 +430,7 @@ extern "C" {
 #endif
 #endif
 
-GTM_ASSUME_NONNULL_BEGIN
+NS_ASSUME_NONNULL_BEGIN
 
 // Notifications
 //
@@ -533,8 +512,8 @@ extern "C" {
 typedef void (^GTMSessionFetcherConfigurationBlock)(GTMSessionFetcher *fetcher,
                                                     NSURLSessionConfiguration *configuration);
 typedef void (^GTMSessionFetcherSystemCompletionHandler)(void);
-typedef void (^GTMSessionFetcherCompletionHandler)(NSData *GTM_NULLABLE_TYPE data,
-                                                   NSError *GTM_NULLABLE_TYPE error);
+typedef void (^GTMSessionFetcherCompletionHandler)(NSData *_Nullable data,
+                                                   NSError *_Nullable error);
 typedef void (^GTMSessionFetcherBodyStreamProviderResponse)(NSInputStream *bodyStream);
 typedef void (^GTMSessionFetcherBodyStreamProvider)(
     GTMSessionFetcherBodyStreamProviderResponse response);
@@ -543,18 +522,16 @@ typedef void (^GTMSessionFetcherDidReceiveResponseDispositionBlock)(
 typedef void (^GTMSessionFetcherDidReceiveResponseBlock)(
     NSURLResponse *response, GTMSessionFetcherDidReceiveResponseDispositionBlock dispositionBlock);
 typedef void (^GTMSessionFetcherChallengeDispositionBlock)(
-    NSURLSessionAuthChallengeDisposition disposition,
-    NSURLCredential *GTM_NULLABLE_TYPE credential);
+    NSURLSessionAuthChallengeDisposition disposition, NSURLCredential *_Nullable credential);
 typedef void (^GTMSessionFetcherChallengeBlock)(
     GTMSessionFetcher *fetcher, NSURLAuthenticationChallenge *challenge,
     GTMSessionFetcherChallengeDispositionBlock dispositionBlock);
-typedef void (^GTMSessionFetcherWillRedirectResponse)(
-    NSURLRequest *GTM_NULLABLE_TYPE redirectedRequest);
+typedef void (^GTMSessionFetcherWillRedirectResponse)(NSURLRequest *_Nullable redirectedRequest);
 typedef void (^GTMSessionFetcherWillRedirectBlock)(NSHTTPURLResponse *redirectResponse,
                                                    NSURLRequest *redirectRequest,
                                                    GTMSessionFetcherWillRedirectResponse response);
-typedef void (^GTMSessionFetcherAccumulateDataBlock)(NSData *GTM_NULLABLE_TYPE buffer);
-typedef void (^GTMSessionFetcherSimulateByteTransferBlock)(NSData *GTM_NULLABLE_TYPE buffer,
+typedef void (^GTMSessionFetcherAccumulateDataBlock)(NSData *_Nullable buffer);
+typedef void (^GTMSessionFetcherSimulateByteTransferBlock)(NSData *_Nullable buffer,
                                                            int64_t bytesWritten,
                                                            int64_t totalBytesWritten,
                                                            int64_t totalBytesExpectedToWrite);
@@ -566,25 +543,23 @@ typedef void (^GTMSessionFetcherDownloadProgressBlock)(int64_t bytesWritten,
 typedef void (^GTMSessionFetcherSendProgressBlock)(int64_t bytesSent, int64_t totalBytesSent,
                                                    int64_t totalBytesExpectedToSend);
 typedef void (^GTMSessionFetcherWillCacheURLResponseResponse)(
-    NSCachedURLResponse *GTM_NULLABLE_TYPE cachedResponse);
+    NSCachedURLResponse *_Nullable cachedResponse);
 typedef void (^GTMSessionFetcherWillCacheURLResponseBlock)(
     NSCachedURLResponse *proposedResponse,
     GTMSessionFetcherWillCacheURLResponseResponse responseBlock);
 typedef void (^GTMSessionFetcherRetryResponse)(BOOL shouldRetry);
-typedef void (^GTMSessionFetcherRetryBlock)(BOOL suggestedWillRetry,
-                                            NSError *GTM_NULLABLE_TYPE error,
+typedef void (^GTMSessionFetcherRetryBlock)(BOOL suggestedWillRetry, NSError *_Nullable error,
                                             GTMSessionFetcherRetryResponse response);
 
 API_AVAILABLE(ios(10.0), macosx(10.12), tvos(10.0), watchos(3.0))
 typedef void (^GTMSessionFetcherMetricsCollectionBlock)(NSURLSessionTaskMetrics *metrics);
 
-typedef void (^GTMSessionFetcherTestResponse)(NSHTTPURLResponse *GTM_NULLABLE_TYPE response,
-                                              NSData *GTM_NULLABLE_TYPE data,
-                                              NSError *GTM_NULLABLE_TYPE error);
+typedef void (^GTMSessionFetcherTestResponse)(NSHTTPURLResponse *_Nullable response,
+                                              NSData *_Nullable data, NSError *_Nullable error);
 typedef void (^GTMSessionFetcherTestBlock)(GTMSessionFetcher *fetcherToTest,
                                            GTMSessionFetcherTestResponse testResponse);
 
-void GTMSessionFetcherAssertValidSelector(id GTM_NULLABLE_TYPE obj, SEL GTM_NULLABLE_TYPE sel, ...);
+void GTMSessionFetcherAssertValidSelector(id _Nullable obj, SEL _Nullable sel, ...);
 
 // Utility functions for applications self-identifying to servers via a
 // user-agent header
@@ -596,7 +571,7 @@ void GTMSessionFetcherAssertValidSelector(id GTM_NULLABLE_TYPE obj, SEL GTM_NULL
 // Applications may use this as a starting point for their own user agent strings, perhaps
 // with additional sections appended.  Use GTMFetcherCleanedUserAgentString() below to
 // clean up any string being added to the user agent.
-NSString *GTMFetcherStandardUserAgentString(NSBundle *GTM_NULLABLE_TYPE bundle);
+NSString *GTMFetcherStandardUserAgentString(NSBundle *_Nullable bundle);
 
 // Make a generic name and version for the current application, like
 // com.example.MyApp/1.2.3 relying on the bundle identifier and the
@@ -610,7 +585,7 @@ NSString *GTMFetcherStandardUserAgentString(NSBundle *GTM_NULLABLE_TYPE bundle);
 //
 // If no bundle ID or override is available, the process name preceded
 // by "proc_" is used.
-NSString *GTMFetcherApplicationIdentifier(NSBundle *GTM_NULLABLE_TYPE bundle);
+NSString *GTMFetcherApplicationIdentifier(NSBundle *_Nullable bundle);
 
 // Make an identifier like "MacOSX/10.7.1" or "iPod_Touch/4.1 hw/iPod1_1"
 NSString *GTMFetcherSystemVersionString(void);
@@ -633,7 +608,7 @@ NSString *GTMFetcherCleanedUserAgentString(NSString *str);
 // queue before calling this function.
 //
 // Failure is indicated by a returned data value of nil.
-NSData *GTM_NULLABLE_TYPE GTMDataFromInputStream(NSInputStream *inputStream, NSError **outError);
+NSData *_Nullable GTMDataFromInputStream(NSInputStream *inputStream, NSError **outError);
 
 #ifdef __cplusplus
 }  // extern "C"
@@ -662,13 +637,13 @@ NSData *GTM_NULLABLE_TYPE GTMDataFromInputStream(NSInputStream *inputStream, NSE
 - (BOOL)isDelayingFetcher:(GTMSessionFetcher *)fetcher;
 
 @property(atomic, assign) BOOL reuseSession;
-- (GTM_NULLABLE NSURLSession *)session;
-- (GTM_NULLABLE NSURLSession *)sessionForFetcherCreation;
-- (GTM_NULLABLE id<NSURLSessionDelegate>)sessionDelegate;
-- (GTM_NULLABLE NSDate *)stoppedAllFetchersDate;
+- (nullable NSURLSession *)session;
+- (nullable NSURLSession *)sessionForFetcherCreation;
+- (nullable id<NSURLSessionDelegate>)sessionDelegate;
+- (nullable NSDate *)stoppedAllFetchersDate;
 
 // Methods for compatibility with the old GTMHTTPFetcher.
-@property(atomic, readonly, strong, GTM_NULLABLE) NSOperationQueue *delegateQueue;
+@property(atomic, readonly, strong, nullable) NSOperationQueue *delegateQueue;
 
 @end  // @protocol GTMSessionFetcherServiceProtocol
 
@@ -678,7 +653,7 @@ NSData *GTM_NULLABLE_TYPE GTMDataFromInputStream(NSInputStream *inputStream, NSE
 @required
 // This protocol allows us to call the authorizer without requiring its sources
 // in this project.
-- (void)authorizeRequest:(GTM_NULLABLE NSMutableURLRequest *)request
+- (void)authorizeRequest:(nullable NSMutableURLRequest *)request
                 delegate:(id)delegate
        didFinishSelector:(SEL)sel;
 
@@ -690,7 +665,7 @@ NSData *GTM_NULLABLE_TYPE GTMDataFromInputStream(NSInputStream *inputStream, NSE
 
 - (BOOL)isAuthorizedRequest:(NSURLRequest *)request;
 
-@property(atomic, strong, readonly, GTM_NULLABLE) NSString *userEmail;
+@property(atomic, strong, readonly, nullable) NSString *userEmail;
 
 @optional
 
@@ -702,13 +677,13 @@ NSData *GTM_NULLABLE_TYPE GTMDataFromInputStream(NSInputStream *inputStream, NSE
 // transmission of the bearer token unencrypted.
 @property(atomic, assign) BOOL shouldAuthorizeAllRequests;
 
-- (void)authorizeRequest:(GTM_NULLABLE NSMutableURLRequest *)request
-       completionHandler:(void (^)(NSError *GTM_NULLABLE_TYPE error))handler;
+- (void)authorizeRequest:(nullable NSMutableURLRequest *)request
+       completionHandler:(void (^)(NSError *_Nullable error))handler;
 
 #if GTM_USE_SESSION_FETCHER
-@property(atomic, weak, GTM_NULLABLE) id<GTMSessionFetcherServiceProtocol> fetcherService;
+@property(atomic, weak, nullable) id<GTMSessionFetcherServiceProtocol> fetcherService;
 #else
-@property(atomic, weak, GTM_NULLABLE) id<GTMHTTPFetcherServiceProtocol> fetcherService;
+@property(atomic, weak, nullable) id<GTMHTTPFetcherServiceProtocol> fetcherService;
 #endif
 
 - (BOOL)primeForRefresh;
@@ -739,7 +714,7 @@ NSData *GTM_NULLABLE_TYPE GTMDataFromInputStream(NSInputStream *inputStream, NSE
 // the connection is successfully created, the connection should retain the
 // fetcher for the life of the connection as well. So the caller doesn't have
 // to retain the fetcher explicitly unless they want to be able to cancel it.
-+ (instancetype)fetcherWithRequest:(GTM_NULLABLE NSURLRequest *)request;
++ (instancetype)fetcherWithRequest:(nullable NSURLRequest *)request;
 
 // Convenience methods that make a request, like +fetcherWithRequest
 + (instancetype)fetcherWithURL:(NSURL *)requestURL;
@@ -747,7 +722,7 @@ NSData *GTM_NULLABLE_TYPE GTMDataFromInputStream(NSInputStream *inputStream, NSE
 
 // Methods for creating fetchers to continue previous fetches.
 + (instancetype)fetcherWithDownloadResumeData:(NSData *)resumeData;
-+ (GTM_NULLABLE instancetype)fetcherWithSessionIdentifier:(NSString *)sessionIdentifier;
++ (nullable instancetype)fetcherWithSessionIdentifier:(NSString *)sessionIdentifier;
 
 // Returns an array of currently active fetchers for background sessions,
 // both restarted and newly created ones.
@@ -760,19 +735,19 @@ NSData *GTM_NULLABLE_TYPE GTMDataFromInputStream(NSInputStream *inputStream, NSE
 //
 // The configuration should typically be nil. Applications needing to customize
 // the configuration may do so by setting the configurationBlock property.
-- (instancetype)initWithRequest:(GTM_NULLABLE NSURLRequest *)request
-                  configuration:(GTM_NULLABLE NSURLSessionConfiguration *)configuration;
+- (instancetype)initWithRequest:(nullable NSURLRequest *)request
+                  configuration:(nullable NSURLSessionConfiguration *)configuration;
 
 // The fetcher's request.  This may not be set after beginFetch has been invoked. The request
 // may change due to redirects.
-@property(atomic, strong, GTM_NULLABLE) NSURLRequest *request;
+@property(atomic, strong, nullable) NSURLRequest *request;
 
 // Set a header field value on the request. Header field value changes will not
 // affect a fetch after the fetch has begun.
-- (void)setRequestValue:(GTM_NULLABLE NSString *)value forHTTPHeaderField:(NSString *)field;
+- (void)setRequestValue:(nullable NSString *)value forHTTPHeaderField:(NSString *)field;
 
 // Data used for resuming a download task.
-@property(atomic, readonly, GTM_NULLABLE) NSData *downloadResumeData;
+@property(atomic, readonly, nullable) NSData *downloadResumeData;
 
 // The configuration; this must be set before the fetch begins. If no configuration is
 // set or inherited from the fetcher service, then the fetcher uses an ephemeral config.
@@ -781,7 +756,7 @@ NSData *GTM_NULLABLE_TYPE GTMDataFromInputStream(NSInputStream *inputStream, NSE
 // the configuration should do so by setting the configurationBlock property.
 // That allows the fetcher to pick an appropriate base configuration, with the
 // application setting only the configuration properties it needs to customize.
-@property(atomic, strong, GTM_NULLABLE) NSURLSessionConfiguration *configuration;
+@property(atomic, strong, nullable) NSURLSessionConfiguration *configuration;
 
 // A block the client may use to customize the configuration used to create the session.
 //
@@ -793,17 +768,17 @@ NSData *GTM_NULLABLE_TYPE GTMDataFromInputStream(NSInputStream *inputStream, NSE
 // DO NOT change any fetcher properties in the configuration block. Fetcher properties
 // may be set in the fetcher service prior to fetcher creation, or on the fetcher prior
 // to invoking beginFetch.
-@property(atomic, copy, GTM_NULLABLE) GTMSessionFetcherConfigurationBlock configurationBlock;
+@property(atomic, copy, nullable) GTMSessionFetcherConfigurationBlock configurationBlock;
 
 // A session is created as needed by the fetcher.  A fetcher service object
 // may maintain sessions for multiple fetches to the same host.
-@property(atomic, strong, GTM_NULLABLE) NSURLSession *session;
+@property(atomic, strong, nullable) NSURLSession *session;
 
 // The task in flight.
-@property(atomic, readonly, GTM_NULLABLE) NSURLSessionTask *sessionTask;
+@property(atomic, readonly, nullable) NSURLSessionTask *sessionTask;
 
 // The background session identifier.
-@property(atomic, readonly, GTM_NULLABLE) NSString *sessionIdentifier;
+@property(atomic, readonly, nullable) NSString *sessionIdentifier;
 
 // Indicates a fetcher created to finish a background session task.
 @property(atomic, readonly) BOOL wasCreatedFromBackgroundSession;
@@ -817,11 +792,10 @@ NSData *GTM_NULLABLE_TYPE GTMDataFromInputStream(NSInputStream *inputStream, NSE
 // Additional user-supplied data to encode into the session identifier. Since session identifier
 // length limits are unspecified, this should be kept small. Key names beginning with an underscore
 // are reserved for use by the fetcher.
-@property(atomic, strong, GTM_NULLABLE) GTM_NSDictionaryOf(NSString *, NSString *) *
-    sessionUserInfo;
+@property(atomic, strong, nullable) GTM_NSDictionaryOf(NSString *, NSString *) *sessionUserInfo;
 
 // The human-readable description to be assigned to the task.
-@property(atomic, copy, GTM_NULLABLE) NSString *taskDescription;
+@property(atomic, copy, nullable) NSString *taskDescription;
 
 // The priority assigned to the task, if any.  Use NSURLSessionTaskPriorityLow,
 // NSURLSessionTaskPriorityDefault, or NSURLSessionTaskPriorityHigh.
@@ -830,7 +804,7 @@ NSData *GTM_NULLABLE_TYPE GTMDataFromInputStream(NSInputStream *inputStream, NSE
 // The fetcher encodes information used to resume a session in the session identifier.
 // This method, intended for internal use returns the encoded information.  The sessionUserInfo
 // dictionary is stored as identifier metadata.
-- (GTM_NULLABLE GTM_NSDictionaryOf(NSString *, NSString *) *)sessionIdentifierMetadata;
+- (nullable GTM_NSDictionaryOf(NSString *, NSString *) *)sessionIdentifierMetadata;
 
 #if TARGET_OS_IPHONE && !TARGET_OS_WATCH
 // The app should pass to this method the completion handler passed in the app delegate method
@@ -888,7 +862,7 @@ NSData *GTM_NULLABLE_TYPE GTMDataFromInputStream(NSInputStream *inputStream, NSE
 //
 // For builds with the iOS 9/OS X 10.11 and later SDKs, this property is required only when
 // the app specifies NSAppTransportSecurity/NSAllowsArbitraryLoads in the main bundle's Info.plist.
-@property(atomic, copy, GTM_NULLABLE) GTM_NSArrayOf(NSString *) * allowedInsecureSchemes;
+@property(atomic, copy, nullable) GTM_NSArrayOf(NSString *) *allowedInsecureSchemes;
 
 // By default, the fetcher prohibits localhost requests unless this property is set,
 // or the GTM_ALLOW_INSECURE_REQUESTS build flag is set.
@@ -911,40 +885,40 @@ NSData *GTM_NULLABLE_TYPE GTMDataFromInputStream(NSInputStream *inputStream, NSE
 // Because as of Jan 2014 standalone instances of NSHTTPCookieStorage do not actually
 // store any cookies (Radar 15735276) we use our own subclass, GTMSessionCookieStorage,
 // to hold cookies in memory.
-@property(atomic, strong, GTM_NULLABLE) NSHTTPCookieStorage *cookieStorage;
+@property(atomic, strong, nullable) NSHTTPCookieStorage *cookieStorage;
 
 // Setting the credential is optional; it is used if the connection receives
 // an authentication challenge.
-@property(atomic, strong, GTM_NULLABLE) NSURLCredential *credential;
+@property(atomic, strong, nullable) NSURLCredential *credential;
 
 // Setting the proxy credential is optional; it is used if the connection
 // receives an authentication challenge from a proxy.
-@property(atomic, strong, GTM_NULLABLE) NSURLCredential *proxyCredential;
+@property(atomic, strong, nullable) NSURLCredential *proxyCredential;
 
 // If body data, body file URL, or body stream provider is not set, then a GET request
 // method is assumed.
-@property(atomic, strong, GTM_NULLABLE) NSData *bodyData;
+@property(atomic, strong, nullable) NSData *bodyData;
 
 // File to use as the request body. This forces use of an upload task.
-@property(atomic, strong, GTM_NULLABLE) NSURL *bodyFileURL;
+@property(atomic, strong, nullable) NSURL *bodyFileURL;
 
 // Length of body to send, expected or actual.
 @property(atomic, readonly) int64_t bodyLength;
 
 // The body stream provider may be called repeatedly to provide a body.
 // Setting a body stream provider forces use of an upload task.
-@property(atomic, copy, GTM_NULLABLE) GTMSessionFetcherBodyStreamProvider bodyStreamProvider;
+@property(atomic, copy, nullable) GTMSessionFetcherBodyStreamProvider bodyStreamProvider;
 
 // Object to add authorization to the request, if needed.
 //
 // This may not be changed once beginFetch has been invoked.
-@property(atomic, strong, GTM_NULLABLE) id<GTMFetcherAuthorizationProtocol> authorizer;
+@property(atomic, strong, nullable) id<GTMFetcherAuthorizationProtocol> authorizer;
 
 // The service object that created and monitors this fetcher, if any.
 @property(atomic, strong) id<GTMSessionFetcherServiceProtocol> service;
 
 // The host, if any, used to classify this fetcher in the fetcher service.
-@property(atomic, copy, GTM_NULLABLE) NSString *serviceHost;
+@property(atomic, copy, nullable) NSString *serviceHost;
 
 // The priority, if any, used for starting fetchers in the fetcher service.
 //
@@ -959,8 +933,7 @@ NSData *GTM_NULLABLE_TYPE GTMDataFromInputStream(NSInputStream *inputStream, NSE
 // the session task response.
 //
 // This is called on the callback queue.
-@property(atomic, copy, GTM_NULLABLE)
-    GTMSessionFetcherDidReceiveResponseBlock didReceiveResponseBlock;
+@property(atomic, copy, nullable) GTMSessionFetcherDidReceiveResponseBlock didReceiveResponseBlock;
 
 // The delegate's optional challenge block may be used to inspect or alter
 // the session task challenge.
@@ -973,18 +946,18 @@ NSData *GTM_NULLABLE_TYPE GTMDataFromInputStream(NSInputStream *inputStream, NSE
 // challenge.previousFailureCount to identify repeated invocations.
 //
 // This is called on the callback queue.
-@property(atomic, copy, GTM_NULLABLE) GTMSessionFetcherChallengeBlock challengeBlock;
+@property(atomic, copy, nullable) GTMSessionFetcherChallengeBlock challengeBlock;
 
 // The delegate's optional willRedirect block may be used to inspect or alter
 // the redirection.
 //
 // This is called on the callback queue.
-@property(atomic, copy, GTM_NULLABLE) GTMSessionFetcherWillRedirectBlock willRedirectBlock;
+@property(atomic, copy, nullable) GTMSessionFetcherWillRedirectBlock willRedirectBlock;
 
 // The optional send progress block reports body bytes uploaded.
 //
 // This is called on the callback queue.
-@property(atomic, copy, GTM_NULLABLE) GTMSessionFetcherSendProgressBlock sendProgressBlock;
+@property(atomic, copy, nullable) GTMSessionFetcherSendProgressBlock sendProgressBlock;
 
 // The optional accumulate block may be set by clients wishing to accumulate data
 // themselves rather than let the fetcher append each buffer to an NSData.
@@ -993,25 +966,25 @@ NSData *GTM_NULLABLE_TYPE GTMDataFromInputStream(NSInputStream *inputStream, NSE
 // should empty its accumulation buffer.
 //
 // This is called on the callback queue.
-@property(atomic, copy, GTM_NULLABLE) GTMSessionFetcherAccumulateDataBlock accumulateDataBlock;
+@property(atomic, copy, nullable) GTMSessionFetcherAccumulateDataBlock accumulateDataBlock;
 
 // The optional received progress block may be used to monitor data
 // received from a data task.
 //
 // This is called on the callback queue.
-@property(atomic, copy, GTM_NULLABLE) GTMSessionFetcherReceivedProgressBlock receivedProgressBlock;
+@property(atomic, copy, nullable) GTMSessionFetcherReceivedProgressBlock receivedProgressBlock;
 
 // The delegate's optional downloadProgress block may be used to monitor download
 // progress in writing to disk.
 //
 // This is called on the callback queue.
-@property(atomic, copy, GTM_NULLABLE) GTMSessionFetcherDownloadProgressBlock downloadProgressBlock;
+@property(atomic, copy, nullable) GTMSessionFetcherDownloadProgressBlock downloadProgressBlock;
 
 // The delegate's optional willCacheURLResponse block may be used to alter the cached
 // NSURLResponse. The user may prevent caching by passing nil to the block's response.
 //
 // This is called on the callback queue.
-@property(atomic, copy, GTM_NULLABLE)
+@property(atomic, copy, nullable)
     GTMSessionFetcherWillCacheURLResponseBlock willCacheURLResponseBlock;
 
 // Enable retrying; see comments at the top of this file.  Setting
@@ -1023,12 +996,12 @@ NSData *GTM_NULLABLE_TYPE GTMDataFromInputStream(NSInputStream *inputStream, NSE
 // If present, this block should call the response block with YES to cause a retry or NO to end the
 // fetch.
 // See comments at the top of this file.
-@property(atomic, copy, GTM_NULLABLE) GTMSessionFetcherRetryBlock retryBlock;
+@property(atomic, copy, nullable) GTMSessionFetcherRetryBlock retryBlock;
 
 // The optional block for collecting the metrics of the present session.
 //
 // This is called on the callback queue.
-@property(atomic, copy, GTM_NULLABLE)
+@property(atomic, copy, nullable)
     GTMSessionFetcherMetricsCollectionBlock metricsCollectionBlock API_AVAILABLE(
         ios(10.0), macosx(10.12), tvos(10.0), watchos(3.0));
 
@@ -1081,10 +1054,9 @@ NSData *GTM_NULLABLE_TYPE GTMDataFromInputStream(NSInputStream *inputStream, NSE
 // If the application has specified a destinationFileURL or an accumulateDataBlock
 // for the fetcher, the data parameter passed to the callback will be nil.
 
-- (void)beginFetchWithDelegate:(GTM_NULLABLE id)delegate
-             didFinishSelector:(GTM_NULLABLE SEL)finishedSEL;
+- (void)beginFetchWithDelegate:(nullable id)delegate didFinishSelector:(nullable SEL)finishedSEL;
 
-- (void)beginFetchWithCompletionHandler:(GTM_NULLABLE GTMSessionFetcherCompletionHandler)handler;
+- (void)beginFetchWithCompletionHandler:(nullable GTMSessionFetcherCompletionHandler)handler;
 
 // Returns YES if this fetcher is in the process of fetching a URL.
 @property(atomic, readonly, getter=isFetching) BOOL fetching;
@@ -1094,59 +1066,59 @@ NSData *GTM_NULLABLE_TYPE GTMDataFromInputStream(NSInputStream *inputStream, NSE
 - (void)stopFetching;
 
 // A block to be called when the fetch completes.
-@property(atomic, copy, GTM_NULLABLE) GTMSessionFetcherCompletionHandler completionHandler;
+@property(atomic, copy, nullable) GTMSessionFetcherCompletionHandler completionHandler;
 
 // A block to be called if download resume data becomes available.
-@property(atomic, strong, GTM_NULLABLE) void (^resumeDataBlock)(NSData *);
+@property(atomic, strong, nullable) void (^resumeDataBlock)(NSData *);
 
 // Return the status code from the server response.
 @property(atomic, readonly) NSInteger statusCode;
 
 // Return the http headers from the response.
-@property(atomic, strong, readonly, GTM_NULLABLE) GTM_NSDictionaryOf(NSString *, NSString *) *
+@property(atomic, strong, readonly, nullable) GTM_NSDictionaryOf(NSString *, NSString *) *
     responseHeaders;
 
 // The response, once it's been received.
-@property(atomic, strong, readonly, GTM_NULLABLE) NSURLResponse *response;
+@property(atomic, strong, readonly, nullable) NSURLResponse *response;
 
 // Bytes downloaded so far.
 @property(atomic, readonly) int64_t downloadedLength;
 
 // Buffer of currently-downloaded data, if available.
-@property(atomic, readonly, strong, GTM_NULLABLE) NSData *downloadedData;
+@property(atomic, readonly, strong, nullable) NSData *downloadedData;
 
 // Local path to which the downloaded file will be moved.
 //
 // If a file already exists at the path, it will be overwritten.
 // Will create the enclosing folders if they are not present.
-@property(atomic, strong, GTM_NULLABLE) NSURL *destinationFileURL;
+@property(atomic, strong, nullable) NSURL *destinationFileURL;
 
 // The time this fetcher originally began fetching. This is useful as a time
 // barrier for ignoring irrelevant fetch notifications or callbacks.
-@property(atomic, strong, readonly, GTM_NULLABLE) NSDate *initialBeginFetchDate;
+@property(atomic, strong, readonly, nullable) NSDate *initialBeginFetchDate;
 
 // userData is retained solely for the convenience of the client.
-@property(atomic, strong, GTM_NULLABLE) id userData;
+@property(atomic, strong, nullable) id userData;
 
 // Stored property values are retained solely for the convenience of the client.
-@property(atomic, copy, GTM_NULLABLE) GTM_NSDictionaryOf(NSString *, id) * properties;
+@property(atomic, copy, nullable) GTM_NSDictionaryOf(NSString *, id) *properties;
 
-- (void)setProperty:(GTM_NULLABLE id)obj
+- (void)setProperty:(nullable id)obj
              forKey:(NSString *)key;  // Pass nil for obj to remove the property.
-- (GTM_NULLABLE id)propertyForKey:(NSString *)key;
+- (nullable id)propertyForKey:(NSString *)key;
 
 - (void)addPropertiesFromDictionary:(GTM_NSDictionaryOf(NSString *, id) *)dict;
 
 // Comments are useful for logging, so are strongly recommended for each fetcher.
-@property(atomic, copy, GTM_NULLABLE) NSString *comment;
+@property(atomic, copy, nullable) NSString *comment;
 
 - (void)setCommentWithFormat:(NSString *)format, ... NS_FORMAT_FUNCTION(1, 2);
 
 // Log of request and response, if logging is enabled
-@property(atomic, copy, GTM_NULLABLE) NSString *log;
+@property(atomic, copy, nullable) NSString *log;
 
 // Callbacks are run on this queue.  If none is supplied, the main queue is used.
-@property(atomic, strong, GTM_NULL_RESETTABLE) dispatch_queue_t callbackQueue;
+@property(atomic, strong, null_resettable) dispatch_queue_t callbackQueue;
 
 // The queue used internally by the session to invoke its delegate methods in the fetcher.
 //
@@ -1158,7 +1130,7 @@ NSData *GTM_NULLABLE_TYPE GTMDataFromInputStream(NSInputStream *inputStream, NSE
 // This value is ignored after the session has been created, so this
 // property should be set in the fetcher service rather in the fetcher as it applies
 // to a shared session.
-@property(atomic, strong, GTM_NULL_RESETTABLE) NSOperationQueue *sessionDelegateQueue;
+@property(atomic, strong, null_resettable) NSOperationQueue *sessionDelegateQueue;
 
 // DEPRECATED: Callers should use XCTestExpectation instead.
 //
@@ -1187,9 +1159,9 @@ NSData *GTM_NULLABLE_TYPE GTMDataFromInputStream(NSInputStream *inputStream, NSE
 // should proceed.
 //
 // Applications can exclude test block support by setting GTM_DISABLE_FETCHER_TEST_BLOCK.
-@property(atomic, copy, GTM_NULLABLE) GTMSessionFetcherTestBlock testBlock;
+@property(atomic, copy, nullable) GTMSessionFetcherTestBlock testBlock;
 
-+ (void)setGlobalTestBlock:(GTM_NULLABLE GTMSessionFetcherTestBlock)block;
++ (void)setGlobalTestBlock:(nullable GTMSessionFetcherTestBlock)block;
 
 // When using the testBlock, |testBlockAccumulateDataChunkCount| is the desired number of chunks to
 // divide the response data into if the client has streaming enabled. The data will be divided up to
@@ -1229,14 +1201,14 @@ NSData *GTM_NULLABLE_TYPE GTMDataFromInputStream(NSInputStream *inputStream, NSE
 //      fetcher.deferResponseBodyLogging = NO;
 //   }];
 
-@property(atomic, copy, GTM_NULLABLE) NSString *logRequestBody;
+@property(atomic, copy, nullable) NSString *logRequestBody;
 @property(atomic, assign) BOOL deferResponseBodyLogging;
-@property(atomic, copy, GTM_NULLABLE) NSString *logResponseBody;
+@property(atomic, copy, nullable) NSString *logResponseBody;
 
 // Internal logging support.
 @property(atomic, readonly) NSData *loggedStreamData;
 @property(atomic, assign) BOOL hasLoggedError;
-@property(atomic, strong, GTM_NULLABLE) NSURL *redirectedFromURL;
+@property(atomic, strong, nullable) NSURL *redirectedFromURL;
 - (void)appendLoggedStreamData:(NSData *)dataToAdd;
 - (void)clearLoggedStreamData;
 
@@ -1260,7 +1232,7 @@ NSData *GTM_NULLABLE_TYPE GTMDataFromInputStream(NSInputStream *inputStream, NSE
 
 // Add the array off cookies to the storage, replacing duplicates.
 // Also removes expired cookies from the storage.
-- (void)setCookies:(GTM_NULLABLE GTM_NSArrayOf(NSHTTPCookie *) *)cookies;
+- (void)setCookies:(nullable GTM_NSArrayOf(NSHTTPCookie *) *)cookies;
 
 - (void)removeAllCookies;
 
@@ -1347,7 +1319,7 @@ NSData *GTM_NULLABLE_TYPE GTMDataFromInputStream(NSInputStream *inputStream, NSE
                                allowRecursive:(BOOL)allowRecursive
                                  functionName:(const char *)functionName;
 // Return the names of the functions that hold sync on the object, or nil if none.
-+ (NSArray *GTM_NULLABLE_TYPE)functionsHoldingSynchronizationOnObject:(id)object;
++ (nullable NSArray *)functionsHoldingSynchronizationOnObject:(id)object;
 @end
 
 #else
@@ -1366,4 +1338,4 @@ NSData *GTM_NULLABLE_TYPE GTMDataFromInputStream(NSInputStream *inputStream, NSE
 #endif  // !DEBUG
 #endif  // __OBJC__
 
-GTM_ASSUME_NONNULL_END
+NS_ASSUME_NONNULL_END

--- a/Source/GTMSessionFetcher.m
+++ b/Source/GTMSessionFetcher.m
@@ -4244,7 +4244,7 @@ static NSMutableDictionary *gSystemCompletionHandlers = nil;
 }
 
 - (void)getCookiesForTask:(NSURLSessionTask *)task
-        completionHandler:(void (^)(GTM_NSArrayOf(NSHTTPCookie *) *))completionHandler {
+        completionHandler:(void (^)(NSArray<NSHTTPCookie *> *))completionHandler {
   if (completionHandler) {
     NSURLRequest *currentRequest = task.currentRequest;
     NSURL *currentRequestURL = currentRequest.URL;

--- a/Source/GTMSessionFetcher.m
+++ b/Source/GTMSessionFetcher.m
@@ -105,7 +105,7 @@ GTM_ASSUME_NONNULL_END
      (TARGET_OS_IOS && defined(__IPHONE_13_0) &&                                                  \
       __IPHONE_OS_VERSION_MIN_REQUIRED >= __IPHONE_13_0) ||                                       \
      (TARGET_OS_WATCH && defined(__WATCHOS_6_0) &&                                                \
-      __WATCHOS_VERSION_MIN_REQUIRED >= __WATCHOS_6_0) ||                                         \
+      __WATCH_OS_VERSION_MIN_REQUIRED >= __WATCHOS_6_0) ||                                         \
      (TARGET_OS_TV && defined(__TVOS_13_0) && __TVOS_VERSION_MIN_REQUIRED >= __TVOS_13_0))
 #define GTM_SDK_REQUIRES_TLSMINIMUMSUPPORTEDPROTOCOLVERSION 1
 #define GTM_SDK_SUPPORTS_TLSMINIMUMSUPPORTEDPROTOCOLVERSION 1
@@ -113,7 +113,7 @@ GTM_ASSUME_NONNULL_END
        (TARGET_OS_IOS && defined(__IPHONE_13_0) &&                                                 \
         __IPHONE_OS_VERSION_MAX_ALLOWED >= __IPHONE_13_0) ||                                       \
        (TARGET_OS_WATCH && defined(__WATCHOS_6_0) &&                                               \
-        __WATCHOS_VERSION_MAX_ALLOWED >= __WATCHOS_6_0) ||                                         \
+        __WATCH_OS_VERSION_MAX_ALLOWED >= __WATCHOS_6_0) ||                                         \
        (TARGET_OS_TV && defined(__TVOS_13_0) && __TVOS_VERSION_MAX_ALLOWED >= __TVOS_13_0))
 #define GTM_SDK_REQUIRES_TLSMINIMUMSUPPORTEDPROTOCOLVERSION 0
 #define GTM_SDK_SUPPORTS_TLSMINIMUMSUPPORTEDPROTOCOLVERSION 1
@@ -127,7 +127,7 @@ GTM_ASSUME_NONNULL_END
      (TARGET_OS_IOS && defined(__IPHONE_13_0) &&                                                  \
       __IPHONE_OS_VERSION_MIN_REQUIRED >= __IPHONE_13_0) ||                                       \
      (TARGET_OS_WATCH && defined(__WATCHOS_6_0) &&                                                \
-      __WATCHOS_VERSION_MIN_REQUIRED >= __WATCHOS_6_0) ||                                         \
+      __WATCH_OS_VERSION_MIN_REQUIRED >= __WATCHOS_6_0) ||                                         \
      (TARGET_OS_TV && defined(__TVOS_13_0) && __TVOS_VERSION_MIN_REQUIRED >= __TVOS_13_0))
 #define GTM_SDK_REQUIRES_SECTRUSTEVALUATEWITHERROR 1
 #else
@@ -660,19 +660,8 @@ static GTMSessionFetcherTestBlock GTM_NULLABLE_TYPE gGlobalTestBlock;
         NSMapTable *sessionIdentifierToFetcherMap = [[self class] sessionIdentifierToFetcherMap];
         [sessionIdentifierToFetcherMap setObject:self forKey:self.sessionIdentifier];
 
-        if (@available(iOS 8.0, tvOS 9.0, watchOS 2.0, macOS 10.10, *)) {
-          _configuration = [NSURLSessionConfiguration
-              backgroundSessionConfigurationWithIdentifier:sessionIdentifier];
-        } else {
-#if ((!TARGET_OS_IPHONE && MAC_OS_X_VERSION_MIN_REQUIRED < MAC_OS_X_VERSION_10_10) || \
-     (TARGET_OS_IPHONE && __IPHONE_OS_VERSION_MIN_REQUIRED < __IPHONE_8_0))
-          // If building with support for iOS 7 or < macOS 10.10, allow using the older
-          // -backgroundSessionConfiguration: method, otherwise leave it out to avoid deprecated
-          // API warnings/errors.
-          _configuration =
-              [NSURLSessionConfiguration backgroundSessionConfiguration:sessionIdentifier];
-#endif
-        }
+        _configuration = [NSURLSessionConfiguration
+            backgroundSessionConfigurationWithIdentifier:sessionIdentifier];
         self.usingBackgroundSession = YES;
         self.canShareSession = NO;
       } else {
@@ -886,9 +875,7 @@ static GTMSessionFetcherTestBlock GTM_NULLABLE_TYPE gGlobalTestBlock;
     newSessionTask.taskDescription = _taskDescription;
   }
   if (_taskPriority >= 0) {
-    if (@available(iOS 8.0, macOS 10.10, *)) {
-      newSessionTask.priority = _taskPriority;
-    }
+    newSessionTask.priority = _taskPriority;
   }
 
 #if GTM_DISABLE_FETCHER_TEST_BLOCK
@@ -1843,7 +1830,7 @@ NSData *GTM_NULLABLE_TYPE GTMDataFromInputStream(NSInputStream *inputStream, NSE
   self.retryBlock = nil;
   self.testBlock = nil;
   self.resumeDataBlock = nil;
-  if (@available(iOS 10.0, macOS 10.12, tvOS 10.0, watchOS 3.0, *)) {
+  if (@available(iOS 10.0, *)) {
     self.metricsCollectionBlock = nil;
   }
 }

--- a/Source/GTMSessionFetcherCore.xcodeproj/project.pbxproj
+++ b/Source/GTMSessionFetcherCore.xcodeproj/project.pbxproj
@@ -1136,10 +1136,10 @@
 				GCC_WARN_UNUSED_FUNCTION = YES;
 				GCC_WARN_UNUSED_VARIABLE = YES;
 				IPHONEOS_DEPLOYMENT_TARGET = 9.0;
-				MACOSX_DEPLOYMENT_TARGET = 10.9;
+				MACOSX_DEPLOYMENT_TARGET = 10.12;
 				ONLY_ACTIVE_ARCH = YES;
 				SDKROOT = macosx;
-				TVOS_DEPLOYMENT_TARGET = 9.0;
+				TVOS_DEPLOYMENT_TARGET = 10.0;
 				WARNING_CFLAGS = (
 					"-Werror",
 					"-Wextra",
@@ -1162,7 +1162,7 @@
 					"-Widiomatic-parentheses",
 					"-Wimplicit-atomic-properties",
 				);
-				WATCHOS_DEPLOYMENT_TARGET = 2.0;
+				WATCHOS_DEPLOYMENT_TARGET = 6.0;
 			};
 			name = Debug;
 		};
@@ -1217,9 +1217,9 @@
 				GCC_WARN_UNUSED_FUNCTION = YES;
 				GCC_WARN_UNUSED_VARIABLE = YES;
 				IPHONEOS_DEPLOYMENT_TARGET = 9.0;
-				MACOSX_DEPLOYMENT_TARGET = 10.9;
+				MACOSX_DEPLOYMENT_TARGET = 10.12;
 				SDKROOT = macosx;
-				TVOS_DEPLOYMENT_TARGET = 9.0;
+				TVOS_DEPLOYMENT_TARGET = 10.0;
 				WARNING_CFLAGS = (
 					"-Werror",
 					"-Wextra",
@@ -1242,7 +1242,7 @@
 					"-Widiomatic-parentheses",
 					"-Wimplicit-atomic-properties",
 				);
-				WATCHOS_DEPLOYMENT_TARGET = 2.0;
+				WATCHOS_DEPLOYMENT_TARGET = 6.0;
 			};
 			name = Release;
 		};
@@ -1299,7 +1299,6 @@
 				FRAMEWORK_VERSION = A;
 				INFOPLIST_FILE = GTMSessionFetcherOSX/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/../Frameworks @loader_path/Frameworks";
-				MACOSX_DEPLOYMENT_TARGET = 10.9;
 				PRODUCT_BUNDLE_IDENTIFIER = com.google.GTMSessionFetcherOSX;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SKIP_INSTALL = YES;
@@ -1318,7 +1317,6 @@
 				FRAMEWORK_VERSION = A;
 				INFOPLIST_FILE = GTMSessionFetcherOSX/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/../Frameworks @loader_path/Frameworks";
-				MACOSX_DEPLOYMENT_TARGET = 10.9;
 				PRODUCT_BUNDLE_IDENTIFIER = com.google.GTMSessionFetcherOSX;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SKIP_INSTALL = YES;

--- a/Source/GTMSessionFetcherService.h
+++ b/Source/GTMSessionFetcherService.h
@@ -22,7 +22,7 @@
 
 #import "GTMSessionFetcher.h"
 
-GTM_ASSUME_NONNULL_BEGIN
+NS_ASSUME_NONNULL_BEGIN
 
 // Notifications.
 
@@ -38,9 +38,9 @@ extern NSString *const kGTMSessionFetcherServiceSessionKey;
 
 // Queues of delayed and running fetchers. Each dictionary contains arrays
 // of GTMSessionFetcher *fetchers, keyed by NSString *host
-@property(atomic, strong, readonly, GTM_NULLABLE) GTM_NSDictionaryOf(NSString *, NSArray *) *
+@property(atomic, strong, readonly, nullable) GTM_NSDictionaryOf(NSString *, NSArray *) *
     delayedFetchersByHost;
-@property(atomic, strong, readonly, GTM_NULLABLE) GTM_NSDictionaryOf(NSString *, NSArray *) *
+@property(atomic, strong, readonly, nullable) GTM_NSDictionaryOf(NSString *, NSArray *) *
     runningFetchersByHost;
 
 // A max value of 0 means no fetchers should be delayed.
@@ -50,22 +50,22 @@ extern NSString *const kGTMSessionFetcherServiceSessionKey;
 @property(atomic, assign) NSUInteger maxRunningFetchersPerHost;
 
 // Properties to be applied to each fetcher; see GTMSessionFetcher.h for descriptions
-@property(atomic, strong, GTM_NULLABLE) NSURLSessionConfiguration *configuration;
-@property(atomic, copy, GTM_NULLABLE) GTMSessionFetcherConfigurationBlock configurationBlock;
-@property(atomic, strong, GTM_NULLABLE) NSHTTPCookieStorage *cookieStorage;
-@property(atomic, strong, GTM_NULL_RESETTABLE) dispatch_queue_t callbackQueue;
-@property(atomic, copy, GTM_NULLABLE) GTMSessionFetcherChallengeBlock challengeBlock;
-@property(atomic, strong, GTM_NULLABLE) NSURLCredential *credential;
+@property(atomic, strong, nullable) NSURLSessionConfiguration *configuration;
+@property(atomic, copy, nullable) GTMSessionFetcherConfigurationBlock configurationBlock;
+@property(atomic, strong, nullable) NSHTTPCookieStorage *cookieStorage;
+@property(atomic, strong, null_resettable) dispatch_queue_t callbackQueue;
+@property(atomic, copy, nullable) GTMSessionFetcherChallengeBlock challengeBlock;
+@property(atomic, strong, nullable) NSURLCredential *credential;
 @property(atomic, strong) NSURLCredential *proxyCredential;
-@property(atomic, copy, GTM_NULLABLE) GTM_NSArrayOf(NSString *) * allowedInsecureSchemes;
+@property(atomic, copy, nullable) GTM_NSArrayOf(NSString *) *allowedInsecureSchemes;
 @property(atomic, assign) BOOL allowLocalhostRequest;
 @property(atomic, assign) BOOL allowInvalidServerCertificates;
 @property(atomic, assign, getter=isRetryEnabled) BOOL retryEnabled;
-@property(atomic, copy, GTM_NULLABLE) GTMSessionFetcherRetryBlock retryBlock;
+@property(atomic, copy, nullable) GTMSessionFetcherRetryBlock retryBlock;
 @property(atomic, assign) NSTimeInterval maxRetryInterval;
 @property(atomic, assign) NSTimeInterval minRetryInterval;
-@property(atomic, copy, GTM_NULLABLE) GTM_NSDictionaryOf(NSString *, id) * properties;
-@property(atomic, copy, GTM_NULLABLE)
+@property(atomic, copy, nullable) GTM_NSDictionaryOf(NSString *, id) *properties;
+@property(atomic, copy, nullable)
     GTMSessionFetcherMetricsCollectionBlock metricsCollectionBlock API_AVAILABLE(
         ios(10.0), macosx(10.12), tvos(10.0), watchos(3.0));
 
@@ -78,17 +78,17 @@ extern NSString *const kGTMSessionFetcherServiceSessionKey;
 // This default will be added starting with builds with the SDKs for OS X 10.11 and iOS 9.
 //
 // To use the configuration's default user agent, set this property to nil.
-@property(atomic, copy, GTM_NULLABLE) NSString *userAgent;
+@property(atomic, copy, nullable) NSString *userAgent;
 
 // The authorizer to attach to the created fetchers. If a specific fetcher should
 // not authorize its requests, the fetcher's authorizer property may be set to nil
 // before the fetch begins.
-@property(atomic, strong, GTM_NULLABLE) id<GTMFetcherAuthorizationProtocol> authorizer;
+@property(atomic, strong, nullable) id<GTMFetcherAuthorizationProtocol> authorizer;
 
 // Delegate queue used by the session when calling back to the fetcher.  The default
 // is the main queue.  Changing this does not affect the queue used to call back to the
 // application; that is specified by the callbackQueue property above.
-@property(atomic, strong, GTM_NULL_RESETTABLE) NSOperationQueue *sessionDelegateQueue;
+@property(atomic, strong, null_resettable) NSOperationQueue *sessionDelegateQueue;
 
 // When enabled, indicates the same session should be used by subsequent fetchers.
 //
@@ -134,25 +134,24 @@ extern NSString *const kGTMSessionFetcherServiceSessionKey;
 // by the service which have been started and have not yet stopped.
 //
 // Returns an array of fetcher objects, or nil if none.
-- (GTM_NULLABLE GTM_NSArrayOf(GTMSessionFetcher *) *)issuedFetchers;
+- (nullable GTM_NSArrayOf(GTMSessionFetcher *) *)issuedFetchers;
 
 // Search for running or delayed fetchers with the specified URL.
 //
 // Returns an array of fetcher objects found, or nil if none found.
-- (GTM_NULLABLE GTM_NSArrayOf(GTMSessionFetcher *) *)issuedFetchersWithRequestURL:
-    (NSURL *)requestURL;
+- (nullable GTM_NSArrayOf(GTMSessionFetcher *) *)issuedFetchersWithRequestURL:(NSURL *)requestURL;
 
 - (void)stopAllFetchers;
 
 // Methods for use by the fetcher class only.
-- (GTM_NULLABLE NSURLSession *)session;
-- (GTM_NULLABLE NSURLSession *)sessionForFetcherCreation;
-- (GTM_NULLABLE id<NSURLSessionDelegate>)sessionDelegate;
-- (GTM_NULLABLE NSDate *)stoppedAllFetchersDate;
+- (nullable NSURLSession *)session;
+- (nullable NSURLSession *)sessionForFetcherCreation;
+- (nullable id<NSURLSessionDelegate>)sessionDelegate;
+- (nullable NSDate *)stoppedAllFetchersDate;
 
 // The testBlock can inspect its fetcher parameter's request property to
 // determine which fetcher is being faked.
-@property(atomic, copy, GTM_NULLABLE) GTMSessionFetcherTestBlock testBlock;
+@property(atomic, copy, nullable) GTMSessionFetcherTestBlock testBlock;
 
 @end
 
@@ -168,11 +167,11 @@ extern NSString *const kGTMSessionFetcherServiceSessionKey;
 // or fetcher; the test block can inspect the fetcher's request or other properties.
 //
 // See the description of the testBlock property below.
-+ (instancetype)mockFetcherServiceWithFakedData:(GTM_NULLABLE NSData *)fakedDataOrNil
-                                     fakedError:(GTM_NULLABLE NSError *)fakedErrorOrNil;
-+ (instancetype)mockFetcherServiceWithFakedData:(GTM_NULLABLE NSData *)fakedDataOrNil
++ (instancetype)mockFetcherServiceWithFakedData:(nullable NSData *)fakedDataOrNil
+                                     fakedError:(nullable NSError *)fakedErrorOrNil;
++ (instancetype)mockFetcherServiceWithFakedData:(nullable NSData *)fakedDataOrNil
                                   fakedResponse:(NSHTTPURLResponse *)fakedResponse
-                                     fakedError:(GTM_NULLABLE NSError *)fakedErrorOrNil;
+                                     fakedError:(nullable NSError *)fakedErrorOrNil;
 
 // DEPRECATED: Callers should use XCTestExpectation instead.
 //
@@ -198,4 +197,4 @@ extern NSString *const kGTMSessionFetcherServiceSessionKey;
 
 @end
 
-GTM_ASSUME_NONNULL_END
+NS_ASSUME_NONNULL_END

--- a/Source/GTMSessionFetcherService.h
+++ b/Source/GTMSessionFetcherService.h
@@ -38,10 +38,10 @@ extern NSString *const kGTMSessionFetcherServiceSessionKey;
 
 // Queues of delayed and running fetchers. Each dictionary contains arrays
 // of GTMSessionFetcher *fetchers, keyed by NSString *host
-@property(atomic, strong, readonly, nullable) GTM_NSDictionaryOf(NSString *, NSArray *) *
-    delayedFetchersByHost;
-@property(atomic, strong, readonly, nullable) GTM_NSDictionaryOf(NSString *, NSArray *) *
-    runningFetchersByHost;
+@property(atomic, strong, readonly, nullable)
+    NSDictionary<NSString *, NSArray *> *delayedFetchersByHost;
+@property(atomic, strong, readonly, nullable)
+    NSDictionary<NSString *, NSArray *> *runningFetchersByHost;
 
 // A max value of 0 means no fetchers should be delayed.
 // The default limit is 10 simultaneous fetchers targeting each host.
@@ -57,14 +57,14 @@ extern NSString *const kGTMSessionFetcherServiceSessionKey;
 @property(atomic, copy, nullable) GTMSessionFetcherChallengeBlock challengeBlock;
 @property(atomic, strong, nullable) NSURLCredential *credential;
 @property(atomic, strong) NSURLCredential *proxyCredential;
-@property(atomic, copy, nullable) GTM_NSArrayOf(NSString *) *allowedInsecureSchemes;
+@property(atomic, copy, nullable) NSArray<NSString *> *allowedInsecureSchemes;
 @property(atomic, assign) BOOL allowLocalhostRequest;
 @property(atomic, assign) BOOL allowInvalidServerCertificates;
 @property(atomic, assign, getter=isRetryEnabled) BOOL retryEnabled;
 @property(atomic, copy, nullable) GTMSessionFetcherRetryBlock retryBlock;
 @property(atomic, assign) NSTimeInterval maxRetryInterval;
 @property(atomic, assign) NSTimeInterval minRetryInterval;
-@property(atomic, copy, nullable) GTM_NSDictionaryOf(NSString *, id) *properties;
+@property(atomic, copy, nullable) NSDictionary<NSString *, id> *properties;
 @property(atomic, copy, nullable)
     GTMSessionFetcherMetricsCollectionBlock metricsCollectionBlock API_AVAILABLE(
         ios(10.0), macosx(10.12), tvos(10.0), watchos(3.0));
@@ -134,12 +134,12 @@ extern NSString *const kGTMSessionFetcherServiceSessionKey;
 // by the service which have been started and have not yet stopped.
 //
 // Returns an array of fetcher objects, or nil if none.
-- (nullable GTM_NSArrayOf(GTMSessionFetcher *) *)issuedFetchers;
+- (nullable NSArray<GTMSessionFetcher *> *)issuedFetchers;
 
 // Search for running or delayed fetchers with the specified URL.
 //
 // Returns an array of fetcher objects found, or nil if none found.
-- (nullable GTM_NSArrayOf(GTMSessionFetcher *) *)issuedFetchersWithRequestURL:(NSURL *)requestURL;
+- (nullable NSArray<GTMSessionFetcher *> *)issuedFetchersWithRequestURL:(NSURL *)requestURL;
 
 - (void)stopAllFetchers;
 

--- a/Source/GTMSessionFetcherService.m
+++ b/Source/GTMSessionFetcherService.m
@@ -25,7 +25,8 @@ NSString *const kGTMSessionFetcherServiceSessionKey = @"kGTMSessionFetcherServic
 
 #if !GTMSESSION_BUILD_COMBINED_SOURCES
 @interface GTMSessionFetcher (ServiceMethods)
-- (BOOL)beginFetchMayDelay:(BOOL)mayDelay mayAuthorize:(BOOL)mayAuthorize;
+- (BOOL)beginFetchMayDelay:(BOOL)mayDelay
+              mayAuthorize:(BOOL)mayAuthorize;
 @end
 #endif  // !GTMSESSION_BUILD_COMBINED_SOURCES
 
@@ -803,7 +804,7 @@ NSString *const kGTMSessionFetcherServiceSessionKey = @"kGTMSessionFetcherServic
   }
 }
 
-- (dispatch_queue_t GTM_NONNULL_TYPE)callbackQueue {
+- (nonnull dispatch_queue_t)callbackQueue {
   @synchronized(self) {
     GTMSessionMonitorSynchronized(self);
 
@@ -811,7 +812,7 @@ NSString *const kGTMSessionFetcherServiceSessionKey = @"kGTMSessionFetcherServic
   }  // @synchronized(self)
 }
 
-- (void)setCallbackQueue:(dispatch_queue_t GTM_NULLABLE_TYPE)queue {
+- (void)setCallbackQueue:(dispatch_queue_t)queue {
   @synchronized(self) {
     GTMSessionMonitorSynchronized(self);
 
@@ -819,7 +820,7 @@ NSString *const kGTMSessionFetcherServiceSessionKey = @"kGTMSessionFetcherServic
   }  // @synchronized(self)
 }
 
-- (NSOperationQueue *GTM_NONNULL_TYPE)sessionDelegateQueue {
+- (NSOperationQueue *)sessionDelegateQueue {
   @synchronized(self) {
     GTMSessionMonitorSynchronized(self);
 
@@ -827,7 +828,7 @@ NSString *const kGTMSessionFetcherServiceSessionKey = @"kGTMSessionFetcherServic
   }  // @synchronized(self)
 }
 
-- (void)setSessionDelegateQueue:(NSOperationQueue *GTM_NULLABLE_TYPE)queue {
+- (void)setSessionDelegateQueue:(NSOperationQueue *)queue {
   @synchronized(self) {
     GTMSessionMonitorSynchronized(self);
 

--- a/Source/GTMSessionFetcherService.m
+++ b/Source/GTMSessionFetcherService.m
@@ -173,7 +173,7 @@ NSString *const kGTMSessionFetcherServiceSessionKey = @"kGTMSessionFetcherServic
   fetcher.retryBlock = self.retryBlock;
   fetcher.maxRetryInterval = self.maxRetryInterval;
   fetcher.minRetryInterval = self.minRetryInterval;
-  if (@available(iOS 10.0, macOS 10.12, tvOS 10.0, watchOS 3.0, *)) {
+  if (@available(iOS 10.0, *)) {
     fetcher.metricsCollectionBlock = self.metricsCollectionBlock;
   }
   fetcher.properties = self.properties;

--- a/Source/GTMSessionUploadFetcher.h
+++ b/Source/GTMSessionUploadFetcher.h
@@ -40,7 +40,7 @@
 #import "GTMSessionFetcher.h"
 #import "GTMSessionFetcherService.h"
 
-GTM_ASSUME_NONNULL_BEGIN
+NS_ASSUME_NONNULL_BEGIN
 
 // The value to use for file size parameters when the file size is not yet known.
 extern int64_t const kGTMSessionUploadFetcherUnknownFileSize;
@@ -68,9 +68,9 @@ extern NSString *const kGTMSessionFetcherUploadLocationObtainedNotification;
 // to its proper value.
 //
 // Pass nil as the data (and optionally an NSError) for a failure.
-typedef void (^GTMSessionUploadFetcherDataProviderResponse)(NSData *GTM_NULLABLE_TYPE data,
+typedef void (^GTMSessionUploadFetcherDataProviderResponse)(NSData *_Nullable data,
                                                             int64_t fullUploadLength,
-                                                            NSError *GTM_NULLABLE_TYPE error);
+                                                            NSError *_Nullable error);
 // Do not call the response with an NSData object with less data than the requested length unless
 // you are passing the fullUploadLength to the fetcher for the first time and it is the last chunk
 // of data in the file being uploaded.
@@ -82,9 +82,9 @@ typedef void (^GTMSessionUploadFetcherDataProvider)(
 // |fetcher| will be the cancel request that was sent to the server, or nil if stopFetching is not
 // going to send a cancel request. If |fetcher| is provided, the other parameters correspond to the
 // completion handler of the cancellation request fetcher.
-typedef void (^GTMSessionUploadFetcherCancellationHandler)(
-    GTMSessionFetcher *GTM_NULLABLE_TYPE fetcher, NSData *GTM_NULLABLE_TYPE data,
-    NSError *GTM_NULLABLE_TYPE error);
+typedef void (^GTMSessionUploadFetcherCancellationHandler)(GTMSessionFetcher *_Nullable fetcher,
+                                                           NSData *_Nullable data,
+                                                           NSError *_Nullable error);
 
 @interface GTMSessionUploadFetcher : GTMSessionFetcher
 
@@ -99,41 +99,37 @@ typedef void (^GTMSessionUploadFetcherCancellationHandler)(
 + (instancetype)uploadFetcherWithRequest:(NSURLRequest *)request
                           uploadMIMEType:(NSString *)uploadMIMEType
                                chunkSize:(int64_t)chunkSize
-                          fetcherService:
-                              (GTM_NULLABLE GTMSessionFetcherService *)fetcherServiceOrNil;
+                          fetcherService:(nullable GTMSessionFetcherService *)fetcherServiceOrNil;
 
 // Allows cellular access.
-+ (instancetype)uploadFetcherWithLocation:(NSURL *GTM_NULLABLE_TYPE)uploadLocationURL
++ (instancetype)uploadFetcherWithLocation:(nullable NSURL *)uploadLocationURL
                            uploadMIMEType:(NSString *)uploadMIMEType
                                 chunkSize:(int64_t)chunkSize
-                           fetcherService:
-                               (GTM_NULLABLE GTMSessionFetcherService *)fetcherServiceOrNil;
+                           fetcherService:(nullable GTMSessionFetcherService *)fetcherServiceOrNil;
 
-+ (instancetype)uploadFetcherWithLocation:(NSURL *GTM_NULLABLE_TYPE)uploadLocationURL
++ (instancetype)uploadFetcherWithLocation:(nullable NSURL *)uploadLocationURL
                            uploadMIMEType:(NSString *)uploadMIMEType
                                 chunkSize:(int64_t)chunkSize
                      allowsCellularAccess:(BOOL)allowsCellularAccess
-                           fetcherService:
-                               (GTM_NULLABLE GTMSessionFetcherService *)fetcherServiceOrNil;
+                           fetcherService:(nullable GTMSessionFetcherService *)fetcherServiceOrNil;
 
 // Allows dataProviders for files of unknown length. Pass kGTMSessionUploadFetcherUnknownFileSize as
 // |fullLength| if the length is unknown.
 - (void)setUploadDataLength:(int64_t)fullLength
-                   provider:(GTM_NULLABLE GTMSessionUploadFetcherDataProvider)block;
+                   provider:(nullable GTMSessionUploadFetcherDataProvider)block;
 
 + (NSArray *)uploadFetchersForBackgroundSessions;
-+ (GTM_NULLABLE instancetype)uploadFetcherForSessionIdentifier:(NSString *)sessionIdentifier;
++ (nullable instancetype)uploadFetcherForSessionIdentifier:(NSString *)sessionIdentifier;
 
 - (void)pauseFetching;
 - (void)resumeFetching;
 - (BOOL)isPaused;
 
-@property(atomic, strong, GTM_NULLABLE) NSURL *uploadLocationURL;
-@property(atomic, strong, GTM_NULLABLE) NSData *uploadData;
-@property(atomic, strong, GTM_NULLABLE) NSURL *uploadFileURL;
-@property(atomic, strong, GTM_NULLABLE) NSFileHandle *uploadFileHandle;
-@property(atomic, copy, readonly, GTM_NULLABLE)
-    GTMSessionUploadFetcherDataProvider uploadDataProvider;
+@property(atomic, strong, nullable) NSURL *uploadLocationURL;
+@property(atomic, strong, nullable) NSData *uploadData;
+@property(atomic, strong, nullable) NSURL *uploadFileURL;
+@property(atomic, strong, nullable) NSFileHandle *uploadFileHandle;
+@property(atomic, copy, readonly, nullable) GTMSessionUploadFetcherDataProvider uploadDataProvider;
 @property(atomic, copy) NSString *uploadMIMEType;
 @property(atomic, readonly, assign) int64_t chunkSize;
 @property(atomic, readonly, assign) int64_t currentOffset;
@@ -141,14 +137,14 @@ typedef void (^GTMSessionUploadFetcherCancellationHandler)(
 @property(atomic, readonly, assign) BOOL allowsCellularAccess;
 
 // The fetcher for the current data chunk, if any
-@property(atomic, strong, GTM_NULLABLE) GTMSessionFetcher *chunkFetcher;
+@property(atomic, strong, nullable) GTMSessionFetcher *chunkFetcher;
 
 // The active fetcher is the current chunk fetcher, or the upload fetcher itself
 // if no chunk fetcher has yet been created.
 @property(atomic, readonly) GTMSessionFetcher *activeFetcher;
 
 // The last request made by an active fetcher.  Useful for testing.
-@property(atomic, readonly, GTM_NULLABLE) NSURLRequest *lastChunkRequest;
+@property(atomic, readonly, nullable) NSURLRequest *lastChunkRequest;
 
 // The status code from the most recently-completed fetch.
 @property(atomic, assign) NSInteger statusCode;
@@ -160,20 +156,18 @@ typedef void (^GTMSessionUploadFetcherCancellationHandler)(
 // Unlike other callbacks, since this is related specifically to the stopFetching flow it is not
 // cleared by stopFetching. It will instead clear itself after it is invoked or if the completion
 // has occured before stopFetching is called.
-@property(atomic, copy, GTM_NULLABLE)
-    GTMSessionUploadFetcherCancellationHandler cancellationHandler;
+@property(atomic, copy, nullable) GTMSessionUploadFetcherCancellationHandler cancellationHandler;
 
 // Exposed for testing only.
-@property(atomic, readonly, GTM_NULLABLE) dispatch_queue_t delegateCallbackQueue;
-@property(atomic, readonly, GTM_NULLABLE)
-    GTMSessionFetcherCompletionHandler delegateCompletionHandler;
+@property(atomic, readonly, nullable) dispatch_queue_t delegateCallbackQueue;
+@property(atomic, readonly, nullable) GTMSessionFetcherCompletionHandler delegateCompletionHandler;
 
 @end
 
 @interface GTMSessionFetcher (GTMSessionUploadFetcherMethods)
 
-@property(readonly, GTM_NULLABLE) GTMSessionUploadFetcher *parentUploadFetcher;
+@property(readonly, nullable) GTMSessionUploadFetcher *parentUploadFetcher;
 
 @end
 
-GTM_ASSUME_NONNULL_END
+NS_ASSUME_NONNULL_END

--- a/Source/GTMSessionUploadFetcher.m
+++ b/Source/GTMSessionUploadFetcher.m
@@ -102,8 +102,7 @@ NSString *const kGTMSessionFetcherUploadLocationObtainedNotification =
 @property(atomic, readwrite, assign) int64_t currentOffset;
 
 // Internal properties.
-@property(strong, atomic, GTM_NULLABLE)
-    GTMSessionFetcher *fetcherInFlight;  // Synchronized on self.
+@property(strong, atomic, nullable) GTMSessionFetcher *fetcherInFlight;  // Synchronized on self.
 
 @property(assign, atomic, getter=isSubdataGenerating) BOOL subdataGenerating;
 @property(assign, atomic) BOOL shouldInitiateOffsetQuery;
@@ -198,11 +197,10 @@ NSString *const kGTMSessionFetcherUploadLocationObtainedNotification =
   return fetcher;
 }
 
-+ (instancetype)uploadFetcherWithLocation:(NSURL *GTM_NULLABLE_TYPE)uploadLocationURL
++ (instancetype)uploadFetcherWithLocation:(nullable NSURL *)uploadLocationURL
                            uploadMIMEType:(NSString *)uploadMIMEType
                                 chunkSize:(int64_t)chunkSize
-                           fetcherService:
-                               (GTM_NULLABLE GTMSessionFetcherService *)fetcherServiceOrNil {
+                           fetcherService:(nullable GTMSessionFetcherService *)fetcherServiceOrNil {
   return [self uploadFetcherWithLocation:uploadLocationURL
                           uploadMIMEType:uploadMIMEType
                                chunkSize:chunkSize
@@ -210,7 +208,7 @@ NSString *const kGTMSessionFetcherUploadLocationObtainedNotification =
                           fetcherService:fetcherServiceOrNil];
 }
 
-+ (instancetype)uploadFetcherWithLocation:(NSURL *GTM_NULLABLE_TYPE)uploadLocationURL
++ (instancetype)uploadFetcherWithLocation:(nullable NSURL *)uploadLocationURL
                            uploadMIMEType:(NSString *)uploadMIMEType
                                 chunkSize:(int64_t)chunkSize
                      allowsCellularAccess:(BOOL)allowsCellularAccess
@@ -558,7 +556,7 @@ NSString *const kGTMSessionFetcherUploadLocationObtainedNotification =
   [self setRequest:mutableRequest];
 }
 
-- (void)setLocationURL:(NSURL *GTM_NULLABLE_TYPE)location
+- (void)setLocationURL:(nullable NSURL *)location
           uploadMIMEType:(NSString *)uploadMIMEType
                chunkSize:(int64_t)chunkSize
     allowsCellularAccess:(BOOL)allowsCellularAccess {
@@ -822,7 +820,7 @@ NSString *const kGTMSessionFetcherUploadLocationObtainedNotification =
   }
 }
 
-- (void)setDelegateCallbackQueue:(dispatch_queue_t GTM_NULLABLE_TYPE)queue {
+- (void)setDelegateCallbackQueue:(nullable dispatch_queue_t)queue {
   @synchronized(self) {
     GTMSessionMonitorSynchronized(self);
 
@@ -830,7 +828,7 @@ NSString *const kGTMSessionFetcherUploadLocationObtainedNotification =
   }
 }
 
-- (dispatch_queue_t GTM_NULLABLE_TYPE)delegateCallbackQueue {
+- (nullable dispatch_queue_t)delegateCallbackQueue {
   @synchronized(self) {
     GTMSessionMonitorSynchronized(self);
 
@@ -846,7 +844,7 @@ NSString *const kGTMSessionFetcherUploadLocationObtainedNotification =
   }
 }
 
-- (GTMSessionFetcher *GTM_NULLABLE_TYPE)chunkFetcher {
+- (nullable GTMSessionFetcher *)chunkFetcher {
   @synchronized(self) {
     GTMSessionMonitorSynchronized(self);
 
@@ -854,7 +852,7 @@ NSString *const kGTMSessionFetcherUploadLocationObtainedNotification =
   }
 }
 
-- (void)setChunkFetcher:(GTMSessionFetcher *GTM_NULLABLE_TYPE)fetcher {
+- (void)setChunkFetcher:(nullable GTMSessionFetcher *)fetcher {
   @synchronized(self) {
     GTMSessionMonitorSynchronized(self);
 
@@ -862,7 +860,7 @@ NSString *const kGTMSessionFetcherUploadLocationObtainedNotification =
   }
 }
 
-- (void)setFetcherInFlight:(GTMSessionFetcher *GTM_NULLABLE_TYPE)fetcher {
+- (void)setFetcherInFlight:(nullable GTMSessionFetcher *)fetcher {
   @synchronized(self) {
     GTMSessionMonitorSynchronized(self);
 
@@ -870,7 +868,7 @@ NSString *const kGTMSessionFetcherUploadLocationObtainedNotification =
   }
 }
 
-- (GTMSessionFetcher *GTM_NULLABLE_TYPE)fetcherInFlight {
+- (nullable GTMSessionFetcher *)fetcherInFlight {
   @synchronized(self) {
     GTMSessionMonitorSynchronized(self);
 
@@ -879,7 +877,7 @@ NSString *const kGTMSessionFetcherUploadLocationObtainedNotification =
 }
 
 - (void)setCancellationHandler:
-    (GTMSessionUploadFetcherCancellationHandler GTM_NULLABLE_TYPE)cancellationHandler {
+    (nullable GTMSessionUploadFetcherCancellationHandler)cancellationHandler {
   @synchronized(self) {
     GTMSessionMonitorSynchronized(self);
 
@@ -887,7 +885,7 @@ NSString *const kGTMSessionFetcherUploadLocationObtainedNotification =
   }
 }
 
-- (GTMSessionUploadFetcherCancellationHandler GTM_NULLABLE_TYPE)cancellationHandler {
+- (nullable GTMSessionUploadFetcherCancellationHandler)cancellationHandler {
   @synchronized(self) {
     GTMSessionMonitorSynchronized(self);
 

--- a/Source/UnitTests/GTMSessionFetcherFetchingTest.h
+++ b/Source/UnitTests/GTMSessionFetcherFetchingTest.h
@@ -27,7 +27,7 @@
 #import "GTMSessionUploadFetcher.h"
 #endif
 
-GTM_ASSUME_NONNULL_BEGIN
+NS_ASSUME_NONNULL_BEGIN
 
 extern NSString *const kGTMGettysburgFileName;
 
@@ -69,7 +69,7 @@ extern NSString *const kGTMGettysburgFileName;
 @interface GTMSessionFetcher (FetchingTest)
 // During testing only, we may want to modify the request being fetched
 // after beginFetch has been called.
-- (GTM_NULLABLE NSMutableURLRequest *)mutableRequestForTesting;
+- (nullable NSMutableURLRequest *)mutableRequestForTesting;
 @end
 
 // Authorization testing.
@@ -134,4 +134,4 @@ extern NSString *const kSubUIAppBackgroundTaskEnded;
 
 @end
 
-GTM_ASSUME_NONNULL_END
+NS_ASSUME_NONNULL_END

--- a/Source/UnitTests/GTMSessionFetcherFetchingTest.m
+++ b/Source/UnitTests/GTMSessionFetcherFetchingTest.m
@@ -247,7 +247,7 @@ NSString *const kGTMGettysburgFileName = @"gettysburgaddress.txt";
   XCTAssertNil(fetcher.downloadProgressBlock);
   XCTAssertNil(fetcher.willCacheURLResponseBlock);
   XCTAssertNil(fetcher.retryBlock);
-  if (@available(iOS 10.0, macOS 10.12, tvOS 10.0, watchOS 3.0, *)) {
+  if (@available(iOS 10.0, *)) {
     XCTAssertNil(fetcher.metricsCollectionBlock);
   }
   XCTAssertNil(fetcher.testBlock);

--- a/Source/UnitTests/GTMSessionFetcherFetchingTest.m
+++ b/Source/UnitTests/GTMSessionFetcherFetchingTest.m
@@ -46,8 +46,8 @@ NSString *const kGTMGettysburgFileName = @"gettysburgaddress.txt";
                     timeout:5.0];
 
 @interface GTMSessionFetcher (ExposedForTesting)
-+ (GTM_NULLABLE NSURL *)redirectURLWithOriginalRequestURL:(GTM_NULLABLE NSURL *)originalRequestURL
-                                       redirectRequestURL:(GTM_NULLABLE NSURL *)redirectRequestURL;
++ (nullable NSURL *)redirectURLWithOriginalRequestURL:(nullable NSURL *)originalRequestURL
+                                   redirectRequestURL:(nullable NSURL *)redirectRequestURL;
 @end
 
 // Base class for fetcher and chunked upload tests.


### PR DESCRIPTION
Updates OS and Xcode version support as follows:

Xcode: 11.7+ (no specific changes for this, but no longer guaranteeing any support for pre-11.7 Xcode)
iOS: 9.0+
macOS: 10.12+
tvOS: 10.0+
watchOS: 6.0+

Updates code based on these changes:
- Removes `@available` checks for usage of SDK functions prior to these versions, and any `#if` conditional code.
- Replaces all usage of nullability and Objective-C generics macros with directly declaring nullability and generics.
