### PR TITLE
Add new `.git-blame-ignore-revs` file.

### DIFF
--- a/.git-blame-ignore-revs
+++ b/.git-blame-ignore-revs
@@ -1,0 +1,3 @@
+# Running clang-format all over the place.
+915ec2ffb0f581aff5624a84a5dea2d3fc01c000
+


### PR DESCRIPTION
Allows hiding of blame information when using `--ignore-revs-file` either locally or globally. Currently hides the original run of `clang-format` over the code.