### PR TITLE
Use new GTMUserAgentProvider by default

### DIFF
--- a/UnitTests/GTMSessionFetcherServiceTest.m
+++ b/UnitTests/GTMSessionFetcherServiceTest.m
@@ -183,8 +183,6 @@ typedef NSString * (^GTMUserAgentBlock)(void);
 
 @interface GTMSessionFetcherService (GTMSessionFetcherServiceInternal)
 
-@property(class, atomic, assign) BOOL useStandardUserAgentProvider;
-
 - (id)delegateDispatcherForFetcher:(GTMSessionFetcher *)fetcher;
 
 @end
@@ -1066,11 +1064,6 @@ static bool IsCurrentProcessBeingDebugged(void) {
 }
 
 - (void)testFetcherShouldUseStandardUserAgent {
-  BOOL oldValue = GTMSessionFetcherService.useStandardUserAgentProvider;
-  GTMSessionFetcherService.useStandardUserAgentProvider = YES;
-  [self addTeardownBlock:^{
-    GTMSessionFetcherService.useStandardUserAgentProvider = oldValue;
-  }];
   GTMSessionFetcherService *service =
       [GTMSessionFetcherService mockFetcherServiceWithFakedData:nil fakedError:nil];
   GTMSessionFetcher *fetcher = [service fetcherWithURLString:@"https://www.html5zombo.com"];


### PR DESCRIPTION
We ran a study testing the new `GTMUserAgentProvider` logic and it was net positive (about 7 ms launch time saved at p50).

So, this PR enables the feature by default.

Tested:
  `swift test` passes:
  ```
  Test Suite 'All tests' passed at 2023-07-24 15:23:42.347.
  Executed 159 tests, with 0 failures (0 unexpected) in 128.175 (128.185) seconds
  ```

