### PR TITLE
Clean up backwards-compatibility code and add deprecations.

### DIFF
--- a/Source/GTMSessionFetcher.h
+++ b/Source/GTMSessionFetcher.h
@@ -179,9 +179,8 @@
 // Note: cookies set while following redirects will be sent to the server, as
 // the redirects are followed by the fetcher.
 //
-// To completely disable cookies, similar to setting cookieStorageMethod to
-// kGTMHTTPFetcherCookieStorageMethodNone, adjust the session configuration
-// appropriately in the fetcher or fetcher service:
+// To completely disable cookies, adjust the session configuration appropriately
+// in the fetcher or fetcher service:
 //  fetcher.configurationBlock = ^(GTMSessionFetcher *configFetcher,
 //                                 NSURLSessionConfiguration *config) {
 //    config.HTTPCookieAcceptPolicy = NSHTTPCookieAcceptPolicyNever;
@@ -382,45 +381,6 @@
 
 #ifdef __cplusplus
 extern "C" {
-#endif
-
-#if (TARGET_OS_TV || TARGET_OS_WATCH ||                          \
-     (!TARGET_OS_IPHONE && defined(MAC_OS_X_VERSION_10_11) &&    \
-      MAC_OS_X_VERSION_MAX_ALLOWED >= MAC_OS_X_VERSION_10_11) || \
-     (TARGET_OS_IPHONE && defined(__IPHONE_9_0) &&               \
-      __IPHONE_OS_VERSION_MAX_ALLOWED >= __IPHONE_9_0))
-#ifndef GTM_USE_SESSION_FETCHER
-#define GTM_USE_SESSION_FETCHER 1
-#endif
-#endif
-
-#if !defined(GTMBridgeFetcher)
-// These bridge macros should be identical in GTMHTTPFetcher.h and GTMSessionFetcher.h
-#if GTM_USE_SESSION_FETCHER
-// Macros to new fetcher class.
-#define GTMBridgeFetcher GTMSessionFetcher
-#define GTMBridgeFetcherService GTMSessionFetcherService
-#define GTMBridgeFetcherServiceProtocol GTMSessionFetcherServiceProtocol
-#define GTMBridgeAssertValidSelector GTMSessionFetcherAssertValidSelector
-#define GTMBridgeCookieStorage GTMSessionCookieStorage
-#define GTMBridgeCleanedUserAgentString GTMFetcherCleanedUserAgentString
-#define GTMBridgeSystemVersionString GTMFetcherSystemVersionString
-#define GTMBridgeApplicationIdentifier GTMFetcherApplicationIdentifier
-#define kGTMBridgeFetcherStatusDomain kGTMSessionFetcherStatusDomain
-#define kGTMBridgeFetcherStatusBadRequest GTMSessionFetcherStatusBadRequest
-#else
-// Macros to old fetcher class.
-#define GTMBridgeFetcher GTMHTTPFetcher
-#define GTMBridgeFetcherService GTMHTTPFetcherService
-#define GTMBridgeFetcherServiceProtocol GTMHTTPFetcherServiceProtocol
-#define GTMBridgeAssertValidSelector GTMAssertSelectorNilOrImplementedWithArgs
-#define GTMBridgeCookieStorage GTMCookieStorage
-#define GTMBridgeCleanedUserAgentString GTMCleanedUserAgentString
-#define GTMBridgeSystemVersionString GTMSystemVersionString
-#define GTMBridgeApplicationIdentifier GTMApplicationIdentifier
-#define kGTMBridgeFetcherStatusDomain kGTMHTTPFetcherStatusDomain
-#define kGTMBridgeFetcherStatusBadRequest kGTMHTTPFetcherStatusBadRequest
-#endif  // GTM_USE_SESSION_FETCHER
 #endif
 
 // When creating background sessions to perform out-of-process uploads and
@@ -633,10 +593,6 @@ NSData *_Nullable GTMDataFromInputStream(NSInputStream *inputStream, NSError **o
 }  // extern "C"
 #endif
 
-#if !GTM_USE_SESSION_FETCHER
-@protocol GTMHTTPFetcherServiceProtocol;
-#endif
-
 // This protocol allows abstract references to the fetcher service, primarily for
 // fetchers (which may be compiled without the fetcher service class present.)
 //
@@ -661,7 +617,6 @@ NSData *_Nullable GTMDataFromInputStream(NSInputStream *inputStream, NSError **o
 - (nullable id<NSURLSessionDelegate>)sessionDelegate;
 - (nullable NSDate *)stoppedAllFetchersDate;
 
-// Methods for compatibility with the old GTMHTTPFetcher.
 @property(atomic, readonly, strong, nullable) NSOperationQueue *delegateQueue;
 
 @end  // @protocol GTMSessionFetcherServiceProtocol
@@ -699,11 +654,7 @@ NSData *_Nullable GTMDataFromInputStream(NSInputStream *inputStream, NSError **o
 - (void)authorizeRequest:(nullable NSMutableURLRequest *)request
        completionHandler:(void (^)(NSError *_Nullable error))handler;
 
-#if GTM_USE_SESSION_FETCHER
 @property(atomic, weak, nullable) id<GTMSessionFetcherServiceProtocol> fetcherService;
-#else
-@property(atomic, weak, nullable) id<GTMHTTPFetcherServiceProtocol> fetcherService;
-#endif
 
 - (BOOL)primeForRefresh;
 
@@ -1232,12 +1183,6 @@ NSData *_Nullable GTMDataFromInputStream(NSInputStream *inputStream, NSError **o
 
 #endif  // STRIP_GTM_FETCH_LOGGING
 
-@end
-
-@interface GTMSessionFetcher (BackwardsCompatibilityOnly)
-// Clients using GTMSessionFetcher should set the cookie storage explicitly themselves.
-// This method is just for compatibility with the old GTMHTTPFetcher class.
-- (void)setCookieStorageMethod:(NSInteger)method;
 @end
 
 // Until we can just instantiate NSHTTPCookieStorage for local use, we'll

--- a/Source/GTMSessionFetcher.h
+++ b/Source/GTMSessionFetcher.h
@@ -383,6 +383,21 @@
 extern "C" {
 #endif
 
+#if !defined(GTMBridgeFetcher)
+// The bridge macros are deprecated, and should be replaced; GTMHTTPFetcher is no longer supperted
+// and all code should switch to use GTMSessionFetcher types directly.
+#define GTMBridgeFetcher GTMSessionFetcher
+#define GTMBridgeFetcherService GTMSessionFetcherService
+#define GTMBridgeFetcherServiceProtocol GTMSessionFetcherServiceProtocol
+#define GTMBridgeAssertValidSelector GTMSessionFetcherAssertValidSelector
+#define GTMBridgeCookieStorage GTMSessionCookieStorage
+#define GTMBridgeCleanedUserAgentString GTMFetcherCleanedUserAgentString
+#define GTMBridgeSystemVersionString GTMFetcherSystemVersionString
+#define GTMBridgeApplicationIdentifier GTMFetcherApplicationIdentifier
+#define kGTMBridgeFetcherStatusDomain kGTMSessionFetcherStatusDomain
+#define kGTMBridgeFetcherStatusBadRequest GTMSessionFetcherStatusBadRequest
+#endif
+
 // When creating background sessions to perform out-of-process uploads and
 // downloads, on app launch any background sessions must be reconnected in
 // order to receive events that occurred while the app was not running.
@@ -1183,6 +1198,12 @@ NSData *_Nullable GTMDataFromInputStream(NSInputStream *inputStream, NSError **o
 
 #endif  // STRIP_GTM_FETCH_LOGGING
 
+@end
+
+@interface GTMSessionFetcher (BackwardsCompatibilityOnly)
+// Clients using GTMSessionFetcher should set the cookie storage explicitly themselves;
+// this method is deprecated and will be removed soon.
+- (void)setCookieStorageMethod:(NSInteger)method __deprecated_msg("Create an NSHTTPCookieStorage and set .cookieStorage directly.");
 @end
 
 // Until we can just instantiate NSHTTPCookieStorage for local use, we'll

--- a/Source/GTMSessionFetcher.h
+++ b/Source/GTMSessionFetcher.h
@@ -384,8 +384,8 @@ extern "C" {
 #endif
 
 #if !defined(GTMBridgeFetcher)
-// The bridge macros are deprecated, and should be replaced; GTMHTTPFetcher is no longer supperted
-// and all code should switch to use GTMSessionFetcher types directly.
+// The bridge macros are deprecated, and should be replaced; GTMHTTPFetcher is no longer
+// supported and all code should switch to use GTMSessionFetcher types directly.
 #define GTMBridgeFetcher GTMSessionFetcher
 #define GTMBridgeFetcherService GTMSessionFetcherService
 #define GTMBridgeFetcherServiceProtocol GTMSessionFetcherServiceProtocol

--- a/Source/GTMSessionFetcher.h
+++ b/Source/GTMSessionFetcher.h
@@ -1203,7 +1203,8 @@ NSData *_Nullable GTMDataFromInputStream(NSInputStream *inputStream, NSError **o
 @interface GTMSessionFetcher (BackwardsCompatibilityOnly)
 // Clients using GTMSessionFetcher should set the cookie storage explicitly themselves;
 // this method is deprecated and will be removed soon.
-- (void)setCookieStorageMethod:(NSInteger)method __deprecated_msg("Create an NSHTTPCookieStorage and set .cookieStorage directly.");
+- (void)setCookieStorageMethod:(NSInteger)method
+    __deprecated_msg("Create an NSHTTPCookieStorage and set .cookieStorage directly.");
 @end
 
 // Until we can just instantiate NSHTTPCookieStorage for local use, we'll

--- a/Source/GTMSessionFetcher.m
+++ b/Source/GTMSessionFetcher.m
@@ -4038,6 +4038,36 @@ static NSMutableDictionary *gSystemCompletionHandlers = nil;
 
 @end
 
+@implementation GTMSessionFetcher (BackwardsCompatibilityOnly)
+
+- (void)setCookieStorageMethod:(NSInteger)method {
+  // For backwards compatibility with the old fetcher, we'll support the old constants.
+  //
+  // Clients using the GTMSessionFetcher class should set the cookie storage explicitly
+  // themselves.
+  NSHTTPCookieStorage *storage = nil;
+  switch (method) {
+    case 0:  // kGTMHTTPFetcherCookieStorageMethodStatic
+             // nil storage will use [[self class] staticCookieStorage] when the fetch begins.
+      break;
+    case 1:  // kGTMHTTPFetcherCookieStorageMethodFetchHistory
+             // Do nothing; use whatever was set by the fetcher service.
+      return;
+    case 2:  // kGTMHTTPFetcherCookieStorageMethodSystemDefault
+      storage = [NSHTTPCookieStorage sharedHTTPCookieStorage];
+      break;
+    case 3:  // kGTMHTTPFetcherCookieStorageMethodNone
+             // Create temporary storage for this fetcher only.
+      storage = [[GTMSessionCookieStorage alloc] init];
+      break;
+    default:
+      GTMSESSION_ASSERT_DEBUG(0, @"Invalid cookie storage method: %d", (int)method);
+  }
+  self.cookieStorage = storage;
+}
+
+@end
+
 @implementation GTMSessionCookieStorage {
   NSMutableArray *_cookies;
   NSHTTPCookieAcceptPolicy _policy;

--- a/Source/GTMSessionFetcher.m
+++ b/Source/GTMSessionFetcher.m
@@ -4038,36 +4038,6 @@ static NSMutableDictionary *gSystemCompletionHandlers = nil;
 
 @end
 
-@implementation GTMSessionFetcher (BackwardsCompatibilityOnly)
-
-- (void)setCookieStorageMethod:(NSInteger)method {
-  // For backwards compatibility with the old fetcher, we'll support the old constants.
-  //
-  // Clients using the GTMSessionFetcher class should set the cookie storage explicitly
-  // themselves.
-  NSHTTPCookieStorage *storage = nil;
-  switch (method) {
-    case 0:  // kGTMHTTPFetcherCookieStorageMethodStatic
-             // nil storage will use [[self class] staticCookieStorage] when the fetch begins.
-      break;
-    case 1:  // kGTMHTTPFetcherCookieStorageMethodFetchHistory
-             // Do nothing; use whatever was set by the fetcher service.
-      return;
-    case 2:  // kGTMHTTPFetcherCookieStorageMethodSystemDefault
-      storage = [NSHTTPCookieStorage sharedHTTPCookieStorage];
-      break;
-    case 3:  // kGTMHTTPFetcherCookieStorageMethodNone
-             // Create temporary storage for this fetcher only.
-      storage = [[GTMSessionCookieStorage alloc] init];
-      break;
-    default:
-      GTMSESSION_ASSERT_DEBUG(0, @"Invalid cookie storage method: %d", (int)method);
-  }
-  self.cookieStorage = storage;
-}
-
-@end
-
 @implementation GTMSessionCookieStorage {
   NSMutableArray *_cookies;
   NSHTTPCookieAcceptPolicy _policy;

--- a/Source/GTMSessionFetcherLogging.h
+++ b/Source/GTMSessionFetcherLogging.h
@@ -82,10 +82,9 @@
 + (void)setLoggingDateStamp:(NSString *)dateStamp;
 + (NSString *)loggingDateStamp;
 
-// client apps can specify the directory for the log for this specific run,
-// typically to match the directory used by another fetcher class, like:
+// client apps can specify the directory for the log for this specific run:
 //
-//   [GTMSessionFetcher setLogDirectoryForCurrentRun:[GTMHTTPFetcher logDirectoryForCurrentRun]];
+//   [GTMSessionFetcher setLogDirectoryForCurrentRun:logDirectoryPath];
 //
 // Setting this overrides the logging directory, process name, and date stamp when writing
 // the log file.

--- a/Source/GTMSessionFetcherLogging.m
+++ b/Source/GTMSessionFetcherLogging.m
@@ -53,7 +53,7 @@
 @class GTMReadMonitorInputStream;
 #endif  // !GTMSESSION_BUILD_COMBINED_SOURCES
 
-@interface GTMSessionFetcher (GTMHTTPFetcherLoggingUtilities)
+@interface GTMSessionFetcher (GTMSessionFetcherLoggingUtilities)
 
 + (NSString *)headersStringForDictionary:(NSDictionary *)dict;
 + (NSString *)snipSubstringOfString:(NSString *)originalStr

--- a/Source/GTMSessionFetcherService.h
+++ b/Source/GTMSessionFetcherService.h
@@ -189,12 +189,4 @@ extern NSString *const kGTMSessionFetcherServiceSessionKey;
 
 @end
 
-@interface GTMSessionFetcherService (BackwardsCompatibilityOnly)
-
-// Clients using GTMSessionFetcher should set the cookie storage explicitly themselves.
-// This method is just for compatibility with the old fetcher.
-@property(atomic, assign) NSInteger cookieStorageMethod;
-
-@end
-
 NS_ASSUME_NONNULL_END

--- a/Source/GTMSessionFetcherService.h
+++ b/Source/GTMSessionFetcherService.h
@@ -193,7 +193,8 @@ extern NSString *const kGTMSessionFetcherServiceSessionKey;
 
 // Clients using GTMSessionFetcher should set the cookie storage explicitly themselves;
 // this property is deprecated and will be removed soon.
-@property(atomic, assign) NSInteger cookieStorageMethod __deprecated_msg("Create an NSHTTPCookieStorage and set .cookieStorage directly.");
+@property(atomic, assign) NSInteger cookieStorageMethod __deprecated_msg(
+    "Create an NSHTTPCookieStorage and set .cookieStorage directly.");
 
 @end
 

--- a/Source/GTMSessionFetcherService.h
+++ b/Source/GTMSessionFetcherService.h
@@ -189,4 +189,12 @@ extern NSString *const kGTMSessionFetcherServiceSessionKey;
 
 @end
 
+@interface GTMSessionFetcherService (BackwardsCompatibilityOnly)
+
+// Clients using GTMSessionFetcher should set the cookie storage explicitly themselves;
+// this property is deprecated and will be removed soon.
+@property(atomic, assign) NSInteger cookieStorageMethod __deprecated_msg("Create an NSHTTPCookieStorage and set .cookieStorage directly.");
+
+@end
+
 NS_ASSUME_NONNULL_END

--- a/Source/GTMSessionFetcherService.m
+++ b/Source/GTMSessionFetcherService.m
@@ -88,8 +88,6 @@ NSString *const kGTMSessionFetcherServiceSessionKey = @"kGTMSessionFetcherServic
   NSURLCredential *_credential;       // Username & password.
   NSURLCredential *_proxyCredential;  // Credential supplied to proxy servers.
 
-  NSInteger _cookieStorageMethod;
-
   id<GTMFetcherAuthorizationProtocol> _authorizer;
 
   // For waitForCompletionOfAllFetchersWithTimeout: we need to wait on stopped fetchers since
@@ -135,7 +133,6 @@ NSString *const kGTMSessionFetcherServiceSessionKey = @"kGTMSessionFetcherServic
     _delayedFetchersByHost = [[NSMutableDictionary alloc] init];
     _runningFetchersByHost = [[NSMutableDictionary alloc] init];
     _maxRunningFetchersPerHost = 10;
-    _cookieStorageMethod = -1;
     _unusedSessionTimeout = 60.0;
     _delegateDispatcher = [[GTMSessionFetcherSessionDelegateDispatcher alloc]
          initWithParentService:self
@@ -191,9 +188,6 @@ NSString *const kGTMSessionFetcherServiceSessionKey = @"kGTMSessionFetcherServic
   }
   fetcher.properties = self.properties;
   fetcher.service = self;
-  if (self.cookieStorageMethod >= 0) {
-    [fetcher setCookieStorageMethod:self.cookieStorageMethod];
-  }
 
 #if GTM_BACKGROUND_TASK_FETCHING
   fetcher.skipBackgroundTask = self.skipBackgroundTask;
@@ -788,11 +782,7 @@ NSString *const kGTMSessionFetcherServiceSessionKey = @"kGTMSessionFetcherServic
   // Use the fetcher service for the authorization fetches if the auth
   // object supports fetcher services
   if ([obj respondsToSelector:@selector(setFetcherService:)]) {
-#if GTM_USE_SESSION_FETCHER
     [obj setFetcherService:self];
-#else
-    [obj setFetcherService:(id)self];
-#endif
   }
 }
 
@@ -931,26 +921,6 @@ NSString *const kGTMSessionFetcherServiceSessionKey = @"kGTMSessionFetcherServic
   _stoppedFetchersToWaitFor = nil;
 
   return !didTimeOut;
-}
-
-@end
-
-@implementation GTMSessionFetcherService (BackwardsCompatibilityOnly)
-
-- (NSInteger)cookieStorageMethod {
-  @synchronized(self) {
-    GTMSessionMonitorSynchronized(self);
-
-    return _cookieStorageMethod;
-  }
-}
-
-- (void)setCookieStorageMethod:(NSInteger)cookieStorageMethod {
-  @synchronized(self) {
-    GTMSessionMonitorSynchronized(self);
-
-    _cookieStorageMethod = cookieStorageMethod;
-  }
 }
 
 @end

--- a/Source/GTMSessionFetcherService.m
+++ b/Source/GTMSessionFetcherService.m
@@ -88,6 +88,8 @@ NSString *const kGTMSessionFetcherServiceSessionKey = @"kGTMSessionFetcherServic
   NSURLCredential *_credential;       // Username & password.
   NSURLCredential *_proxyCredential;  // Credential supplied to proxy servers.
 
+  NSInteger _cookieStorageMethod;
+
   id<GTMFetcherAuthorizationProtocol> _authorizer;
 
   // For waitForCompletionOfAllFetchersWithTimeout: we need to wait on stopped fetchers since
@@ -133,6 +135,7 @@ NSString *const kGTMSessionFetcherServiceSessionKey = @"kGTMSessionFetcherServic
     _delayedFetchersByHost = [[NSMutableDictionary alloc] init];
     _runningFetchersByHost = [[NSMutableDictionary alloc] init];
     _maxRunningFetchersPerHost = 10;
+    _cookieStorageMethod = -1;
     _unusedSessionTimeout = 60.0;
     _delegateDispatcher = [[GTMSessionFetcherSessionDelegateDispatcher alloc]
          initWithParentService:self
@@ -188,6 +191,12 @@ NSString *const kGTMSessionFetcherServiceSessionKey = @"kGTMSessionFetcherServic
   }
   fetcher.properties = self.properties;
   fetcher.service = self;
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wdeprecated-declarations"
+  if (self.cookieStorageMethod >= 0) {
+    [fetcher setCookieStorageMethod:self.cookieStorageMethod];
+  }
+#pragma clang diagnostic pop
 
 #if GTM_BACKGROUND_TASK_FETCHING
   fetcher.skipBackgroundTask = self.skipBackgroundTask;
@@ -921,6 +930,26 @@ NSString *const kGTMSessionFetcherServiceSessionKey = @"kGTMSessionFetcherServic
   _stoppedFetchersToWaitFor = nil;
 
   return !didTimeOut;
+}
+
+@end
+
+@implementation GTMSessionFetcherService (BackwardsCompatibilityOnly)
+
+- (NSInteger)cookieStorageMethod {
+  @synchronized(self) {
+    GTMSessionMonitorSynchronized(self);
+
+    return _cookieStorageMethod;
+  }
+}
+
+- (void)setCookieStorageMethod:(NSInteger)cookieStorageMethod {
+  @synchronized(self) {
+    GTMSessionMonitorSynchronized(self);
+
+    _cookieStorageMethod = cookieStorageMethod;
+  }
 }
 
 @end

--- a/Source/UnitTests/GTMSessionFetcherFetchingTest.m
+++ b/Source/UnitTests/GTMSessionFetcherFetchingTest.m
@@ -1343,7 +1343,7 @@ NSString *const kGTMGettysburgFileName = @"gettysburgaddress.txt";
         ![requestURL.host isEqual:responseURL.host] || ![requestURL.port isEqual:responseURL.port],
         @"did not receive redirect");
 
-    XCTAssertEqualObjects(error.domain, kGTMBridgeFetcherStatusDomain);
+    XCTAssertEqualObjects(error.domain, kGTMSessionFetcherStatusDomain);
     XCTAssertEqual(error.code, 302, @"expect HTTP 302 status code error when cancelling redirect.");
 
     // Cookies should have been set by the response; specifically, TestCookie

--- a/Source/UnitTests/GTMSessionFetcherTestServer.m
+++ b/Source/UnitTests/GTMSessionFetcherTestServer.m
@@ -158,7 +158,7 @@ static NSString *const kEtag = @"GoodETag";
   self = [super init];
   if (self) {
     if (docRoot == nil) {
-      NSLog(@"Failed to supply docRoot to GTMHTTPFetcherTestServer");
+      NSLog(@"Failed to supply docRoot to GTMSessionFetcherTestServer");
       return nil;
     }
     _server = [GTMHTTPServer startedServerWithDelegate:self];
@@ -169,7 +169,7 @@ static NSString *const kEtag = @"GoodETag";
     _docRoot = [docRoot copy];
     _uploadBytesExpected = -1;
 #if GTMHTTPSERVER_LOG_VERBOSE
-    NSLog(@"Started GTMHTTPFetcherTestServer for docRoot='%@'", _docRoot);
+    NSLog(@"Started GTMSessionFetcherTestServer for docRoot='%@'", _docRoot);
 #endif
   }
   return self;
@@ -661,7 +661,7 @@ static NSString *const kEtag = @"GoodETag";
 - (void)stopServers {
   if (_server) {
 #if GTMHTTPSERVER_LOG_VERBOSE
-    NSLog(@"Stopped GTMHTTPFetcherTestServer on port %d (docRoot='%@')", _server.port, _docRoot);
+    NSLog(@"Stopped GTMSessionFetcherTestServer on port %d (docRoot='%@')", _server.port, _docRoot);
 #endif
     _server = nil;
   }


### PR DESCRIPTION
This reverts commit 0d539fdd85c004076df09790d631cc29e22d4dd3.

Re-removes the backwards compatibility code. Next release should be v2.0.0.