### PR TITLE
Convert `#pragma unused()` uses to `__unused`.

### DIFF
--- a/Sources/Core/GTMSessionFetcher.m
+++ b/Sources/Core/GTMSessionFetcher.m
@@ -4072,10 +4072,8 @@ static NSMutableDictionary *gSystemCompletionHandlers = nil;
       // On both the simulator and devices, the path can change to the download file, but the name
       // shouldn't change. Technically, this isn't supported in the fetcher, but the change of
       // URL is expected to happen only across development runs through Xcode.
-      NSString *oldFilename = [_destinationFileURL lastPathComponent];
-      NSString *newFilename = [destinationFileURL lastPathComponent];
-#pragma unused(oldFilename)
-#pragma unused(newFilename)
+      __unused NSString *oldFilename = [_destinationFileURL lastPathComponent];
+      __unused NSString *newFilename = [destinationFileURL lastPathComponent];
       GTMSESSION_ASSERT_DEBUG(
           [oldFilename isEqualToString:newFilename],
           @"Destination File URL cannot be changed after session identifier has been created");

--- a/Sources/Core/GTMSessionUploadFetcher.m
+++ b/Sources/Core/GTMSessionUploadFetcher.m
@@ -513,8 +513,7 @@ NSString *const kGTMSessionFetcherUploadLocationObtainedNotification =
     int hasFileHandle = (_uploadFileHandle != nil) ? 1 : 0;
     int hasFileURL = (_uploadFileURL != nil) ? 1 : 0;
     int hasUploadDataProvider = (_uploadDataProvider != nil) ? 1 : 0;
-    int numberOfSources = hasData + hasFileHandle + hasFileURL + hasUploadDataProvider;
-#pragma unused(numberOfSources)
+    __unused int numberOfSources = hasData + hasFileHandle + hasFileURL + hasUploadDataProvider;
     GTMSESSION_ASSERT_DEBUG(numberOfSources == 1, @"Need just one upload source (%d)",
                             numberOfSources);
   }  // @synchronized(self)
@@ -982,8 +981,8 @@ NSString *const kGTMSessionFetcherUploadLocationObtainedNotification =
   // resumable request/response.
   if (self.downloadedData.length > 0) {
     NSData *downloadedData = self.downloadedData;
-    NSString *str = [[NSString alloc] initWithData:downloadedData encoding:NSUTF8StringEncoding];
-#pragma unused(str)
+    __unused NSString *str = [[NSString alloc] initWithData:downloadedData
+                                                   encoding:NSUTF8StringEncoding];
     GTMSESSION_ASSERT_DEBUG(NO, @"unexpected response data (uploading to the wrong URL?)\n%@", str);
   }
 #endif
@@ -1517,9 +1516,8 @@ NSString *const kGTMSessionFetcherUploadLocationObtainedNotification =
 #if DEBUG
     // Verify that if we think all of the uploading data has been sent, the server responded with
     // the "final" upload status.
-    BOOL hasUploadAllData = (newOffset == [self fullUploadLength]);
-    BOOL isFinalStatus = (uploadStatus == kStatusFinal);
-#pragma unused(hasUploadAllData, isFinalStatus)
+    __unused BOOL hasUploadAllData = (newOffset == [self fullUploadLength]);
+    __unused BOOL isFinalStatus = (uploadStatus == kStatusFinal);
     GTMSESSION_ASSERT_DEBUG(hasUploadAllData == isFinalStatus || !hasKnownChunkSize,
                             @"uploadStatus:%@  newOffset:%lld (%lld + %lld)  fullUploadLength:%lld"
                             @" chunkFetcher:%@ requestHeaders:%@ responseHeaders:%@",

--- a/UnitTests/GTMSessionFetcherFetchingTest.m
+++ b/UnitTests/GTMSessionFetcherFetchingTest.m
@@ -3142,9 +3142,7 @@ UIBackgroundTaskIdentifier gTaskID = 1000;
 - (void)uploadLocationObtained:(NSNotification *)note {
   if ([self shouldIgnoreNotification:note]) return;
 
-  GTMSessionUploadFetcher *fetcher = note.object;
-#pragma unused(fetcher)  // Unused when NS_BLOCK_ASSERTIONS
-
+  __unused GTMSessionUploadFetcher *fetcher = note.object;
   NSAssert(fetcher.uploadLocationURL != nil, @"missing upload location: %@", fetcher);
 
   ++_uploadLocationObtained;


### PR DESCRIPTION
Going for consistency. #cleanup