### PR TITLE
And direct path for schema not changing.

### DIFF
--- a/Sources/Core/GTMSessionFetcher.m
+++ b/Sources/Core/GTMSessionFetcher.m
@@ -2546,6 +2546,14 @@ static _Nullable id<GTMUIApplicationProtocol> gSubstituteUIApp;
 
   NSString *originalScheme = originalRequestURL.scheme;
   NSString *redirectScheme = redirectRequestURL.scheme;
+
+  // If no change in scheme with redirect, just return the redirect.
+  if (originalScheme != nil &&
+      redirectScheme != nil &&
+      [originalScheme caseInsensitiveCompare:redirectScheme] == NSOrderedSame) {
+    return redirectRequestURL;
+  }
+
   BOOL insecureToSecureRedirect =
       (originalScheme != nil && [originalScheme caseInsensitiveCompare:@"http"] == NSOrderedSame &&
        redirectScheme != nil && [redirectScheme caseInsensitiveCompare:@"https"] == NSOrderedSame);


### PR DESCRIPTION
To simplify the flow a little but also avoid doing any work in cases where the redirect doesn't change the scheme, and an explicit path for that in the redirection validations.