### PR TITLE
Replace `dispatch_semaphore` use with `os_unfair_lock`.

### DIFF
--- a/Sources/Core/GTMSessionFetcher.m
+++ b/Sources/Core/GTMSessionFetcher.m
@@ -649,74 +649,15 @@ static GTMSessionFetcherTestBlock _Nullable gGlobalTestBlock;
 
   self.canShareSession = (_service != nil) && !isRecreatingSession && !self.usingBackgroundSession;
 
-  if (!self.session && self.canShareSession) {
-    self.session = [_service sessionForFetcherCreation];
-    // If _session is nil, then the service's session creation semaphore will block
-    // until this fetcher invokes fetcherDidCreateSession: below, so this *must* invoke
-    // that method, even if the session fails to be created.
-  }
-
   if (!self.session) {
-    // Create a session.
-    if (!_configuration) {
-      if (priorSessionIdentifier || self.usingBackgroundSession) {
-        NSString *sessionIdentifier = priorSessionIdentifier;
-        if (!sessionIdentifier) {
-          sessionIdentifier = [self createSessionIdentifierWithMetadata:nil];
-        }
-        NSMapTable *sessionIdentifierToFetcherMap = [[self class] sessionIdentifierToFetcherMap];
-        [sessionIdentifierToFetcherMap setObject:self forKey:self.sessionIdentifier];
-
-        _configuration = [NSURLSessionConfiguration
-            backgroundSessionConfigurationWithIdentifier:sessionIdentifier];
-        self.usingBackgroundSession = YES;
-        self.canShareSession = NO;
-      } else {
-        _configuration = [NSURLSessionConfiguration ephemeralSessionConfiguration];
-      }
-#if !GTM_ALLOW_INSECURE_REQUESTS
-#if GTM_SDK_REQUIRES_TLSMINIMUMSUPPORTEDPROTOCOLVERSION
-      _configuration.TLSMinimumSupportedProtocolVersion = tls_protocol_version_TLSv12;
-#elif GTM_SDK_SUPPORTS_TLSMINIMUMSUPPORTEDPROTOCOLVERSION
-      if (@available(iOS 13, tvOS 13, macOS 10.15, *)) {
-        _configuration.TLSMinimumSupportedProtocolVersion = tls_protocol_version_TLSv12;
-      } else {
-        _configuration.TLSMinimumSupportedProtocol = kTLSProtocol12;
-      }
-#else
-      _configuration.TLSMinimumSupportedProtocol = kTLSProtocol12;
-#endif  // GTM_SDK_REQUIRES_TLSMINIMUMSUPPORTEDPROTOCOLVERSION
-#endif
-    }  // !_configuration
-    _configuration.HTTPCookieStorage = self.cookieStorage;
-
-    if (_configurationBlock) {
-      _configurationBlock(self, _configuration);
-    }
-
-    id<NSURLSessionDelegate> delegate = [_service sessionDelegate];
-    if (!delegate || !self.canShareSession) {
-      delegate = self;
-    }
-    self.session = [NSURLSession sessionWithConfiguration:_configuration
-                                                 delegate:delegate
-                                            delegateQueue:self.sessionDelegateQueue];
-    GTMSESSION_ASSERT_DEBUG(self.session, @"Couldn't create session");
-
-    // Tell the service about the session created by this fetcher.  This also signals the
-    // service's semaphore to allow other fetchers to request this session.
-    [_service fetcherDidCreateSession:self];
-
-    // If this assertion fires, the client probably tried to use a session identifier that was
-    // already used. The solution is to make the client use a unique identifier (or better yet let
-    // the session fetcher assign the identifier).
-    GTMSESSION_ASSERT_DEBUG(self.session.delegate == delegate, @"Couldn't assign delegate.");
-
-    if (self.session) {
-      BOOL isUsingSharedDelegate = (delegate != self);
-      if (!isUsingSharedDelegate) {
-        _shouldInvalidateSession = YES;
-      }
+    if (self.canShareSession) {
+      self.session = [_service
+          sessionWithCreationBlock:^NSURLSession *(id<NSURLSessionDelegate> sessionDelegate) {
+            return [self createSessionWithDelegate:sessionDelegate
+                                 sessionIdentifier:priorSessionIdentifier];
+          }];
+    } else {
+      self.session = [self createSessionWithDelegate:self sessionIdentifier:priorSessionIdentifier];
     }
   }
 
@@ -992,6 +933,73 @@ static GTMSessionFetcherTestBlock _Nullable gGlobalTestBlock;
     // of the session task.
     [newSessionTask resume];
   }
+}
+
+// Helper method to create a new NSURLSession for this fetcher. Because the original
+// implementation had this code inline, marking direct to avoid any danger of subclasses
+// overriding the behavior.
+- (NSURLSession *)createSessionWithDelegate:(id<NSURLSessionDelegate>)sessionDelegate
+                          sessionIdentifier:(nullable NSString *)priorSessionIdentifier
+    __attribute__((objc_direct)) {
+  // Create a session.
+  if (!_configuration) {
+    if (priorSessionIdentifier || self.usingBackgroundSession) {
+      NSString *sessionIdentifier = priorSessionIdentifier;
+      if (!sessionIdentifier) {
+        sessionIdentifier = [self createSessionIdentifierWithMetadata:nil];
+      }
+      NSMapTable *sessionIdentifierToFetcherMap = [[self class] sessionIdentifierToFetcherMap];
+      [sessionIdentifierToFetcherMap setObject:self forKey:self.sessionIdentifier];
+
+      _configuration = [NSURLSessionConfiguration
+          backgroundSessionConfigurationWithIdentifier:sessionIdentifier];
+      self.usingBackgroundSession = YES;
+      self.canShareSession = NO;
+    } else {
+      _configuration = [NSURLSessionConfiguration ephemeralSessionConfiguration];
+    }
+#if !GTM_ALLOW_INSECURE_REQUESTS
+#if GTM_SDK_REQUIRES_TLSMINIMUMSUPPORTEDPROTOCOLVERSION
+    _configuration.TLSMinimumSupportedProtocolVersion = tls_protocol_version_TLSv12;
+#elif GTM_SDK_SUPPORTS_TLSMINIMUMSUPPORTEDPROTOCOLVERSION
+    if (@available(iOS 13, tvOS 13, macOS 10.15, *)) {
+      _configuration.TLSMinimumSupportedProtocolVersion = tls_protocol_version_TLSv12;
+    } else {
+      _configuration.TLSMinimumSupportedProtocol = kTLSProtocol12;
+    }
+#else
+    _configuration.TLSMinimumSupportedProtocol = kTLSProtocol12;
+#endif  // GTM_SDK_REQUIRES_TLSMINIMUMSUPPORTEDPROTOCOLVERSION
+#endif
+  }  // !_configuration
+  _configuration.HTTPCookieStorage = self.cookieStorage;
+
+  if (_configurationBlock) {
+    _configurationBlock(self, _configuration);
+  }
+
+  id<NSURLSessionDelegate> delegate = sessionDelegate;
+  if (!delegate || !self.canShareSession) {
+    delegate = self;
+  }
+  NSURLSession *session = [NSURLSession sessionWithConfiguration:_configuration
+                                                        delegate:delegate
+                                                   delegateQueue:self.sessionDelegateQueue];
+  GTMSESSION_ASSERT_DEBUG(session, @"Couldn't create session");
+
+  // If this assertion fires, the client probably tried to use a session identifier that was
+  // already used. The solution is to make the client use a unique identifier (or better yet let
+  // the session fetcher assign the identifier).
+  GTMSESSION_ASSERT_DEBUG(session.delegate == delegate, @"Couldn't assign delegate.");
+
+  if (session) {
+    BOOL isUsingSharedDelegate = (delegate != self);
+    if (!isUsingSharedDelegate) {
+      _shouldInvalidateSession = YES;
+    }
+  }
+
+  return session;
 }
 
 NSData *_Nullable GTMDataFromInputStream(NSInputStream *inputStream, NSError **outError) {

--- a/Sources/Core/Public/GTMSessionFetcher/GTMSessionFetcher.h
+++ b/Sources/Core/Public/GTMSessionFetcher/GTMSessionFetcher.h
@@ -459,6 +459,8 @@ typedef void (^GTMSessionFetcherConfigurationBlock)(GTMSessionFetcher *fetcher,
 typedef void (^GTMSessionFetcherSystemCompletionHandler)(void);
 typedef void (^GTMSessionFetcherCompletionHandler)(NSData *_Nullable data,
                                                    NSError *_Nullable error);
+typedef NSURLSession *_Nullable (^GTMSessionFetcherSessionCreationBlock)(
+    id<NSURLSessionDelegate> _Nullable sessionDelegate);
 typedef void (^GTMSessionFetcherBodyStreamProviderResponse)(NSInputStream *bodyStream);
 typedef void (^GTMSessionFetcherBodyStreamProvider)(
     GTMSessionFetcherBodyStreamProviderResponse response);
@@ -619,7 +621,6 @@ typedef void (^GTMFetcherDecoratorFetcherWillStartCompletionHandler)(NSURLReques
 @property(atomic, strong) dispatch_queue_t callbackQueue;
 
 - (BOOL)fetcherShouldBeginFetching:(GTMSessionFetcher *)fetcher;
-- (void)fetcherDidCreateSession:(GTMSessionFetcher *)fetcher;
 - (void)fetcherDidBeginFetching:(GTMSessionFetcher *)fetcher;
 - (void)fetcherDidStop:(GTMSessionFetcher *)fetcher;
 
@@ -628,7 +629,8 @@ typedef void (^GTMFetcherDecoratorFetcherWillStartCompletionHandler)(NSURLReques
 
 @property(atomic, assign) BOOL reuseSession;
 - (nullable NSURLSession *)session;
-- (nullable NSURLSession *)sessionForFetcherCreation;
+- (nullable NSURLSession *)sessionWithCreationBlock:
+    (nonnull NS_NOESCAPE GTMSessionFetcherSessionCreationBlock)creationBlock;
 - (nullable id<NSURLSessionDelegate>)sessionDelegate;
 - (nullable NSDate *)stoppedAllFetchersDate;
 

--- a/Sources/Core/Public/GTMSessionFetcher/GTMSessionFetcherService.h
+++ b/Sources/Core/Public/GTMSessionFetcher/GTMSessionFetcherService.h
@@ -168,7 +168,8 @@ extern NSString *const kGTMSessionFetcherServiceSessionKey;
 
 // Methods for use by the fetcher class only.
 - (nullable NSURLSession *)session;
-- (nullable NSURLSession *)sessionForFetcherCreation;
+- (nullable NSURLSession *)sessionWithCreationBlock:
+    (nonnull NS_NOESCAPE GTMSessionFetcherSessionCreationBlock)creationBlock;
 - (nullable id<NSURLSessionDelegate>)sessionDelegate;
 - (nullable NSDate *)stoppedAllFetchersDate;
 


### PR DESCRIPTION
Xcode 14 thread checker has flagged potential priority inversion issues relating to use of `dispatch_semaphore` when handling session creation and dispatcher resetting. This replaces uses of semaphores with `os_unfair_lock` which is available on iOS 10+ and all other platforms we're concerned with.

To avoid the danger of leaking the lock, this also refactors session creation by having `GTMSessionFetcher` instances provide a session creation block to the service, which is only called if the service does not have an active `NSURLSession`.