### PR TITLE
Enable `.allowLocalhostRequest` on some tests failing under Xcode 14.

### DIFF
--- a/UnitTests/GTMSessionFetcherFetchingTest.m
+++ b/UnitTests/GTMSessionFetcherFetchingTest.m
@@ -1903,7 +1903,7 @@ NSString *const kGTMGettysburgFileName = @"gettysburgaddress.txt";
         testResponse(nil, [NSData data], nil);
       };
 
-  CREATE_START_STOP_NOTIFICATION_EXPECTATIONS(10, 10);
+  CREATE_START_STOP_NOTIFICATION_EXPECTATIONS(6, 6);
 
   for (int i = 0; records[i].urlString; i++) {
     NSString *urlString = records[i].urlString;

--- a/UnitTests/GTMSessionFetcherServiceTest.m
+++ b/UnitTests/GTMSessionFetcherServiceTest.m
@@ -434,6 +434,7 @@ static bool IsCurrentProcessBeingDebugged(void) {
   if (!_isServerRunning) return;
 
   GTMSessionFetcherService *service = [[GTMSessionFetcherService alloc] init];
+  service.allowLocalhostRequest = YES;
   [service setConcurrentCallbackQueue:dispatch_get_global_queue(QOS_CLASS_USER_INITIATED, 0)];
 
   XCTestExpectation *progressExpectation = [self expectationWithDescription:@"progress block"];
@@ -1541,6 +1542,7 @@ static bool IsCurrentProcessBeingDebugged(void) {
   __block NSURLSessionTaskMetrics *collectedMetrics = nil;
 
   GTMSessionFetcherService *service = [[GTMSessionFetcherService alloc] init];
+  service.allowLocalhostRequest = YES;
   service.metricsCollectionBlock = ^(NSURLSessionTaskMetrics *_Nonnull metrics) {
     collectedMetrics = metrics;
   };


### PR DESCRIPTION
I should probably track down what triggered these to start failing in Xcode 14.