### PR TITLE
Drop the XML processing/formatting support.

### DIFF
--- a/Source/GTMSessionFetcherLogging.h
+++ b/Source/GTMSessionFetcherLogging.h
@@ -41,8 +41,6 @@
 //
 //   AppName_http_log_newest.html
 //
-// For better viewing of XML logs, use Camino or Firefox rather than Safari.
-//
 // Each fetcher may be given a comment to be inserted as a label in the logs,
 // such as
 //   [fetcher setCommentWithFormat:@"retrieve item %@", itemName];


### PR DESCRIPTION
Was only ever on macOS, and there's always the change the parser/formatter does
something to hide an edge case that was actually in the server's response. This
was most useful back in the GData days since they were all XML based.