### PR TITLE
Introduces configurable concurrent callback queue handling behavior.

### DIFF
--- a/Source/GTMSessionFetcher.h
+++ b/Source/GTMSessionFetcher.h
@@ -121,7 +121,7 @@
 // changing thread or queue to create or start a fetcher.
 //
 // Callbacks are run on the main thread; alternatively, the app may set the
-// fetcher's callbackQueue to a dispatch queue.
+// fetcher's callbackQueue to a serial dispatch queue.
 //
 // Once the fetcher's beginFetch method has been called, the fetcher's methods and
 // properties may be accessed from any thread.
@@ -1102,7 +1102,8 @@ NSData *_Nullable GTMDataFromInputStream(NSInputStream *inputStream, NSError **o
 // Log of request and response, if logging is enabled
 @property(atomic, copy, nullable) NSString *log;
 
-// Callbacks are run on this queue.  If none is supplied, the main queue is used.
+// Callbacks are run on this queue.  If none is supplied, the main queue is used. Any
+// queue provided must be a serial queue.
 //
 // This may not be changed once beginFetch has been invoked.
 @property(atomic, strong, null_resettable) dispatch_queue_t callbackQueue;

--- a/Source/GTMSessionFetcher.m
+++ b/Source/GTMSessionFetcher.m
@@ -223,8 +223,7 @@ static GTMSessionFetcherTestBlock _Nullable gGlobalTestBlock;
                            // released)
   id _userData;            // retained, if set by caller
   NSMutableDictionary *_properties;  // more data retained for caller
-  dispatch_queue_t _callbackQueue;   // the target of _internalCallbackQueue
-  dispatch_queue_t _internalCallbackQueue;
+  dispatch_queue_t _callbackQueue;   // the callback queue; this should be serial.
   dispatch_group_t _callbackGroup;   // read-only after creation
   NSOperationQueue *_delegateQueue;  // immutable after beginFetch
 
@@ -522,9 +521,6 @@ static GTMSessionFetcherTestBlock _Nullable gGlobalTestBlock;
     // This ivar is set only here on the initial beginFetch so need not be synchronized.
     _initialBeginFetchDate = [[NSDate alloc] init];
   }
-
-  // Lock in the internal callback queue the first time beginFetch is called.
-  (void)[self internalCallbackQueue];
 
   if (self.sessionTask != nil) {
     // If cached fetcher returned through fetcherWithSessionIdentifier:, then it's
@@ -1783,24 +1779,20 @@ NSData *_Nullable GTMDataFromInputStream(NSInputStream *inputStream, NSError **o
   // the blocks being released may call back into the fetcher or fetcher
   // service.
   dispatch_queue_t NS_VALID_UNTIL_END_OF_SCOPE holdCallbackQueue;
-  dispatch_queue_t NS_VALID_UNTIL_END_OF_SCOPE holdInternalCallbackQueue;
   GTMSessionFetcherCompletionHandler NS_VALID_UNTIL_END_OF_SCOPE holdCompletionHandler;
   @synchronized(self) {
     GTMSessionMonitorSynchronized(self);
 
     holdCallbackQueue = _callbackQueue;
-    holdInternalCallbackQueue = _internalCallbackQueue;
     holdCompletionHandler = _completionHandler;
 
     _callbackQueue = nil;
-    _internalCallbackQueue = nil;
     _completionHandler = nil;  // Setter overridden in upload. Setter assumed to be used externally.
   }
 
   // Set local callback pointers to nil here rather than let them release at the end of the scope
   // to make any problems due to the blocks being released be a bit more obvious in a stack trace.
   holdCallbackQueue = nil;
-  holdInternalCallbackQueue = nil;
   holdCompletionHandler = nil;
 
   self.configurationBlock = nil;
@@ -1900,11 +1892,11 @@ NSData *_Nullable GTMDataFromInputStream(NSInputStream *inputStream, NSError **o
           void (^resumeBlock)(NSData *) = _resumeDataBlock;
           _resumeDataBlock = nil;
 
-          // Save internalCallbackQueue since releaseCallbacks clears it.
-          dispatch_queue_t internalCallbackQueue = [self internalCallbackQueueUnsynchronized];
+          // Save callbackQueue since releaseCallbacks clears it.
+          dispatch_queue_t callbackQueue = _callbackQueue;
           dispatch_group_enter(_callbackGroup);
           [(NSURLSessionDownloadTask *)oldTask cancelByProducingResumeData:^(NSData *resumeData) {
-            [self invokeOnCallbackQueue:internalCallbackQueue
+            [self invokeOnCallbackQueue:callbackQueue
                        afterUserStopped:YES
                                   block:^{
                                     resumeBlock(resumeData);
@@ -2463,9 +2455,7 @@ static _Nullable id<GTMUIApplicationProtocol> gSubstituteUIApp;
 - (void)invokeOnCallbackUnsynchronizedQueueAfterUserStopped:(BOOL)afterStopped
                                                       block:(void (^)(void))block {
   // testBlock simulation code may not be synchronizing when this is invoked.
-  [self invokeOnCallbackQueue:[self internalCallbackQueueUnsynchronized]
-             afterUserStopped:afterStopped
-                        block:block];
+  [self invokeOnCallbackQueue:_callbackQueue afterUserStopped:afterStopped block:block];
 }
 
 - (void)invokeOnCallbackQueue:(dispatch_queue_t)callbackQueue
@@ -3735,80 +3725,7 @@ static NSMutableDictionary *gSystemCompletionHandlers = nil;
                             @"callbackQueue should not change after beginFetch has been invoked");
 
     _callbackQueue = queue ?: dispatch_get_main_queue();
-    // The internal callback queue cannot be changed once fetching has begun.
-    if (!_initialBeginFetchDate) _internalCallbackQueue = nil;
   }  // @synchronized(self)
-}
-
-/**
- * The serial queue to which callbacks should be dispatched.
- *
- * Callbacks need to be dispatched serially. For example, the accumulate data block should never be
- * run after the completion handler. Serial dispatch is guaranteed by dispatching to an intermediate
- * serial queue that targets the actual callback queue (which may or may not be serial).
- */
-- (nonnull dispatch_queue_t)internalCallbackQueue {
-  @synchronized(self) {
-    GTMSessionMonitorSynchronized(self);
-
-    return [self internalCallbackQueueUnsynchronized];
-  }  // @synchronized(self)
-}
-
-- (nonnull dispatch_queue_t)internalCallbackQueueUnsynchronized {
-  GTMSessionCheckSynchronized(self);
-
-  if (!_internalCallbackQueue) {
-    if (ShouldWrapCallbackQueueForFetcher(_callbackQueue, self)) {
-      _internalCallbackQueue = SerialCallbackQueueForTargetQueue(_callbackQueue);
-    } else {
-      _internalCallbackQueue = _callbackQueue;
-    }
-  }
-  return _internalCallbackQueue;
-}
-
-static BOOL ShouldWrapCallbackQueueForFetcher(dispatch_queue_t queue, GTMSessionFetcher *fetcher) {
-  // The main queue is already serial, and does not need to be wrapped in a separate serial queue.
-  if (queue == dispatch_get_main_queue()) return NO;
-  // If the client provided blocks for passive sequential callbacks that have an expected ordering,
-  // e.g. progress blocks, these can reasonably be expected to arrive in sequential order. However,
-  // if the client provided a concurrent queue the blocks may be processed out-of-order, leading
-  // to potential data corruption.
-  bool hasSerialCallbacks = fetcher.accumulateDataBlock || fetcher.sendProgressBlock ||
-                            fetcher.receivedProgressBlock || fetcher.downloadProgressBlock ||
-                            fetcher.resumeDataBlock;
-  if (hasSerialCallbacks) return YES;
-
-  return NO;
-}
-
-static dispatch_queue_t SerialCallbackQueueForTargetQueue(
-    dispatch_queue_t _Nonnull targetQueue) {
-  // Do not wrap the main queue; it's a known serial queue and the default, so avoiding creating
-  // too many queues.
-  if (targetQueue == dispatch_get_main_queue()) {
-    return targetQueue;
-  }
-
-  NSString *queueLabel = @"com.google.GTMSessionFetcher.internalCallbackQueue";
-  // For anything other than the main queue, append the target queue's label (if one exists) to
-  // provide clarity when viewing app behavior in the debugger.
-  const char *targetQueueLabel = dispatch_queue_get_label(targetQueue);
-  if (targetQueueLabel && targetQueueLabel[0] != '\0') {
-    queueLabel = [queueLabel stringByAppendingFormat:@".%s", targetQueueLabel];
-  }
-
-#if TARGET_OS_IOS && __IPHONE_OS_VERSION_MIN_REQUIRED < __IPHONE_10_0
-  dispatch_queue_t internalCallbackQueue =
-      dispatch_queue_create(queueLabel.UTF8String, DISPATCH_QUEUE_SERIAL);
-  dispatch_set_target_queue(internalCallbackQueue, targetQueue);
-#else
-  dispatch_queue_t internalCallbackQueue =
-      dispatch_queue_create_with_target(queueLabel.UTF8String, DISPATCH_QUEUE_SERIAL, targetQueue);
-#endif
-
-  return internalCallbackQueue;
 }
 
 - (nullable NSURLSession *)session {

--- a/Source/GTMSessionUploadFetcher.m
+++ b/Source/GTMSessionUploadFetcher.m
@@ -90,8 +90,6 @@ NSString *const kGTMSessionFetcherUploadLocationObtainedNotification =
 
 - (NSInteger)statusCodeUnsynchronized;
 
-@property(strong, atomic, readonly, nonnull) dispatch_queue_t internalCallbackQueue;
-
 - (BOOL)userStoppedFetching;
 
 @end
@@ -283,7 +281,7 @@ NSString *const kGTMSessionFetcherUploadLocationObtainedNotification =
   uploadFetcher.sessionUserInfo = metadata;
   uploadFetcher.useBackgroundSession = YES;
   uploadFetcher.currentOffset = currentOffset;
-  uploadFetcher.delegateCallbackQueue = uploadFetcher.internalCallbackQueue;
+  uploadFetcher.delegateCallbackQueue = uploadFetcher.callbackQueue;
   uploadFetcher.allowedInsecureSchemes = @[ @"http" ];  // Allowed on restored upload fetcher.
   return uploadFetcher;
 }
@@ -916,7 +914,7 @@ NSString *const kGTMSessionFetcherUploadLocationObtainedNotification =
   // We'll hold onto the superclass's callback queue so we can invoke the handler
   // even after the superclass has released the queue and its callback handler, as
   // happens during auth failure.
-  [self setDelegateCallbackQueue:self.internalCallbackQueue];
+  [self setDelegateCallbackQueue:self.callbackQueue];
   self.completionHandler = handler;
 
   if ([self isRestartedUpload]) {
@@ -1401,7 +1399,7 @@ NSString *const kGTMSessionFetcherUploadLocationObtainedNotification =
   // Make a new chunk fetcher.
   //
   GTMSessionFetcher *chunkFetcher = [GTMSessionFetcher fetcherWithRequest:chunkRequest];
-  chunkFetcher.callbackQueue = self.internalCallbackQueue;
+  chunkFetcher.callbackQueue = self.callbackQueue;
   chunkFetcher.sessionUserInfo = self.sessionUserInfo;
   chunkFetcher.configurationBlock = self.configurationBlock;
   chunkFetcher.allowedInsecureSchemes = self.allowedInsecureSchemes;
@@ -1678,7 +1676,7 @@ NSString *const kGTMSessionFetcherUploadLocationObtainedNotification =
     [self sendCancelUploadWithFetcherProperties:[self properties]];
     self.uploadLocationURL = nil;
   } else {
-    [self invokeOnCallbackQueue:self.internalCallbackQueue
+    [self invokeOnCallbackQueue:self.callbackQueue
                afterUserStopped:YES
                           block:^{
                             // Repeated calls to stopFetching may cause this path to be reached


### PR DESCRIPTION
Wrapping of the callback queue moves from within a `GTMSessionFetcher` instance into the `GTMSessionFetcherService`, and is controlled by the new `GTMSessionFetcherQueueBehavior` (via the service's `.callbackQueueBehavior` property). `GTMSessionFetcher` instances created without a service no longer have guarding against being provided a concurrent queue, but documentation has been updated to reflect that the `callbackQueue` provided must be serial.

Based on the `GTMSessionFetcherQueueBehavior`:

- `GTMSessionFetcherQueueBehaviorTargetOnce`: an internal serial queue is created inside the fetcher service, targeting the provided `callbackQueue`; this serial queue passed as the `callbackQueue` for every fetcher instance the service creates. This behavior is the default.
- `GTMSessionFetcherQueueBehaviorTargetEveryFetcher`: for every fetcher instance the service creates, a new serial queue is created (targeting the service's `callbackQueue`) and assigned as that fetcher's `callbackQueue`. This option may be more performant for clients wanting to pass a concurrent queue to fetcher, while providing guaranteed serialization of callbacks for each fetcher.
- `GTMSessionFetcherQueueBehaviorDirect`: the prior behavior. The service's `callbackQueue` is directly passed as the `callbackQueue` for all created fetchers. When this option is used, clients must pass a serial queue to avoid out-of-order fetcher callbacks.