### PR TITLE
Add xcprivacy manifest info.

### DIFF
--- a/GTMSessionFetcher.podspec
+++ b/GTMSessionFetcher.podspec
@@ -35,12 +35,18 @@ Pod::Spec.new do |s|
     sp.source_files = 'Sources/Core/**/*.{h,m}'
     sp.public_header_files = 'Sources/Core/Public/GTMSessionFetcher/*.h'
     sp.framework = 'Security'
+    sp.resource_bundle = {
+      "GTMSessionFetcher_Core_Privacy" => "Sources/Core/Resources/PrivacyInfo.xcprivacy"
+    }
   end
 
   s.subspec 'Full' do |sp|
     sp.source_files = 'Sources/Full/**/*.{h,m}'
     sp.public_header_files = 'Sources/Full/Public/GTMSessionFetcher/*.h'
     sp.dependency 'GTMSessionFetcher/Core'
+    sp.resource_bundle = {
+      "GTMSessionFetcher_Full_Privacy" => "Sources/Full/Resources/PrivacyInfo.xcprivacy"
+    }
   end
 
   s.subspec 'LogView' do |sp|
@@ -48,6 +54,9 @@ Pod::Spec.new do |s|
     sp.source_files = 'Sources/LogView/**/*.{h,m}'
     sp.public_header_files = 'Sources/LogView/Public/GTMSessionFetcher/*.h'
     sp.dependency 'GTMSessionFetcher/Core'
+    sp.resource_bundle = {
+      "GTMSessionFetcher_LogView_Privacy" => "Sources/LogView/Resources/PrivacyInfo.xcprivacy"
+    }
   end
 
   s.test_spec 'Tests' do |sp|

--- a/Package.swift
+++ b/Package.swift
@@ -1,4 +1,4 @@
-// swift-tools-version:5.1
+// swift-tools-version:5.3
 // The swift-tools-version declares the minimum version of Swift required to build this package.
 import PackageDescription
 
@@ -32,35 +32,44 @@ let package = Package(
         .target(
             name: "GTMSessionFetcherCore",
             path: "Sources/Core",
+            resources: [
+                .process("Resources/PrivacyInfo.xcprivacy")
+            ],
             publicHeadersPath: "Public"
         ),
         .target(
             name: "GTMSessionFetcherFull",
             dependencies: ["GTMSessionFetcherCore"],
             path: "Sources/Full",
+            resources: [
+                .process("Resources/PrivacyInfo.xcprivacy")
+            ],
             publicHeadersPath: "Public"
         ),
         .target(
             name: "GTMSessionFetcherLogView",
             dependencies: ["GTMSessionFetcherCore"],
             path: "Sources/LogView",
+            resources: [
+                .process("Resources/PrivacyInfo.xcprivacy")
+            ],
             publicHeadersPath: "Public"
         ),
         .testTarget(
             name: "GTMSessionFetcherCoreTests",
             dependencies: ["GTMSessionFetcherFull", "GTMSessionFetcherCore"],
             path: "UnitTests",
-	    exclude: ["GTMSessionFetcherUserAgentTest.m"],
+            exclude: ["GTMSessionFetcherUserAgentTest.m"],
             cSettings: [
                 .headerSearchPath("../Sources/Core")
             ]
         ),
         // This runs in its own target since it exercises global variable initialization.
-	.testTarget(
-	    name: "GTMSessionFetcherUserAgentTests",
-	    dependencies: ["GTMSessionFetcherCore"],
+        .testTarget(
+            name: "GTMSessionFetcherUserAgentTests",
+            dependencies: ["GTMSessionFetcherCore"],
             path: "UnitTests",
-	    sources: ["GTMSessionFetcherUserAgentTest.m"],
+            sources: ["GTMSessionFetcherUserAgentTest.m"],
             cSettings: [
                 .headerSearchPath("../Sources/Core")
             ]

--- a/Sources/Core/Resources/PrivacyInfo.xcprivacy
+++ b/Sources/Core/Resources/PrivacyInfo.xcprivacy
@@ -1,0 +1,23 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>NSPrivacyAccessedAPITypes</key>
+	<array>
+		<dict>
+			<key>NSPrivacyAccessedAPIType</key>
+			<string>NSPrivacyAccessedAPICategoryUserDefaults</string>
+			<key>NSPrivacyAccessedAPITypeReasons</key>
+			<array>
+				<string>CA92.1</string>
+			</array>
+		</dict>
+	</array>
+	<key>NSPrivacyCollectedDataTypes</key>
+	<array/>
+	<key>NSPrivacyTracking</key>
+	<false/>
+	<key>NSPrivacyTrackingDomains</key>
+	<array/>
+</dict>
+</plist>

--- a/Sources/Full/Resources/PrivacyInfo.xcprivacy
+++ b/Sources/Full/Resources/PrivacyInfo.xcprivacy
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>NSPrivacyAccessedAPITypes</key>
+	<array/>
+	<key>NSPrivacyCollectedDataTypes</key>
+	<array/>
+	<key>NSPrivacyTracking</key>
+	<false/>
+	<key>NSPrivacyTrackingDomains</key>
+	<array/>
+</dict>
+</plist>

--- a/Sources/LogView/Resources/PrivacyInfo.xcprivacy
+++ b/Sources/LogView/Resources/PrivacyInfo.xcprivacy
@@ -1,0 +1,23 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>NSPrivacyAccessedAPITypes</key>
+	<array>
+		<dict>
+			<key>NSPrivacyAccessedAPIType</key>
+			<string>NSPrivacyAccessedAPICategoryFileTimestamp</string>
+			<key>NSPrivacyAccessedAPITypeReasons</key>
+			<array>
+				<string>C617.1</string>
+			</array>
+		</dict>
+	</array>
+	<key>NSPrivacyCollectedDataTypes</key>
+	<array/>
+	<key>NSPrivacyTracking</key>
+	<false/>
+	<key>NSPrivacyTrackingDomains</key>
+	<array/>
+</dict>
+</plist>


### PR DESCRIPTION
Core -
  If using the NSURLSession background fetch support, the data to restore
  download information across app launches is recorded in NSUserDefaults.

Full -
  No api's called by these sources.

LogView -
  DDA9.1 isn't correct because the data isn't displayed, the data is just used
  to sort the log names within the LogView UX so they are properly ordered.

  The data is *not* sent off the device, C617.1 doesn't state that, but nothing
  else seems to be a match since the data isn't directly displayed.