### PR TITLE
Fix concurrency issue in GTMFetcherCleanedUserAgentString() causing crashes

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -50,6 +50,17 @@ let package = Package(
             name: "GTMSessionFetcherCoreTests",
             dependencies: ["GTMSessionFetcherFull", "GTMSessionFetcherCore"],
             path: "UnitTests",
+	    exclude: ["GTMSessionFetcherUserAgentTest.m"],
+            cSettings: [
+                .headerSearchPath("../Sources/Core")
+            ]
+        ),
+        // This runs in its own target since it exercises global variable initialization.
+	.testTarget(
+	    name: "GTMSessionFetcherUserAgentTests",
+	    dependencies: ["GTMSessionFetcherCore"],
+            path: "UnitTests",
+	    sources: ["GTMSessionFetcherUserAgentTest.m"],
             cSettings: [
                 .headerSearchPath("../Sources/Core")
             ]

--- a/Sources/Core/GTMSessionFetcher.m
+++ b/Sources/Core/GTMSessionFetcher.m
@@ -4639,7 +4639,8 @@ NSString *GTMFetcherCleanedUserAgentString(NSString *str) {
 
   // Delete http token separators and remaining whitespace
   static NSCharacterSet *charsToDelete = nil;
-  if (charsToDelete == nil) {
+  static dispatch_once_t onceToken;
+  dispatch_once(&onceToken, ^{
     // Make a set of unwanted characters
     NSString *const kSeparators = @"()<>@;:\\\"/[]?={}";
 
@@ -4647,7 +4648,7 @@ NSString *GTMFetcherCleanedUserAgentString(NSString *str) {
         [[NSCharacterSet whitespaceAndNewlineCharacterSet] mutableCopy];
     [mutableChars addCharactersInString:kSeparators];
     charsToDelete = [mutableChars copy];  // hang on to an immutable copy
-  }
+  });
 
   while (1) {
     NSRange separatorRange = [result rangeOfCharacterFromSet:charsToDelete];

--- a/UnitTests/GTMSessionFetcherUserAgentTest.m
+++ b/UnitTests/GTMSessionFetcherUserAgentTest.m
@@ -1,0 +1,74 @@
+#import <XCTest/XCTest.h>
+#import <stdatomic.h>
+
+#import <GTMSessionFetcher/GTMSessionFetcher.h>
+
+NS_ASSUME_NONNULL_BEGIN
+
+static atomic_bool gShouldStartThreads = ATOMIC_VAR_INIT(false);
+
+typedef NS_ENUM(NSInteger, GTMSessionFetcherUserAgentThreadState) {
+  GTMSessionFetcherUserAgentThreadStateDefault = 0,
+  GTMSessionFetcherUserAgentThreadStateFinished = 1,
+};
+
+@interface GTMSessionFetcherUserAgentThread : NSThread
+
+@property(nonatomic) NSConditionLock *finishedConditionLock;
+
+@end
+
+@implementation GTMSessionFetcherUserAgentThread
+
+- (instancetype)init {
+  self = [super init];
+  if (self) {
+    _finishedConditionLock =
+        [[NSConditionLock alloc] initWithCondition:GTMSessionFetcherUserAgentThreadStateDefault];
+  }
+  return self;
+}
+
+- (void)main {
+  do {
+  } while (atomic_load(&gShouldStartThreads) == false);
+  GTMFetcherCleanedUserAgentString(@"foo bar baz [123/a.b.c]");
+  [_finishedConditionLock lockWhenCondition:GTMSessionFetcherUserAgentThreadStateDefault];
+  [_finishedConditionLock unlockWithCondition:GTMSessionFetcherUserAgentThreadStateFinished];
+}
+
+- (void)join {
+  [_finishedConditionLock lockWhenCondition:GTMSessionFetcherUserAgentThreadStateFinished];
+  [_finishedConditionLock unlockWithCondition:GTMSessionFetcherUserAgentThreadStateFinished];
+}
+
+@end
+
+@interface GTMSessionFetcherUserAgentTest : XCTestCase
+@end
+
+@implementation GTMSessionFetcherUserAgentTest
+
+- (void)testCleanedUserAgentStringConcurrencyShouldNotCrash {
+  static const size_t kNumConcurrentJobs = 500;
+
+  NSMutableArray<GTMSessionFetcherUserAgentThread *> *threads =
+      [NSMutableArray arrayWithCapacity:kNumConcurrentJobs];
+
+  for (size_t i = 0; i < kNumConcurrentJobs; i++) {
+    GTMSessionFetcherUserAgentThread *thread = [[GTMSessionFetcherUserAgentThread alloc] init];
+    [threads addObject:thread];
+    [thread start];
+  }
+
+  atomic_store(&gShouldStartThreads, true);
+
+  // Wait for all the threads to finish.
+  for (GTMSessionFetcherUserAgentThread *thread in threads) {
+    [thread join];
+  }
+}
+
+@end
+
+NS_ASSUME_NONNULL_END


### PR DESCRIPTION
Fixes #358 .

Tested:
  Before and after fix, ran:
  ```
  for i in {1..100}; do swift test -c release --filter GTMSessionFetcherUserAgentTest >/dev/null 2>&1 && echo "PASS" || echo "FAIL"; done
  ```
  Before fix, test failed almost every time.
  After fix, test passes every time.