### PR TITLE
Fix up things for newer versions of clang.

### DIFF
--- a/Source/UnitTests/GTMHTTPServer.m
+++ b/Source/UnitTests/GTMHTTPServer.m
@@ -368,7 +368,7 @@ static void AcceptCallback(CFSocketRef socket, CFSocketCallBackType callBackType
       NSInputStream *inputStream = connDict[kInputStream];
       NSAssert(aStream == inputStream, @"Unexpected output stream has bytes");
 
-      const NSUInteger kMaxReadDataChunkSize = 32768;
+      enum EnumType : NSUInteger {kMaxReadDataChunkSize = 32768};
       NSMutableData *readData = [[NSMutableData alloc] init];
       uint8_t readDataBytes[kMaxReadDataChunkSize];
       NSInteger readDataSize = [inputStream read:readDataBytes maxLength:kMaxReadDataChunkSize];


### PR DESCRIPTION
Newer Clangs complain where in obj-c const variables used in array declarations
are violating the new  "Wgnu-folding-constant" warning. This warning is
complaining about "variable length array folded to constant array as an
extension"

The resolution is to switch those constant variable declarations to enums, which
are compile-time constants.