### PR TITLE
Deprecating GTMFetcherAuthorizationProtocol in favor of new GTMSessionFetcherAuthorizer

### DIFF
--- a/Sources/Core/GTMSessionFetcher.m
+++ b/Sources/Core/GTMSessionFetcher.m
@@ -3814,6 +3814,8 @@ static NSMutableDictionary *gSystemCompletionHandlers = nil;
   }  // @synchronized(self)
 }
 
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wdeprecated"
 - (nullable id<GTMFetcherAuthorizationProtocol>)authorizer {
   @synchronized(self) {
     GTMSessionMonitorSynchronized(self);
@@ -3836,6 +3838,7 @@ static NSMutableDictionary *gSystemCompletionHandlers = nil;
     }
   }  // @synchronized(self)
 }
+#pragma clang diagnostic pop
 
 - (nullable NSData *)downloadedData {
   @synchronized(self) {

--- a/Sources/Core/GTMSessionFetcher.m
+++ b/Sources/Core/GTMSessionFetcher.m
@@ -1688,11 +1688,10 @@ NSData *_Nullable GTMDataFromInputStream(NSInputStream *inputStream, NSError **o
     // It's unknown how long an authorizer maintains ownership of the provided block, so
     // avoid potential retain cycles on self and the authorizer.
     __weak __typeof__(self) weakSelf = self;
-    __weak __typeof__(authorizer) weakAuthorizer = authorizer;
     NSMutableURLRequest *mutableRequest = [self.request mutableCopy];
     [authorizer authorizeRequest:mutableRequest
                completionHandler:^(NSError *_Nullable error) {
-                 [weakSelf authorizer:(id _Nonnull)weakAuthorizer
+                 [weakSelf authorizer:nil
                                request:mutableRequest
                      finishedWithError:error];
                }];
@@ -1710,7 +1709,10 @@ NSData *_Nullable GTMDataFromInputStream(NSInputStream *inputStream, NSError **o
   }
 }
 
-- (void)authorizer:(id)auth
+// The authorizer parameter is unused, and the block-based callback will never pass
+// non-nil; the field is only for the deprecated selector-based implementation for
+// legacy reasons.
+- (void)authorizer:(nullable id __unused)auth
               request:(nullable NSMutableURLRequest *)authorizedRequest
     finishedWithError:(nullable NSError *)error {
   GTMSessionCheckNotSynchronized(self);

--- a/Sources/Core/GTMSessionFetcherService.m
+++ b/Sources/Core/GTMSessionFetcherService.m
@@ -93,7 +93,10 @@ NSString *const kGTMSessionFetcherServiceSessionKey = @"kGTMSessionFetcherServic
   NSURLCredential *_credential;       // Username & password.
   NSURLCredential *_proxyCredential;  // Credential supplied to proxy servers.
 
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wdeprecated"
   id<GTMFetcherAuthorizationProtocol> _authorizer;
+#pragma clang diagnostic pop
 
   // For waitForCompletionOfAllFetchersWithTimeout: we need to wait on stopped fetchers since
   // they've not yet finished invoking their queued callbacks. This array is nil except when
@@ -822,6 +825,8 @@ NSString *const kGTMSessionFetcherServiceSessionKey = @"kGTMSessionFetcherServic
   }
 }
 
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wdeprecated"
 - (id<GTMFetcherAuthorizationProtocol>)authorizer {
   @synchronized(self) {
     GTMSessionMonitorSynchronized(self);
@@ -847,6 +852,7 @@ NSString *const kGTMSessionFetcherServiceSessionKey = @"kGTMSessionFetcherServic
     [obj setFetcherService:self];
   }
 }
+#pragma clang diagnostic pop
 
 // This should be called inside a @synchronized(self) block except during dealloc.
 - (void)detachAuthorizer {

--- a/Sources/Core/Public/GTMSessionFetcher/GTMSessionFetcherService.h
+++ b/Sources/Core/Public/GTMSessionFetcher/GTMSessionFetcherService.h
@@ -80,10 +80,13 @@ extern NSString *const kGTMSessionFetcherServiceSessionKey;
 // To use the configuration's default user agent, set this property to nil.
 @property(atomic, copy, nullable) NSString *userAgent;
 
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wdeprecated"
 // The authorizer to attach to the created fetchers. If a specific fetcher should
 // not authorize its requests, the fetcher's authorizer property may be set to nil
 // before the fetch begins.
 @property(atomic, strong, nullable) id<GTMFetcherAuthorizationProtocol> authorizer;
+#pragma clang diagnostic pop
 
 // Delegate queue used by the session when calling back to the fetcher.  The default
 // is the main queue.  Changing this does not affect the queue used to call back to the

--- a/UnitTests/GTMSessionFetcherFetchingTest.h
+++ b/UnitTests/GTMSessionFetcherFetchingTest.h
@@ -71,7 +71,7 @@ extern NSString *const kGTMGettysburgFileName;
 @end
 
 // Authorization testing.
-@interface TestAuthorizer : NSObject <GTMFetcherAuthorizationProtocol>
+@interface TestAuthorizer : NSObject <GTMSessionFetcherAuthorizer>
 
 @property(atomic, assign, getter=isAsync) BOOL async;
 @property(atomic, assign, getter=isExpired) BOOL expired;

--- a/UnitTests/GTMSessionFetcherFetchingTest.m
+++ b/UnitTests/GTMSessionFetcherFetchingTest.m
@@ -2838,7 +2838,6 @@ NSString *const kGTMGettysburgFileName = @"gettysburgaddress.txt";
            [invocation setArgument:&selfParam atIndex:2];
            [invocation setArgument:&requestParam atIndex:3];
            [invocation setArgument:&error atIndex:4];
-           [invocation setArgument:&error atIndex:4];
            [invocation invoke];
          }];
   }


### PR DESCRIPTION
GTMFetcherAuthorizationProtocol uses a id/selector-based callback, which does not play nicely with implementations done in Swift. While the protocol also has an optional block-based form, that block-based callback was never used.

The new protocol implements the old protocol, switching the `@required` and `@optional` methods; meanwhile the old protocol is marked deprecated, along with the `@required` method. This will trigger warnings, which are squashed by conforming to the new protocol and ensuring the block-based form is implemented.

The fetcher is further updated to call the `@optional` method if available, and not call the `@required` authorize-request method unless the `@optional` form does not exist. This allows priority for the block-based form.

Whenever the Fetcher is bumped to v3 the old protocol should be deleted and have its other, non-deprecated methods migrated into the new protocol.

Addresses #314.