### PR TITLE
Add error handing to fetching a chunk from file uploads.

### DIFF
--- a/Sources/Core/GTMSessionUploadFetcher.m
+++ b/Sources/Core/GTMSessionUploadFetcher.m
@@ -790,7 +790,15 @@ NSString *const kGTMSessionFetcherUploadInitialBackoffStartedNotification =
     }
     if (offset > 0 || length < fullUploadLength) {
       NSRange range = NSMakeRange((NSUInteger)offset, (NSUInteger)length);
-      resultData = [mappedData subdataWithRange:range];
+      @try {
+        resultData = [mappedData subdataWithRange:range];
+      } @catch (NSException *exception) {
+        NSString *errorMessage = exception.description;
+        GTMSESSION_ASSERT_DEBUG(NO, @"%@", errorMessage);
+        response(nil, kGTMSessionUploadFetcherUnknownFileSize,
+                 [self uploadChunkUnavailableErrorWithDescription:errorMessage]);
+        return;
+      }
     } else {
       resultData = mappedData;
     }


### PR DESCRIPTION
This is the same logic as what happens for non-file based uploaded, it if something happens to cause a failure to collect a subrange, then it will fail the upload instead of the current crash that has occasionally been seen.

For both cases (Data or file based), if we can get better repos, there might be some better checks to do in the future.