### PR TITLE
Remove +[GTMSessionFetcher deleteLogDirectoriesOlderThanDate:]

### DIFF
--- a/Sources/Core/GTMSessionFetcherLogging.m
+++ b/Sources/Core/GTMSessionFetcherLogging.m
@@ -230,33 +230,6 @@ static NSString *gLoggingProcessName = nil;
   return @"aperçu_http_log.html";
 }
 
-+ (void)deleteLogDirectoriesOlderThanDate:(NSDate *)cutoffDate {
-  NSFileManager *fileMgr = [NSFileManager defaultManager];
-  NSURL *parentDir = [NSURL fileURLWithPath:[[self class] loggingDirectory]];
-  NSURL *logDirectoryForCurrentRun =
-      [NSURL fileURLWithPath:[[self class] logDirectoryForCurrentRun]];
-  NSError *error;
-  NSArray *contents = [fileMgr contentsOfDirectoryAtURL:parentDir
-                             includingPropertiesForKeys:@[ NSURLContentModificationDateKey ]
-                                                options:0
-                                                  error:&error];
-  for (NSURL *itemURL in contents) {
-    if ([itemURL isEqual:logDirectoryForCurrentRun]) continue;
-
-    NSDate *modDate;
-    if ([itemURL getResourceValue:&modDate forKey:NSURLContentModificationDateKey error:&error]) {
-      if ([modDate compare:cutoffDate] == NSOrderedAscending) {
-        if (![fileMgr removeItemAtURL:itemURL error:&error]) {
-          NSLog(@"deleteLogDirectoriesOlderThanDate failed to delete %@: %@", itemURL.path, error);
-        }
-      }
-    } else {
-      NSLog(@"deleteLogDirectoriesOlderThanDate failed to get mod date of %@: %@", itemURL.path,
-            error);
-    }
-  }
-}
-
 // formattedStringFromData returns a prettyprinted string for JSON input,
 // and a plain string for other input data
 - (NSString *)formattedStringFromData:(NSData *)inputData

--- a/Sources/Core/Public/GTMSessionFetcher/GTMSessionFetcherLogging.h
+++ b/Sources/Core/Public/GTMSessionFetcher/GTMSessionFetcherLogging.h
@@ -89,10 +89,6 @@
 + (void)setLogDirectoryForCurrentRun:(NSString *)logDirectoryForCurrentRun;
 + (NSString *)logDirectoryForCurrentRun;
 
-// Prunes old log directories that have not been modified since the provided date.
-// This will not delete the current run's log directory.
-+ (void)deleteLogDirectoriesOlderThanDate:(NSDate *)date;
-
 // internal; called by fetcher
 - (void)logFetchWithError:(NSError *)error;
 - (NSInputStream *)loggedInputStreamForInputStream:(NSInputStream *)inputStream;


### PR DESCRIPTION
A google search seems to say it wasn't used by anyone, and it uses `NSURLContentModificationDateKey`; this avoids having to include add an entry in an xcprivacy manifest for the main library just for this unused api.