### PR TITLE
Clean up OS/version macro usage

### DIFF
--- a/Source/GTMSessionFetcher.h
+++ b/Source/GTMSessionFetcher.h
@@ -375,7 +375,8 @@
 // To disallow use of background tasks during fetches, the target should define
 // GTM_BACKGROUND_TASK_FETCHING to 0, or alternatively may set the
 // skipBackgroundTask property to YES.
-#if TARGET_OS_IPHONE && !TARGET_OS_WATCH && !defined(GTM_BACKGROUND_TASK_FETCHING)
+#if (TARGET_OS_IOS || TARGET_OS_TV || TARGET_OS_MACCATALYST) && \
+    !defined(GTM_BACKGROUND_TASK_FETCHING)
 #define GTM_BACKGROUND_TASK_FETCHING 1
 #endif
 

--- a/Source/GTMSessionFetcher.h
+++ b/Source/GTMSessionFetcher.h
@@ -375,8 +375,8 @@
 // To disallow use of background tasks during fetches, the target should define
 // GTM_BACKGROUND_TASK_FETCHING to 0, or alternatively may set the
 // skipBackgroundTask property to YES.
-#if (TARGET_OS_IOS || TARGET_OS_TV || TARGET_OS_MACCATALYST) && \
-    !defined(GTM_BACKGROUND_TASK_FETCHING)
+#if !defined(GTM_BACKGROUND_TASK_FETCHING) && \
+    (TARGET_OS_IOS || TARGET_OS_TV || TARGET_OS_MACCATALYST)
 #define GTM_BACKGROUND_TASK_FETCHING 1
 #endif
 
@@ -546,7 +546,7 @@ typedef void (^GTMSessionFetcherRetryResponse)(BOOL shouldRetry);
 typedef void (^GTMSessionFetcherRetryBlock)(BOOL suggestedWillRetry, NSError *_Nullable error,
                                             GTMSessionFetcherRetryResponse response);
 
-API_AVAILABLE(ios(10.0), macosx(10.12), tvos(10.0), watchos(3.0))
+API_AVAILABLE(ios(10.0), macosx(10.12), tvos(10.0), watchos(6.0))
 typedef void (^GTMSessionFetcherMetricsCollectionBlock)(NSURLSessionTaskMetrics *metrics);
 
 typedef void (^GTMSessionFetcherTestResponse)(NSHTTPURLResponse *_Nullable response,
@@ -989,7 +989,7 @@ NSData *_Nullable GTMDataFromInputStream(NSInputStream *inputStream, NSError **o
 // This is called on the callback queue.
 @property(atomic, copy, nullable)
     GTMSessionFetcherMetricsCollectionBlock metricsCollectionBlock API_AVAILABLE(
-        ios(10.0), macosx(10.12), tvos(10.0), watchos(3.0));
+        ios(10.0), macosx(10.12), tvos(10.0), watchos(6.0));
 
 // Retry intervals must be strictly less than maxRetryInterval, else
 // they will be limited to maxRetryInterval and no further retries will

--- a/Source/GTMSessionFetcher.m
+++ b/Source/GTMSessionFetcher.m
@@ -2868,7 +2868,7 @@ static _Nullable id<GTMUIApplicationProtocol> gSubstituteUIApp;
 - (void)URLSession:(NSURLSession *)session
                           task:(NSURLSessionTask *)task
     didFinishCollectingMetrics:(NSURLSessionTaskMetrics *)metrics
-    API_AVAILABLE(ios(10.0), macosx(10.12), tvos(10.0), watchos(3.0)) {
+    API_AVAILABLE(ios(10.0), macosx(10.12), tvos(10.0), watchos(6.0)) {
   @synchronized(self) {
     GTMSessionMonitorSynchronized(self);
     GTMSessionFetcherMetricsCollectionBlock metricsCollectionBlock = _metricsCollectionBlock;

--- a/Source/GTMSessionFetcher.m
+++ b/Source/GTMSessionFetcher.m
@@ -91,13 +91,7 @@ NS_ASSUME_NONNULL_END
 #endif
 
 #ifndef GTM_TARGET_SUPPORTS_APP_TRANSPORT_SECURITY
-#if (TARGET_OS_TV || TARGET_OS_WATCH ||                          \
-     (!TARGET_OS_IPHONE && defined(MAC_OS_X_VERSION_10_11) &&    \
-      MAC_OS_X_VERSION_MAX_ALLOWED >= MAC_OS_X_VERSION_10_11) || \
-     (TARGET_OS_IPHONE && defined(__IPHONE_9_0) &&               \
-      __IPHONE_OS_VERSION_MAX_ALLOWED >= __IPHONE_9_0))
 #define GTM_TARGET_SUPPORTS_APP_TRANSPORT_SECURITY 1
-#endif
 #endif
 
 #if ((defined(TARGET_OS_MACCATALYST) && TARGET_OS_MACCATALYST) ||                                 \
@@ -4426,17 +4420,6 @@ NSString *GTMFetcherSystemVersionString(void) {
 
   static dispatch_once_t onceToken;
   dispatch_once(&onceToken, ^{
-  // The Xcode 8 SDKs finally cleaned up this mess by providing TARGET_OS_OSX
-  // and TARGET_OS_IOS, but to build with older SDKs, those don't exist and
-  // instead one has to rely on TARGET_OS_MAC (which is true for iOS, watchOS,
-  // and tvOS) and TARGET_OS_IPHONE (which is true for iOS, watchOS, tvOS). So
-  // one has to order these carefully so you pick off the specific things
-  // first.
-  // If the code can ever assume Xcode 8 or higher (even when building for
-  // older OSes), then
-  //   TARGET_OS_MAC -> TARGET_OS_OSX
-  //   TARGET_OS_IPHONE -> TARGET_OS_IOS
-  //   TARGET_IPHONE_SIMULATOR -> TARGET_OS_SIMULATOR
 #if TARGET_OS_WATCH
     // watchOS - WKInterfaceDevice
 
@@ -4464,7 +4447,7 @@ NSString *GTMFetcherSystemVersionString(void) {
     sSavedSystemString =
         [[NSString alloc] initWithFormat:@"%@/%@ hw/%@", model, systemVersion, hardwareModel];
     // Example:  Apple_Watch/3.0 hw/Watch1_2
-#elif TARGET_OS_TV || TARGET_OS_IPHONE
+#elif TARGET_OS_TV || TARGET_OS_IOS
     // iOS and tvOS have UIDevice, use that.
     UIDevice *currentDevice = [UIDevice currentDevice];
 
@@ -4473,7 +4456,7 @@ NSString *GTMFetcherSystemVersionString(void) {
 
     NSString *systemVersion = [currentDevice systemVersion];
 
-#if TARGET_IPHONE_SIMULATOR || TARGET_OS_SIMULATOR
+#if TARGET_OS_SIMULATOR
     NSString *hardwareModel = @"sim";
 #else
     NSString *hardwareModel;
@@ -4491,43 +4474,13 @@ NSString *GTMFetcherSystemVersionString(void) {
                           model, systemVersion, hardwareModel];
     // Example:  iPod_Touch/2.2 hw/iPod1_1
     // Example:  Apple_TV/9.2 hw/AppleTV5,3
-#elif TARGET_OS_MAC
+#elif TARGET_OS_OSX
     // Mac build
     NSProcessInfo *procInfo = [NSProcessInfo processInfo];
-#if !defined(MAC_OS_X_VERSION_10_10)
-    BOOL hasOperatingSystemVersion = NO;
-#elif MAC_OS_X_VERSION_MIN_REQUIRED < MAC_OS_X_VERSION_10_10
-    BOOL hasOperatingSystemVersion =
-        [procInfo respondsToSelector:@selector(operatingSystemVersion)];
-#else
-    BOOL hasOperatingSystemVersion = YES;
-#endif
     NSString *versString;
-    if (hasOperatingSystemVersion) {
-#if defined(MAC_OS_X_VERSION_10_10)
-      // A reference to NSOperatingSystemVersion requires the 10.10 SDK.
-#pragma clang diagnostic push
-#pragma clang diagnostic ignored "-Wunguarded-availability"
-// Disable unguarded availability warning as we can't use the @availability macro until we require
-// all clients to build with Xcode 9 or above.
-      NSOperatingSystemVersion version = procInfo.operatingSystemVersion;
-#pragma clang diagnostic pop
-      versString = [NSString stringWithFormat:@"%ld.%ld.%ld",
-                    (long)version.majorVersion, (long)version.minorVersion,
-                    (long)version.patchVersion];
-#else
-#pragma unused(procInfo)
-#endif
-    } else {
-      // With Gestalt inexplicably deprecated in 10.8, we're reduced to reading
-      // the system plist file.
-      NSString *const kPath = @"/System/Library/CoreServices/SystemVersion.plist";
-      NSDictionary *plist = [NSDictionary dictionaryWithContentsOfFile:kPath];
-      versString = [plist objectForKey:@"ProductVersion"];
-      if (versString.length == 0) {
-        versString = @"10.?.?";
-      }
-    }
+    NSOperatingSystemVersion version = procInfo.operatingSystemVersion;
+    versString = [NSString stringWithFormat:@"%ld.%ld.%ld", (long)version.majorVersion,
+                                            (long)version.minorVersion, (long)version.patchVersion];
 
     sSavedSystemString = [[NSString alloc] initWithFormat:@"MacOSX/%@", versString];
 #elif defined(_SYS_UTSNAME_H)

--- a/Source/GTMSessionFetcherService.h
+++ b/Source/GTMSessionFetcherService.h
@@ -67,7 +67,7 @@ extern NSString *const kGTMSessionFetcherServiceSessionKey;
 @property(atomic, copy, nullable) NSDictionary<NSString *, id> *properties;
 @property(atomic, copy, nullable)
     GTMSessionFetcherMetricsCollectionBlock metricsCollectionBlock API_AVAILABLE(
-        ios(10.0), macosx(10.12), tvos(10.0), watchos(3.0));
+        ios(10.0), macosx(10.12), tvos(10.0), watchos(6.0));
 
 #if GTM_BACKGROUND_TASK_FETCHING
 @property(atomic, assign) BOOL skipBackgroundTask;

--- a/Source/GTMSessionFetcherService.m
+++ b/Source/GTMSessionFetcherService.m
@@ -1258,7 +1258,7 @@ NSString *const kGTMSessionFetcherServiceSessionKey = @"kGTMSessionFetcherServic
 - (void)URLSession:(NSURLSession *)session
                           task:(NSURLSessionTask *)task
     didFinishCollectingMetrics:(NSURLSessionTaskMetrics *)metrics
-    API_AVAILABLE(ios(10.0), macosx(10.12), tvos(10.0), watchos(3.0)) {
+    API_AVAILABLE(ios(10.0), macosx(10.12), tvos(10.0), watchos(6.0)) {
   id<NSURLSessionTaskDelegate> fetcher = [self fetcherForTask:task];
   [fetcher URLSession:session task:task didFinishCollectingMetrics:metrics];
 }

--- a/Source/GTMSessionFetcherService.m
+++ b/Source/GTMSessionFetcherService.m
@@ -151,11 +151,7 @@ NSString *const kGTMSessionFetcherServiceSessionKey = @"kGTMSessionFetcherServic
     // Starting with the SDKs for OS X 10.11/iOS 9, the service has a default useragent.
     // Apps can remove this and get the default system "CFNetwork" useragent by setting the
     // fetcher service's userAgent property to nil.
-#if (!TARGET_OS_IPHONE && defined(MAC_OS_X_VERSION_10_11) &&    \
-     MAC_OS_X_VERSION_MAX_ALLOWED >= MAC_OS_X_VERSION_10_11) || \
-    (TARGET_OS_IPHONE && defined(__IPHONE_9_0) && __IPHONE_OS_VERSION_MAX_ALLOWED >= __IPHONE_9_0)
     _userAgent = GTMFetcherStandardUserAgentString(nil);
-#endif
   }
   return self;
 }

--- a/Source/UnitTests/GTMSessionFetcherFetchingTest.m
+++ b/Source/UnitTests/GTMSessionFetcherFetchingTest.m
@@ -2015,7 +2015,7 @@ NSString *const kGTMGettysburgFileName = @"gettysburgaddress.txt";
 }
 
 - (void)testCollectingMetrics_WithSuccessfulFetch API_AVAILABLE(ios(10.0), macosx(10.12),
-                                                                tvos(10.0), watchos(3.0)) {
+                                                                tvos(10.0), watchos(6.0)) {
   if (!_isServerRunning) return;
 
   CREATE_START_STOP_NOTIFICATION_EXPECTATIONS(1, 1);
@@ -2050,14 +2050,14 @@ NSString *const kGTMGettysburgFileName = @"gettysburgaddress.txt";
 }
 
 - (void)testCollectingMetrics_WithSuccessfulFetch_WithoutFetcherService API_AVAILABLE(
-    ios(10.0), macosx(10.12), tvos(10.0), watchos(3.0)) {
+    ios(10.0), macosx(10.12), tvos(10.0), watchos(6.0)) {
   _fetcherService = nil;
   [self testCollectingMetrics_WithSuccessfulFetch];
 }
 
 - (void)testCollectingMetrics_WithWrongFetch_FaildToConnect API_AVAILABLE(ios(10.0), macosx(10.12),
                                                                           tvos(10.0),
-                                                                          watchos(3.0)) {
+                                                                          watchos(6.0)) {
   if (!_isServerRunning) return;
 
   CREATE_START_STOP_NOTIFICATION_EXPECTATIONS(1, 1);
@@ -2096,13 +2096,13 @@ NSString *const kGTMGettysburgFileName = @"gettysburgaddress.txt";
 }
 
 - (void)testCollectingMetrics_WithWrongFetch_FaildToConnect_WithoutFetcherService API_AVAILABLE(
-    ios(10.0), macosx(10.12), tvos(10.0), watchos(3.0)) {
+    ios(10.0), macosx(10.12), tvos(10.0), watchos(6.0)) {
   _fetcherService = nil;
   [self testCollectingMetrics_WithWrongFetch_FaildToConnect];
 }
 
 - (void)testCollectingMetrics_WithWrongFetch_BadStatusCode API_AVAILABLE(ios(10.0), macosx(10.12),
-                                                                         tvos(10.0), watchos(3.0)) {
+                                                                         tvos(10.0), watchos(6.0)) {
   if (!_isServerRunning) return;
 
   CREATE_START_STOP_NOTIFICATION_EXPECTATIONS(1, 1);
@@ -2143,7 +2143,7 @@ NSString *const kGTMGettysburgFileName = @"gettysburgaddress.txt";
 }
 
 - (void)testCollectingMetrics_WithWrongFetch_BadStatusCode_WithoutFetcherService API_AVAILABLE(
-    ios(10.0), macosx(10.12), tvos(10.0), watchos(3.0)) {
+    ios(10.0), macosx(10.12), tvos(10.0), watchos(6.0)) {
   _fetcherService = nil;
   [self testCollectingMetrics_WithWrongFetch_BadStatusCode];
 }

--- a/Source/UnitTests/GTMSessionFetcherServiceTest.m
+++ b/Source/UnitTests/GTMSessionFetcherServiceTest.m
@@ -884,7 +884,7 @@ static NSString *const kValidFileName = @"gettysburgaddress.txt";
 - (void)testFetcherUsingMetricsCollectionBlockFromFetcherService API_AVAILABLE(ios(10.0),
                                                                                macosx(10.12),
                                                                                tvos(10.0),
-                                                                               watchos(3.0)) {
+                                                                               watchos(6.0)) {
   if (!_isServerRunning) return;
 
   CREATE_START_STOP_NOTIFICATION_EXPECTATIONS(1, 1);


### PR DESCRIPTION
Cleans up some OS version macro usage, and removes some dead code now that the minimum Xcode and OS versions have increased.
