### PR TITLE
Add explicit concurrent callback queue support for the fetcher service.

### DIFF
--- a/Source/GTMSessionFetcherService.h
+++ b/Source/GTMSessionFetcherService.h
@@ -109,9 +109,10 @@ extern NSString *const kGTMSessionFetcherServiceSessionKey;
 
 // Sets the callback queue, specifying that the provided queue is a concurrent queue.
 //
-// When a concurrent queue is explicitly provided via this setter, the the service
-// will wrap the concurrent queue with a new serial queue for each fetcher instance
-// that is created, ensuring all callbacks for a given fetcher instance occur serially.
+// When a concurrent queue is explicitly provided via this setter, then each new fetcher
+// instance created by the service will be provided a new serial queue targeting the
+// concurrent callback queue; this will ensure callbacks for each instance are executed
+// in order, while callbacks from separate fetcher instances are not blocked by each other.
 //
 // The service behavior when resetting the callback queue after providing a concurrent
 // queue is unspecified.

--- a/Source/GTMSessionFetcherService.h
+++ b/Source/GTMSessionFetcherService.h
@@ -107,6 +107,16 @@ extern NSString *const kGTMSessionFetcherServiceSessionKey;
 // fetchers begin.
 - (void)resetSession;
 
+// Sets the callback queue, specifying that the provided queue is a concurrent queue.
+//
+// When a concurrent queue is explicitly provided via this setter, the the service
+// will wrap the concurrent queue with a new serial queue for each fetcher instance
+// that is created, ensuring all callbacks for a given fetcher instance occur serially.
+//
+// The service behavior when resetting the callback queue after providing a concurrent
+// queue is unspecified.
+- (void)setConcurrentCallbackQueue:(dispatch_queue_t)queue;
+
 // Create a fetcher
 //
 // These methods will return a fetcher. If successfully created, the connection


### PR DESCRIPTION
Clients that wish to provide a concurrent queue for the service's callback queue can call the new `setConcurrentCallbackQueue:` method, and each new fetcher instance will be provided a new serial queue targeting the concurrent callback queue; this will ensure callbacks for each instance are executed in order, while callbacks from separate fetcher instances are not blocked by each other.

If the callback queue is set directly via the `.callbackQueue` property, the service provides that callback queue directly to all new fetcher instances (this is current behavior).

Setting a fetcher service's callback queue after the service has been used to create fetcher instances is not guaranteed to behave in a specific manner, and should be considered an error.