### PR TITLE
Swap to the `macos-12` image.

### DIFF
--- a/.github/workflows/cocoapods.yml
+++ b/.github/workflows/cocoapods.yml
@@ -21,7 +21,10 @@ on:
 
 jobs:
   pod-lib-lint:
-    runs-on: macos-latest
+    # TODO: back to `macos-latest` once that is updated to point to the newer
+    # images for more current Xcode versions.
+    #  https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#choosing-github-hosted-runners
+    runs-on: macos-12
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/swiftpm.yml
+++ b/.github/workflows/swiftpm.yml
@@ -22,7 +22,11 @@ on:
 jobs:
   swift:
     # The swift command line only support build/testing for macOS on.
-    runs-on: macos-latest
+
+    # TODO: back to `macos-latest` once that is updated to point to the newer
+    # images for more current Xcode versions.
+    #  https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#choosing-github-hosted-runners
+    runs-on: macos-12
     strategy:
       fail-fast: false
       matrix:
@@ -38,7 +42,11 @@ jobs:
   xcodebuild:
     # Job(s) to build for all the platforms to ensure that is working and the
     # tests are passing.
-    runs-on: macos-latest
+
+    # TODO: back to `macos-latest` once that is updated to point to the newer
+    # images for more current Xcode versions.
+    #  https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#choosing-github-hosted-runners
+    runs-on: macos-12
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/test_apps.yml
+++ b/.github/workflows/test_apps.yml
@@ -16,7 +16,10 @@ on:
 
 jobs:
   xcodebuild:
-    runs-on: macos-latest
+    # TODO: back to `macos-latest` once that is updated to point to the newer
+    # images for more current Xcode versions.
+    #  https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#choosing-github-hosted-runners
+    runs-on: macos-12
     strategy:
       fail-fast: false
       matrix:


### PR DESCRIPTION
This can be reverted once `macos-latest` is updated to point to the newer image:
-  https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#choosing-github-hosted-runners

The `macos-11`/`macos-latest` image only has Xcode 13.2.1. The `macos-12` image
means we get a 13.x version:
-  https://github.com/actions/virtual-environments/blob/macOS-11/20220419.3/images/macos/macos-12-Readme.md
-  https://github.com/actions/virtual-environments/blob/macOS-11/20220419.3/images/macos/macos-11-Readme.md

This all matters because SwiftPM can have some issues with ObjC based tests.