### PR TITLE
New option to calculate User-Agent string asynchronously and cache it

### DIFF
--- a/Sources/Core/GTMSessionFetcher.m
+++ b/Sources/Core/GTMSessionFetcher.m
@@ -713,6 +713,25 @@ static GTMSessionFetcherTestBlock _Nullable gGlobalTestBlock;
     }
   }
 
+  if ([fetchRequest valueForHTTPHeaderField:@"User-Agent"] == nil) {
+    id<GTMUserAgentProvider> userAgentProvider = _userAgentProvider;
+    NSString *cachedUserAgent = userAgentProvider.cachedUserAgent;
+    if (cachedUserAgent) {
+      // The User-Agent is already cached in memory, so set it synchronously.
+      [fetchRequest setValue:cachedUserAgent forHTTPHeaderField:@"User-Agent"];
+    } else if (userAgentProvider != nil) {
+      // The User-Agent is not cached in memory. Fetch it asynchronously.
+      [self updateUserAgentAsynchronouslyForRequest:fetchRequest
+                                  userAgentProvider:userAgentProvider
+                                           mayDelay:mayDelay
+                                       mayAuthorize:mayAuthorize
+                                        mayDecorate:mayDecorate];
+      // This method can't continue until the User-Agent header is fetched. The above
+      // method call will re-enter this method later, but with the User-Agent header set.
+      return;
+    }
+  }
+
   NSString *effectiveHTTPMethod = [fetchRequest valueForHTTPHeaderField:@"X-HTTP-Method-Override"];
   if (effectiveHTTPMethod == nil) {
     effectiveHTTPMethod = fetchRequest.HTTPMethod;
@@ -1002,6 +1021,49 @@ static GTMSessionFetcherTestBlock _Nullable gGlobalTestBlock;
   }
 
   return session;
+}
+
+// Asynchronously calculates the User-Agent header from |userAgentProvider|, then
+// sets it in |fetchRequest| and continues the request.
+- (void)updateUserAgentAsynchronouslyForRequest:(NSMutableURLRequest *)fetchRequest
+                              userAgentProvider:(id<GTMUserAgentProvider>)userAgentProvider
+                                       mayDelay:(BOOL)mayDelay
+                                   mayAuthorize:(BOOL)mayAuthorize
+                                    mayDecorate:(BOOL)mayDecorate {
+  GTMSESSION_LOG_DEBUG_VERBOSE(
+      @"GTMSessionFetcher fetching User-Agent from GTMUserAgentProvider %@...", _userAgentProvider);
+  __weak __typeof__(self) weakSelf = self;
+  dispatch_async(dispatch_get_global_queue(DISPATCH_QUEUE_PRIORITY_DEFAULT, 0), ^{
+    __strong __typeof__(self) strongSelf = weakSelf;
+    if (!strongSelf) {
+      GTMSESSION_LOG_DEBUG_VERBOSE(@"GTMSessionFetcher deallocated before GTMUserAgentProvider "
+                                   @"fetch dispatched, ignoring.");
+      return;
+    }
+    NSString *userAgent = [userAgentProvider userAgent];
+    GTMSESSION_LOG_DEBUG_VERBOSE(@"Fetched User-Agent string: [%@]", userAgent);
+    GTMSESSION_ASSERT_DEBUG(userAgentProvider.cachedUserAgent != nil,
+                            @"GTMUserAgentProvider %@ should have cached user agent now that it's "
+                            @"calculated, but returned nil",
+                            userAgentProvider);
+    BOOL shouldStop;
+    @synchronized(strongSelf) {
+      GTMSessionMonitorSynchronized(strongSelf);
+      [strongSelf->_request setValue:userAgent forHTTPHeaderField:@"User-Agent"];
+      shouldStop = strongSelf->_userStoppedFetching;
+    }
+    if (shouldStop) {
+      NSError *error = [NSError errorWithDomain:kGTMSessionFetcherErrorDomain
+                                           code:GTMSessionFetcherErrorUserCancelled
+                                       userInfo:nil];
+      [strongSelf invokeFetchCallbacksOnCallbackQueueWithData:nil
+                                                        error:error
+                                                  mayDecorate:NO
+                                       shouldReleaseCallbacks:YES];
+    } else {
+      [strongSelf beginFetchMayDelay:mayDelay mayAuthorize:mayAuthorize mayDecorate:mayDecorate];
+    }
+  });
 }
 
 NSData *_Nullable GTMDataFromInputStream(NSInputStream *inputStream, NSError **outError) {
@@ -3691,6 +3753,7 @@ static NSMutableDictionary *gSystemCompletionHandlers = nil;
             testBlockAccumulateDataChunkCount = _testBlockAccumulateDataChunkCount,
             comment = _comment,
             log = _log,
+            userAgentProvider = _userAgentProvider,
             stopFetchingTriggersCompletionHandler = _stopFetchingTriggersCompletionHandler;
 
 #if !STRIP_GTM_FETCH_LOGGING
@@ -4675,6 +4738,68 @@ NSString *GTMFetcherSystemVersionString(void) {
   });
   return sSavedSystemString;
 }
+
+@interface GTMUserAgentStringProvider ()
+@end
+
+@implementation GTMUserAgentStringProvider
+
+@synthesize userAgent = _userAgent;
+
+- (instancetype)initWithUserAgentString:(NSString *)userAgentString {
+  self = [super init];
+  if (self) {
+    _userAgent = [userAgentString copy];
+  }
+  return self;
+}
+
+#pragma mark - GTMUserAgentProvider
+
+- (nullable NSString *)cachedUserAgent {
+  return _userAgent;
+}
+
+- (NSString *)userAgent {
+  return _userAgent;
+}
+
+@end
+
+@interface GTMStandardUserAgentProvider () {
+  NSBundle *_Nullable _bundle;
+}
+
+@property(atomic, copy) NSString *cachedUserAgent;
+
+@end
+
+@implementation GTMStandardUserAgentProvider
+
+@synthesize cachedUserAgent = _cachedUserAgent;
+
+- (instancetype)initWithBundle:(nullable NSBundle *)bundle {
+  self = [super init];
+  if (self) {
+    _bundle = bundle;
+  }
+  return self;
+}
+
+#pragma mark - GTMUserAgentProvider
+
+- (NSString *)userAgent {
+  NSString *userAgent = self.cachedUserAgent;
+  if (!userAgent) {
+    // This might invoke `GTMFetcherStandardUserAgentString()` more than once if two threads enter
+    // here concurrently, but the result will be the same for both.
+    userAgent = GTMFetcherStandardUserAgentString(_bundle);
+    self.cachedUserAgent = userAgent;
+  }
+  return userAgent;
+}
+
+@end
 
 NSString *GTMFetcherStandardUserAgentString(NSBundle *_Nullable bundle) {
   NSString *result = [NSString stringWithFormat:@"%@ %@", GTMFetcherApplicationIdentifier(bundle),

--- a/Sources/Core/Public/GTMSessionFetcher/GTMSessionFetcherService.h
+++ b/Sources/Core/Public/GTMSessionFetcher/GTMSessionFetcherService.h
@@ -73,6 +73,11 @@ extern NSString *const kGTMSessionFetcherServiceSessionKey;
 @property(atomic, assign) BOOL skipBackgroundTask;
 #endif
 
+// An optional provider to calculate the User-Agent string on demand. If non-nil and
+// an HTTP header field for User-Agent is not set, this is queried before sending out
+// the network request for the User-Agent string.
+@property(atomic, strong, nullable) id<GTMUserAgentProvider> userAgentProvider;
+
 // A default useragent of GTMFetcherStandardUserAgentString(nil) will be given to each fetcher
 // created by this service unless the request already has a user-agent header set.
 // This default will be added starting with builds with the SDKs for OS X 10.11 and iOS 9.

--- a/UnitTests/GTMSessionFetcherFetchingTest.m
+++ b/UnitTests/GTMSessionFetcherFetchingTest.m
@@ -83,6 +83,8 @@ NSString *const kGTMGettysburgFileName = @"gettysburgaddress.txt";
   // For tests that create fetchers without a fetcher service, _fetcherService will
   // be set to nil by the test.
   _fetcherService = [[GTMSessionFetcherService alloc] init];
+  _fetcherService.userAgentProvider =
+      [[GTMUserAgentStringProvider alloc] initWithUserAgentString:@"GTMSessionFetcher"];
 
   _testServer = [[GTMSessionFetcherTestServer alloc] init];
   _isServerRunning = (_testServer != nil);


### PR DESCRIPTION
This PR introduces a new protocol `GTMUserAgentProvider` which allows calculating the default `User-Agent` header off the UI thread and caching it for re-use.

The new behavior is off by default and requires setting `GTMSessionFetcherService.useStandardUserAgentProvider = YES` (a private `@class` property) so the performance improvement can be experimentally verified.

Tested:
  New tests added. `swift test` passes:
  ```
  Test Suite 'All tests' passed at 2023-05-24 16:31:31.782.
  	 Executed 159 tests, with 0 failures (0 unexpected) in 116.824 (116.834) seconds
  ```

Fixes: #352 
Fixes: b/284149500