### PR TITLE
Ignore `-Wunused` warnings around `objc_precise_lifetime` variables.

### DIFF
--- a/Source/GTMMIMEDocument.m
+++ b/Source/GTMMIMEDocument.m
@@ -401,11 +401,11 @@ static void SearchDataForBytes(NSData *data, const void *targetBytes, NSUInteger
         // and map that two-byte subrange.
         const void *partDataBuffer;
         size_t partDataBufferSize;
-        // It's necessary to ignore -Wunused-but-set-variable warnings, as the variables with
-        // objc_precise_lifetime semantics are being used to force ARC to release objects at
-        // a known time.
+        // The clang included with Xcode 13.3 betas added a -Wunused-but-set-variable warning,
+        // which doesn't (yet) skip variables annotated with objc_precie_lifetime. Since that
+        // warning is not available in all Xcodes, turn off the -Wunused warning group entirely.
 #pragma clang diagnostic push
-#pragma clang diagnostic ignored "-Wunused-but-set-variable"
+#pragma clang diagnostic ignored "-Wunused"
         dispatch_data_t mappedPartData NS_VALID_UNTIL_END_OF_SCOPE =
             dispatch_data_create_map(partData, &partDataBuffer, &partDataBufferSize);
 #pragma clang diagnostic pop

--- a/Source/GTMMIMEDocument.m
+++ b/Source/GTMMIMEDocument.m
@@ -401,8 +401,14 @@ static void SearchDataForBytes(NSData *data, const void *targetBytes, NSUInteger
         // and map that two-byte subrange.
         const void *partDataBuffer;
         size_t partDataBufferSize;
+        // It's necessary to ignore -Wunused-but-set-variable warnings, as the variables with
+        // objc_precise_lifetime semantics are being used to force ARC to release objects at
+        // a known time.
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wunused-but-set-variable"
         dispatch_data_t mappedPartData NS_VALID_UNTIL_END_OF_SCOPE =
             dispatch_data_create_map(partData, &partDataBuffer, &partDataBufferSize);
+#pragma clang diagnostic pop
         dispatch_data_t bodyData;
         NSDictionary *headers;
         BOOL hasAnotherCRLF =

--- a/Source/GTMSessionFetcher.m
+++ b/Source/GTMSessionFetcher.m
@@ -1878,11 +1878,16 @@ NSData *_Nullable GTMDataFromInputStream(NSInputStream *inputStream, NSError **o
 }
 
 - (void)releaseCallbacks {
+  // Need to ignore -Wunused-but-set-variable until it no longer applies to objc_precise_lifetime
+  // attributed variables.
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wunused-but-set-variable"
   // Avoid releasing blocks in the sync section since objects dealloc'd by
   // the blocks being released may call back into the fetcher or fetcher
   // service.
   dispatch_queue_t NS_VALID_UNTIL_END_OF_SCOPE holdCallbackQueue;
   GTMSessionFetcherCompletionHandler NS_VALID_UNTIL_END_OF_SCOPE holdCompletionHandler;
+#pragma clang diagnostic pop
   @synchronized(self) {
     GTMSessionMonitorSynchronized(self);
 

--- a/Source/GTMSessionFetcher.m
+++ b/Source/GTMSessionFetcher.m
@@ -1878,10 +1878,11 @@ NSData *_Nullable GTMDataFromInputStream(NSInputStream *inputStream, NSError **o
 }
 
 - (void)releaseCallbacks {
-  // Need to ignore -Wunused-but-set-variable until it no longer applies to objc_precise_lifetime
-  // attributed variables.
+  // The clang included with Xcode 13.3 betas added a -Wunused-but-set-variable warning,
+  // which doesn't (yet) skip variables annotated with objc_precie_lifetime. Since that
+  // warning is not available in all Xcodes, turn off the -Wunused warning group entirely.
 #pragma clang diagnostic push
-#pragma clang diagnostic ignored "-Wunused-but-set-variable"
+#pragma clang diagnostic ignored "-Wunused"
   // Avoid releasing blocks in the sync section since objects dealloc'd by
   // the blocks being released may call back into the fetcher or fetcher
   // service.

--- a/Source/GTMSessionUploadFetcher.m
+++ b/Source/GTMSessionUploadFetcher.m
@@ -1602,8 +1602,11 @@ NSString *const kGTMSessionFetcherUploadLocationObtainedNotification =
               totalBytesExpectedToSend:(int64_t)totalBytesExpected {
   GTMSessionCheckNotSynchronized(self);
 
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wunused-but-set-variable"
   // Ensure the chunk fetcher survives the callback in case the user pauses the upload process.
   __block GTMSessionFetcher *holdFetcher = self.chunkFetcher;
+#pragma clang diagnostic pop
 
   [self invokeOnCallbackQueue:self.delegateCallbackQueue
              afterUserStopped:NO

--- a/Source/GTMSessionUploadFetcher.m
+++ b/Source/GTMSessionUploadFetcher.m
@@ -1602,8 +1602,11 @@ NSString *const kGTMSessionFetcherUploadLocationObtainedNotification =
               totalBytesExpectedToSend:(int64_t)totalBytesExpected {
   GTMSessionCheckNotSynchronized(self);
 
+  // The clang included with Xcode 13.3 betas added a -Wunused-but-set-variable warning,
+  // which doesn't (yet) skip variables annotated with objc_precie_lifetime. Since that
+  // warning is not available in all Xcodes, turn off the -Wunused warning group entirely.
 #pragma clang diagnostic push
-#pragma clang diagnostic ignored "-Wunused-but-set-variable"
+#pragma clang diagnostic ignored "-Wunused"
   // Ensure the chunk fetcher survives the callback in case the user pauses the upload process.
   __block GTMSessionFetcher *holdFetcher = self.chunkFetcher;
 #pragma clang diagnostic pop


### PR DESCRIPTION
Several `__attribute__((objc_precise_lifetime))`/`NS_VALID_UNTIL_END_OF_SCOPE`-annotated variables are used to ensure ARC doesn't release variables before we're ready, but the new `-Wunused-but-set-variable` warning introduced in the Xcode 13.3 betas complains about these. Since the variables are not truly _unused_, but have no reason to be accessed beyond their initial setting, it seems better to quash the warning at the specific code rather than annotate the variables `__unused`.

While it wouldn't likely be available in Xcode for quite some time, a patch has been sent to LLVM to exempt `objc_precise_lifetime` variables from the warning: https://reviews.llvm.org/D120372