### PR TITLE
Move to actions/checkout@v4 to avoid warnings.

### DIFF
--- a/.github/workflows/cocoapods.yml
+++ b/.github/workflows/cocoapods.yml
@@ -32,7 +32,7 @@ jobs:
         PLATFORM: ["ios", "macos", "tvos", "watchos --skip-tests"]
         CONFIGURATION: ["Debug", "Release"]
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
     # Need cocoapods 1.12+ for watchOS to work again.
     - name: Update Cocoapods
       run: gem update cocoapods

--- a/.github/workflows/swiftpm.yml
+++ b/.github/workflows/swiftpm.yml
@@ -32,7 +32,7 @@ jobs:
       matrix:
         CONFIGURATION: ["debug", "release"]
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
     - name: Build and Test
       run:  |
         set -eu
@@ -49,7 +49,7 @@ jobs:
         PLATFORM: ["ios", "macos", "tvos", "watchos"]
         CONFIGURATION: ["Debug", "Release"]
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
     - name: Build and Test
       run:  |
         set -eu

--- a/.github/workflows/test_apps.yml
+++ b/.github/workflows/test_apps.yml
@@ -28,7 +28,7 @@ jobs:
         PLATFORM: ["macOS"]
         CONFIGURATION: ["Debug", "Release"]
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
     - name: Build
       run:  |
         set -eu


### PR DESCRIPTION
Current CI runs are reporting:

> Node.js 16 actions are deprecated. Please update the following actions to use Node.js 20: actions/checkout@v3. For more information see: https://github.blog/changelog/2023-09-22-github-actions-transitioning-from-node-16-to-node-20/.