### PR TITLE
Use xcpretty again for CI.

### DIFF
--- a/.github/workflows/swiftpm.yml
+++ b/.github/workflows/swiftpm.yml
@@ -64,8 +64,10 @@ jobs:
             ;;
         esac
 
+        set -o pipefail
         xcodebuild \
-          -scheme GTMSessionFetcher-Package \
-          -configuration ${{ matrix.CONFIGURATION }} \
-          -destination "${DESTINATION}" \
-          build test
+            -scheme GTMSessionFetcher-Package \
+            -configuration ${{ matrix.CONFIGURATION }} \
+            -destination "${DESTINATION}" \
+            build test \
+          | xcpretty


### PR DESCRIPTION
Used to conditionally enable this in script, but lost the support, so directly
adding it to the yml to help reduce the length out outputs.