### PR TITLE
Make the `pod lib lint` steps verbose.

### DIFF
--- a/.github/workflows/cocoapods.yml
+++ b/.github/workflows/cocoapods.yml
@@ -35,13 +35,13 @@ jobs:
     # Manually expanding out static frameworks to avoid making to many jobs.
     - name: Pod lib lint
       run:  |
-        pod lib lint \
+        pod lib lint --verbose \
           --configuration=${{ matrix.CONFIGURATION }} \
           --platforms=${{ matrix.PLATFORM }} \
           GTMSessionFetcher.podspec
     - name: Pod lib lint - Use Static Frameworks
       run:  |
-        pod lib lint --use-static-frameworks \
+        pod lib lint --verbose --use-static-frameworks \
           --configuration=${{ matrix.CONFIGURATION }} \
           --platforms=${{ matrix.PLATFORM }} \
           GTMSessionFetcher.podspec


### PR DESCRIPTION
When something fails, CocoaPods tends to print a short line about what failed,
but some times when `xcodebuild` fails, that isn't much detail, so just enable
the verbose flag so there is a better chance that the problem can be figured
out (or realized it is some Xcode flake).