### PR TITLE
Fix Swift async fetcher leak

### DIFF
--- a/Sources/Core/GTMSessionFetcher.m
+++ b/Sources/Core/GTMSessionFetcher.m
@@ -2000,7 +2000,7 @@ NSData *_Nullable GTMDataFromInputStream(NSInputStream *inputStream, NSError **o
   [holdSelf destroyRetryTimer];
 
   BOOL sendStopNotification = YES;
-  BOOL cancelStopFetcher = NO;
+  BOOL callbacksPending = NO;
   @synchronized(self) {
     GTMSessionMonitorSynchronized(self);
 
@@ -2072,7 +2072,7 @@ NSData *_Nullable GTMDataFromInputStream(NSInputStream *inputStream, NSError **o
         }
       }
     }
-    cancelStopFetcher = _stopFetchingTriggersCompletionHandler && _userStoppedFetching;
+    callbacksPending = _stopFetchingTriggersCompletionHandler && _userStoppedFetching;
   }  // @synchronized(self)
 
   // If the NSURLSession needs to be invalidated, but needs to wait until the delegate method
@@ -2090,9 +2090,7 @@ NSData *_Nullable GTMDataFromInputStream(NSInputStream *inputStream, NSError **o
     self.authorizer = nil;
   }
 
-  if (!cancelStopFetcher) {
-    [service fetcherDidStop:self];
-  }
+  [service fetcherDidStop:self callbacksPending:callbacksPending];
 
 #if GTM_BACKGROUND_TASK_FETCHING
   [self endBackgroundTask];

--- a/Sources/Core/GTMSessionFetcherService+Internal.h
+++ b/Sources/Core/GTMSessionFetcherService+Internal.h
@@ -25,5 +25,6 @@
     (nonnull NS_NOESCAPE GTMSessionFetcherSessionCreationBlock)creationBlock;
 - (nullable id<NSURLSessionDelegate>)sessionDelegate;
 - (nullable NSDate *)stoppedAllFetchersDate;
+- (void)fetcherDidStop:(nonnull GTMSessionFetcher *)fetcher callbacksPending: (BOOL)callbacksPending;
 
 @end

--- a/Sources/Core/GTMSessionFetcherService.m
+++ b/Sources/Core/GTMSessionFetcherService.m
@@ -474,6 +474,10 @@ NSString *const kGTMSessionFetcherServiceSessionKey = @"kGTMSessionFetcherServic
 }
 
 - (void)fetcherDidStop:(GTMSessionFetcher *)fetcher {
+  [self fetcherDidStop:fetcher callbacksPending:false];
+}
+
+- (void)fetcherDidStop:(GTMSessionFetcher *)fetcher callbacksPending:(BOOL) callbacksPending {
   // Entry point from the fetcher
   NSString *host = fetcher.serviceHost;
   if (!host) {
@@ -483,9 +487,11 @@ NSString *const kGTMSessionFetcherServiceSessionKey = @"kGTMSessionFetcherServic
 
   // This removeFetcher: invocation is a fallback; typically, fetchers are removed from the task
   // map when the task completes.
-  GTMSessionFetcherSessionDelegateDispatcher *delegateDispatcher =
-      [self delegateDispatcherForFetcher:fetcher];
-  [delegateDispatcher removeFetcher:fetcher];
+  if (!callbacksPending) {
+    GTMSessionFetcherSessionDelegateDispatcher *delegateDispatcher =
+    [self delegateDispatcherForFetcher:fetcher];
+    [delegateDispatcher removeFetcher:fetcher];
+  }
 
   NSMutableArray *fetchersToStart;
 


### PR DESCRIPTION
Fix internal b/274149394:

_When using [GTMSessionFetcher](https://source.corp.google.com/piper///depot/google3/third_party/objective_c/gtm_session_fetcher/Source/GTMSessionFetcher.h) with swift async programming, after some fetcher cancellations, any new GTMSessionFetcher instances created from the [GTMSessionFetcherService](https://source.corp.google.com/piper///depot/google3/third_party/objective_c/gtm_session_fetcher/Source/GTMSessionFetcherService.h) stops working as the previously cancelled fetcher instances are not being removed from service cache._ 

This PR restores the removed (in #328) `fetcherDidStop` invocation and does everything in it except removing the fetcher in the delegateDispatcher - so the callback can still run.

The PR also adds two additional unit tests to verify the cleanup of the `service.delayedFetchersByHost` and 
 `runningFetchersByHost` arrays when stopFetch is called on fetchers individually with and without callbacks enabled.