### PR TITLE
Bump minimum iOS version to 10.0.

### DIFF
--- a/.github/workflows/cocoapods.yml
+++ b/.github/workflows/cocoapods.yml
@@ -28,7 +28,8 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        PLATFORM: ["ios", "macos", "tvos", "watchos"]
+        # Add back watchOS. See CocoaPods/CocoaPods#11558
+        PLATFORM: ["ios", "macos", "tvos"]
         CONFIGURATION: ["Debug", "Release"]
     steps:
     - uses: actions/checkout@v2

--- a/GTMSessionFetcher.podspec
+++ b/GTMSessionFetcher.podspec
@@ -17,7 +17,7 @@ Pod::Spec.new do |s|
   and uses operating-system settings.
   DESC
 
-  ios_deployment_target = '9.0'
+  ios_deployment_target = '10.0'
   osx_deployment_target = '10.12'
   tvos_deployment_target = '10.0'
   watchos_deployment_target = '6.0'

--- a/Package.swift
+++ b/Package.swift
@@ -5,7 +5,7 @@ import PackageDescription
 let package = Package(
     name: "GTMSessionFetcher",
     platforms: [
-        .iOS(.v9),
+        .iOS(.v10),
         .macOS(.v10_12),
         .tvOS(.v10),
         .watchOS(.v6)

--- a/Sources/Core/GTMSessionFetcherService.m
+++ b/Sources/Core/GTMSessionFetcherService.m
@@ -180,19 +180,7 @@ NSString *const kGTMSessionFetcherServiceSessionKey = @"kGTMSessionFetcherServic
     if (!_callbackQueueIsConcurrent) return _callbackQueue;
 
     static const char *kQueueLabel = "com.google.GTMSessionFetcher.serialCallbackQueue";
-    dispatch_queue_t queue;
-#if TARGET_OS_IOS && (__IPHONE_OS_VERSION_MIN_REQUIRED < __IPHONE_10_0)
-    // All targets except iPhone < iOS 10 support dispatch_queue_create_with_target().
-    // iOS builds supporting <iOS 10 will create the queue and set the target separately,
-    // but all other builds have mininum support that includes the one-stop function.
-    queue = dispatch_queue_create(kQueueLabel, DISPATCH_QUEUE_SERIAL);
-    dispatch_set_target_queue(queue, _callbackQueue);
-#else
-    // All other targets support dispatch_queue_create_with_target()
-    queue = dispatch_queue_create_with_target(kQueueLabel, DISPATCH_QUEUE_SERIAL, _callbackQueue);
-#endif
-
-    return queue;
+    return dispatch_queue_create_with_target(kQueueLabel, DISPATCH_QUEUE_SERIAL, _callbackQueue);
   }
 }
 

--- a/TestApps/TestApps.xcodeproj/project.pbxproj
+++ b/TestApps/TestApps.xcodeproj/project.pbxproj
@@ -494,7 +494,7 @@
 					../Sources/Core/Public,
 					../Sources/Full/Public,
 				);
-				IPHONEOS_DEPLOYMENT_TARGET = 9.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 10.0;
 				MACOSX_DEPLOYMENT_TARGET = 10.12;
 				ONLY_ACTIVE_ARCH = YES;
 				SDKROOT = macosx;
@@ -579,7 +579,7 @@
 					../Sources/Core/Public,
 					../Sources/Full/Public,
 				);
-				IPHONEOS_DEPLOYMENT_TARGET = 9.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 10.0;
 				MACOSX_DEPLOYMENT_TARGET = 10.12;
 				SDKROOT = macosx;
 				TVOS_DEPLOYMENT_TARGET = 10.0;


### PR DESCRIPTION
This will allow use of some iOS 10-minimum features, and any other cleanup.

Firebase updated iOS minimum (https://github.com/firebase/firebase-ios-sdk/pull/6517).