### PR TITLE
Invoke upload completion handler only after releasing callbacks.

### DIFF
--- a/UnitTests/GTMSessionFetcherChunkedUploadTest.m
+++ b/UnitTests/GTMSessionFetcherChunkedUploadTest.m
@@ -217,7 +217,6 @@ static NSString *const kPauseAtKey = @"pauseAt";
 static NSString *const kCancelAtKey = @"cancelAt";
 static NSString *const kRetryAtKey = @"retryAt";
 static NSString *const kOriginalURLKey = @"originalURL";
-static NSDictionary *const kSleepParamsDict = @{ @"sleep": @"0.2" };
 
 static void TestProgressBlock(GTMSessionUploadFetcher *fetcher, int64_t bytesSent,
                               int64_t totalBytesSent, int64_t totalBytesExpectedToSend) {
@@ -1369,7 +1368,7 @@ static void TestProgressBlock(GTMSessionUploadFetcher *fetcher, int64_t bytesSen
 
   // Add a sleep on the server side during each chunk fetch, to ensure there is time to pause
   // the fetcher before all chunk fetches complete.
-  NSURLRequest *request = [self validUploadFileRequestWithParameters:kSleepParamsDict];
+  NSURLRequest *request = [self validUploadFileRequestWithParameters:@{@"sleep" : @"0.2"}];
   NSData *bigData = [self bigUploadData];
   GTMSessionUploadFetcher *fetcher = [GTMSessionUploadFetcher uploadFetcherWithRequest:request
                                                                         uploadMIMEType:@"text/plain"
@@ -1430,7 +1429,7 @@ static void TestProgressBlock(GTMSessionUploadFetcher *fetcher, int64_t bytesSen
 
   // Add a sleep on the server side during each chunk fetch, to ensure there is time to pause
   // the fetcher before all chunk fetches complete.
-  NSURLRequest *request = [self validUploadFileRequestWithParameters:kSleepParamsDict];
+  NSURLRequest *request = [self validUploadFileRequestWithParameters:@{@"sleep" : @"0.2"}];
   NSData *bigData = [self bigUploadData];
   GTMSessionUploadFetcher *fetcher = [GTMSessionUploadFetcher uploadFetcherWithRequest:request
                                                                         uploadMIMEType:@"text/plain"


### PR DESCRIPTION
Captures the queue and handler block locally, before releasing all callbacks, and finally invokes the completion handler. This should fix the flake in tests, while being equivalent for overall behavior.