### PR TITLE
Make GTMSessionFetcherServiceProtocol's `decorators` property `@optional`

### DIFF
--- a/Source/GTMSessionFetcher.h
+++ b/Source/GTMSessionFetcher.h
@@ -686,6 +686,9 @@ typedef void (^GTMFetcherDecoratorFetcherWillStartCompletionHandler)(NSURLReques
 
 @property(atomic, readonly, strong, nullable) NSOperationQueue *delegateQueue;
 
+@optional
+// This property is optional, for now, to enable releasing the feature without breaking existing
+// code that fakes the service but doesn't implement this.
 @property(atomic, readonly, strong, nullable) NSArray<id<GTMFetcherDecoratorProtocol>> *decorators;
 
 @end  // @protocol GTMSessionFetcherServiceProtocol

--- a/Source/GTMSessionFetcher.m
+++ b/Source/GTMSessionFetcher.m
@@ -811,7 +811,7 @@ static GTMSessionFetcherTestBlock _Nullable gGlobalTestBlock;
     }
   }
 
-  if (mayDecorate) {
+  if (mayDecorate && [_service respondsToSelector:@selector(decorators)]) {
     NSArray<id<GTMFetcherDecoratorProtocol>> *decorators = _service.decorators;
     if (decorators.count) {
       // If this session is held by the fetcher service, clear the session now so that we don't
@@ -2594,7 +2594,7 @@ static _Nullable id<GTMUIApplicationProtocol> gSubstituteUIApp;
                                               error:(nullable NSError *)error
                                         mayDecorate:(BOOL)mayDecorate
                              shouldReleaseCallbacks:(BOOL)shouldReleaseCallbacks {
-  if (mayDecorate) {
+  if (mayDecorate && [_service respondsToSelector:@selector(decorators)]) {
     NSArray<id<GTMFetcherDecoratorProtocol>> *decorators = _service.decorators;
     if (decorators.count) {
       [self applyDecoratorsAtRequestDidFinish:decorators


### PR DESCRIPTION
Several outside projects create fakes of the service, so adding a new `@required` property to the service protocol becomes a breaking change. Have intentions to rework to eliminate this in a future version.