### PR TITLE
Add CocoaPods testing spec.

### DIFF
--- a/GTMSessionFetcher.podspec
+++ b/GTMSessionFetcher.podspec
@@ -14,13 +14,18 @@ Pod::Spec.new do |s|
   GTMSessionFetcher makes it easy for Cocoa applications
   to perform http operations. The fetcher is implemented
   as a wrapper on NSURLSession, so its behavior is asynchronous
-  and uses operating-system settings on iOS and Mac OS X.
+  and uses operating-system settings.
   DESC
 
-  s.ios.deployment_target = '9.0'
-  s.osx.deployment_target = '10.12'
-  s.tvos.deployment_target = '10.0'
-  s.watchos.deployment_target = '6.0'
+  ios_deployment_target = '9.0'
+  osx_deployment_target = '10.12'
+  tvos_deployment_target = '10.0'
+  watchos_deployment_target = '6.0'
+
+  s.ios.deployment_target = ios_deployment_target
+  s.osx.deployment_target = osx_deployment_target
+  s.tvos.deployment_target = tvos_deployment_target
+  s.watchos.deployment_target = watchos_deployment_target
 
   s.default_subspec = 'Full'
 
@@ -46,5 +51,18 @@ Pod::Spec.new do |s|
     sp.source_files =
       'Source/GTMSessionFetcherLogViewController.{h,m}'
     sp.dependency 'GTMSessionFetcher/Core', "#{s.version}"
+  end
+
+  s.test_spec 'Tests' do |sp|
+    sp.source_files = 'UnitTests/*.{h,m}'
+    sp.resource = 'UnitTests/Data/gettysburgaddress.txt'
+
+    sp.platforms = {
+      :ios => ios_deployment_target,
+      :osx => osx_deployment_target,
+      :tvos => tvos_deployment_target,
+      # Seem to need a higher min to get a good test runner picked/supported.
+      :watchos => '7.4'
+    }
   end
 end

--- a/UnitTests/GTMHTTPServer.h
+++ b/UnitTests/GTMHTTPServer.h
@@ -13,6 +13,10 @@
  * limitations under the License.
  */
 
+#import <TargetConditionals.h>
+
+#if !TARGET_OS_WATCH
+
 //
 //  GTMHTTPServer.h
 //
@@ -123,3 +127,5 @@ enum {
 - (void)setHeaderValuesFromDictionary:(NSDictionary *)dict;
 
 @end
+
+#endif  // !TARGET_OS_WATCH

--- a/UnitTests/GTMHTTPServer.m
+++ b/UnitTests/GTMHTTPServer.m
@@ -13,6 +13,10 @@
  * limitations under the License.
  */
 
+#import <TargetConditionals.h>
+
+#if !TARGET_OS_WATCH
+
 #if !defined(__has_feature) || !__has_feature(objc_arc)
 #error "This file requires ARC support."
 #endif
@@ -757,3 +761,5 @@ static void AcceptCallback(CFSocketRef socket, CFSocketCallBackType callBackType
 }
 
 @end
+
+#endif  // !TARGET_OS_WATCH

--- a/UnitTests/GTMSessionFetcherChunkedUploadTest.m
+++ b/UnitTests/GTMSessionFetcherChunkedUploadTest.m
@@ -13,6 +13,10 @@
  * limitations under the License.
  */
 
+#import <TargetConditionals.h>
+
+#if !TARGET_OS_WATCH
+
 #if !defined(__has_feature) || !__has_feature(objc_arc)
 #error "This file requires ARC support."
 #endif
@@ -1612,3 +1616,5 @@ static void TestProgressBlock(GTMSessionUploadFetcher *fetcher, int64_t bytesSen
 }
 
 @end
+
+#endif  // !TARGET_OS_WATCH

--- a/UnitTests/GTMSessionFetcherFetchingTest.h
+++ b/UnitTests/GTMSessionFetcherFetchingTest.h
@@ -13,6 +13,10 @@
  * limitations under the License.
  */
 
+#import <TargetConditionals.h>
+
+#if !TARGET_OS_WATCH
+
 #import <XCTest/XCTest.h>
 #import <stdlib.h>
 #import <sys/sysctl.h>
@@ -135,3 +139,5 @@ extern NSString *const kSubUIAppBackgroundTaskEnded;
 @end
 
 NS_ASSUME_NONNULL_END
+
+#endif  // !TARGET_OS_WATCH

--- a/UnitTests/GTMSessionFetcherFetchingTest.m
+++ b/UnitTests/GTMSessionFetcherFetchingTest.m
@@ -13,6 +13,10 @@
  * limitations under the License.
  */
 
+#import <TargetConditionals.h>
+
+#if !TARGET_OS_WATCH
+
 #if !defined(__has_feature) || !__has_feature(objc_arc)
 #error "This file requires ARC support."
 #endif
@@ -3250,3 +3254,5 @@ static bool IsCurrentProcessBeingDebugged(void) {
 
   return result;
 }
+
+#endif  // !TARGET_OS_WATCH

--- a/UnitTests/GTMSessionFetcherServiceTest.m
+++ b/UnitTests/GTMSessionFetcherServiceTest.m
@@ -13,6 +13,10 @@
  * limitations under the License.
  */
 
+#import <TargetConditionals.h>
+
+#if !TARGET_OS_WATCH
+
 #if !defined(__has_feature) || !__has_feature(objc_arc)
 #error "This file requires ARC support."
 #endif
@@ -1546,3 +1550,5 @@ static NSString *const kValidFileName = @"gettysburgaddress.txt";
 }
 
 @end
+
+#endif  // !TARGET_OS_WATCH

--- a/UnitTests/GTMSessionFetcherTestServer.h
+++ b/UnitTests/GTMSessionFetcherTestServer.h
@@ -13,6 +13,10 @@
  * limitations under the License.
  */
 
+#import <TargetConditionals.h>
+
+#if !TARGET_OS_WATCH
+
 #import <Foundation/Foundation.h>
 
 typedef enum {
@@ -53,3 +57,5 @@ typedef enum {
 + (NSData *)generatedBodyDataWithLength:(NSUInteger)length;
 
 @end
+
+#endif  // !TARGET_OS_WATCH

--- a/UnitTests/GTMSessionFetcherTestServer.m
+++ b/UnitTests/GTMSessionFetcherTestServer.m
@@ -13,6 +13,10 @@
  * limitations under the License.
  */
 
+#import <TargetConditionals.h>
+
+#if !TARGET_OS_WATCH
+
 #if !defined(__has_feature) || !__has_feature(objc_arc)
 #error "This file requires ARC support."
 #endif
@@ -833,3 +837,5 @@ static NSString *const kEtag = @"GoodETag";
 }
 
 @end
+
+#endif  // !TARGET_OS_WATCH


### PR DESCRIPTION
Like the LogViewer does, gate off the contents of the files that won't compiled
on unsupported platforms.