### PR TITLE
Add #if DEBUG to vars not used outside of DEBUG

### DIFF
--- a/Sources/Full/GTMMIMEDocument.m
+++ b/Sources/Full/GTMMIMEDocument.m
@@ -364,10 +364,14 @@ static void SearchDataForBytes(NSData *data, const void *targetBytes, NSUInteger
   }
   NSMutableArray *parts;
   NSInteger previousBoundaryOffset = -1;
+#if DEBUG
   NSInteger partCounter = -1;
   NSInteger numberOfPartsWithHeaders = 0;
+#endif
   for (NSNumber *currentBoundaryOffset in foundBoundaryOffsets) {
+#if DEBUG
     ++partCounter;
+#endif
     if (previousBoundaryOffset == -1) {
       // This is the first boundary.
       previousBoundaryOffset = currentBoundaryOffset.integerValue;
@@ -441,7 +445,9 @@ static void SearchDataForBytes(NSData *data, const void *targetBytes, NSUInteger
                 partData, (size_t)headerSeparatorOffset + 4,
                 (size_t)(previousPartDataLength - (headerSeparatorOffset + 4)));
 
+#if DEBUG
             numberOfPartsWithHeaders++;
+#endif
           }  // crlfOffsets.count == 0
         }    // hasAnotherCRLF
 


### PR DESCRIPTION
Add #if DEBUG directive to variables not used outside of DEBUG to fix -wunused-but-set-variable warning.

Because the variables `partCounter` and `numberOfPartsWithHeaders` were used only in `#if Debug` directives, updated compiler could not detect that they were in use and threw the -wunused-but-set-variable warning. This fixes the warning.