### PR TITLE
Add schedule CI runs.

### DIFF
--- a/.github/workflows/cocoapods.yml
+++ b/.github/workflows/cocoapods.yml
@@ -17,6 +17,9 @@ on:
     - 'Package*.swift'
     - 'Source/SwiftPackage/**'
     - '.github/workflows/swiftpm.yml'
+  schedule:
+    # Run the first and fifteenth of every month at 5:12 UTC
+    - cron:  '5 12 1,15 * *'
 
 jobs:
   pod-lib-lint:

--- a/.github/workflows/swiftpm.yml
+++ b/.github/workflows/swiftpm.yml
@@ -15,6 +15,9 @@ on:
     - 'LICENSE'
     - '*.podspec'
     - '.github/workflows/cocoapods.yml'
+  schedule:
+    # Run the first and fifteenth of every month at 5:12 UTC
+    - cron:  '5 12 1,15 * *'
 
 jobs:
   swift:


### PR DESCRIPTION
This will help catch when there are new images and thus new Xcode/Cocoapods
versions, and ensure things are still working.