### PR TITLE
Docs updates.

### DIFF
--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -1,6 +1,41 @@
-# Releasing GTMSessionFetcher
+# Development/Releasing of this Project
+
+## Development
+
+You can use CocoaPods or Swift Package Manager.
+
+**Reminder:** Please see the
+[CONTRIBUTING.md](https://github.com/google/gtm-session-fetcher/blob/main/CONTRIBUTING.md)
+file for how to contribute to this project.
+
+## Swift Package Manager
+
+*  `open Package.swift` or double click `Package.swift` in Finder.
+*  Xcode will open the project
+   *  The _GTMSessionFetcher-Package_ scheme seems generally the simplest to
+      build everything and run tests.
+   *  Choose a target platform by selecting the run destination along with the
+      scheme
+
+## CocoaPods
+
+Install
+*  CocoaPods 1.10.0 (or later)
+*  [CocoaPods generate](https://github.com/square/cocoapods-generate) - This is
+    not part of the _core_ cocoapods install.
+
+Generate an Xcode project from the podspec:
+
+```
+pod gen GTMSessionFetcher.podspec --local-sources=./ --auto-open --platforms=ios
+```
+
+Note: Set the `--platforms` option to `macos`, `tvos`, or `watchos` to
+develop/test for those platforms.
 
 ---
+
+## Releasing
 
 To update the version number and push a release:
 

--- a/README.md
+++ b/README.md
@@ -23,30 +23,6 @@ Features include:
 - Automatic rate limiting when created by the `GTMSessionFetcherService` factory class
 - Fully independent of other projects
 
-## Development of this Project
-
-You can use CocoaPods or Swift Package Manager.
-
-### Swift Package Manager
-
-* `open Package.swift` or double click `Package.swift` in Finder.
-* Xcode will open the project
-  * The _GTMSessionFetcher-Package_ scheme seems generally the simplest to build
-    everything and run tests.
-  * Choose a target platform by selecting the run destination along with the scheme
-
-### CocoaPods
-
-Install
-  * CocoaPods 1.10.0 (or later)
-  * [CocoaPods generate](https://github.com/square/cocoapods-generate) - This is
-    not part of the _core_ cocoapods install.
-
-Generate an Xcode project from the podspec:
-
-```
-pod gen GTMSessionFetcher.podspec --local-sources=./ --auto-open --platforms=ios
-```
-
-Note: Set the `--platforms` option to `macos`, `tvos`, or `watchos` to
-develop/test for those platforms.
+**To get started** please read
+[USING.md](https://github.com/google/google-api-objectivec-client-for-rest/blob/main/USING.md)
+for detailed information.

--- a/USING.md
+++ b/USING.md
@@ -12,23 +12,35 @@ The Google Toolbox for Mac Session Fetcher is a set of classes to simplify HTTP 
 - When you need to set a credential for the HTTP operation
 - When you want to support a synchronous or asynchronous authorization of requests, such as for OAuth 2
 
-# Using the Fetcher
+## Adding the Library to a Project
 
-## Adding the Fetcher to Your Project
+### Integration via CocoaPods
 
-Only the `GTMSessionFetcher.h/m` source files are strictly required, though using the Service class is highly recommended. If your application will make multiple fetches, the Service class will improve performance and provide added convenience methods and properties. The Logging class file is optional but useful for all applications.
+If you are building from CocoaPods, just use the pod provided: `GTMSessionFetcher`.
 
-| **Source files** | **Purpose** |
-| ---------------- | ----------- |
-| GTMSessionFetcher.h/m | required |
-| GTMSessionFetcherLogging.h/m | HTTP logging (often helpful) |
-| GTMSessionFetcherService.h/m | coordination across fetches, better performance |
-| GTMMIMEDocument.h/m, GTMGatherInputStream.h/m | multipart MIME uploads and downloads |
-| GTMSessionUploadFetcher.h/m | [resumable-uploads](https://developers.google.com/gdata/docs/resumable_upload) |
+The `Core` subspec includes the minimum parts of the library. There is also a `Full` subspec that includes some the multipart MIME uploads and downloads and [resumable-uploads](https://developers.google.com/gdata/docs/resumable_upload). The `LogView` subspec provides an iOS view that can easily be added to applications to allow viewing of the [logging](#http-logging) this library supports.
 
-### ARC Compatibility
+For example, if use the `Full` support, you'd just need to add:
 
-The fetcher source files can be compiled directly into a project that has ARC enabled. If the project doesn't have ARC enabled, it will need to be enabled for these files.
+```
+pod 'GTMSessionFetcher/Full'
+```
+
+To your `Podfile` and run `pod install`.
+
+### Integration via Swift Package Manager (SwiftPM)
+
+Refer to the Xcode docs for how to add SwiftPM based dependences to the Xcode UI or via your `Package.swift` file.
+
+The `GTMSessionFetcherCore` product includes the minimum parts of the library. There is also a `GTMSessionFetcherFull` product that includes some the multipart MIME uploads and downloads and [resumable-uploads](https://developers.google.com/gdata/docs/resumable_upload). The `GTMSessionFetcherLogView` product provides an iOS view that can easily be added to applications to allow viewing of the [logging](#http-logging) this library supports.
+
+For example, if you needed the _Full_ apis, you just need to depend on the `GTMSessionFetcherFull` product.
+
+### `#import`s and `@import`s
+
+Since CocoaPods and SwiftPM use different models for how things are built, the module names for `@import` directives will be specific to each packaging system.
+
+However, if consuming this library via Objective-C, all the packages export their headers as _GTMSessionFetcher/HEADER.h_, so you can always `#import` them as a framework import and that will work with either packaging system, i.e. - `#import <GTMSessionFetcher/GTMSessionFetcherService.h` and `#import <GTMSessionFetcher/GTMGatherInputStream.h`.
 
 ## Usage
 


### PR DESCRIPTION
- Move RELEASING -> DEVELOPMENT
- Move the development note out of the README.md and into the DEVELOPMENT one.
- Have the README point to the USING guidance.
- Update USING to cover the packaging systems and header imports (with the new
  structure)