### PR TITLE
Implement +[GTMSessionUploadFetcher fetcherWithSessionIdentifier:]

### DIFF
--- a/Sources/Core/GTMSessionUploadFetcher.m
+++ b/Sources/Core/GTMSessionUploadFetcher.m
@@ -332,6 +332,10 @@ NSString *const kGTMSessionFetcherUploadInitialBackoffStartedNotification =
   return gUploadFetcherPointerArrayForBackgroundSessions;
 }
 
++ (instancetype)fetcherWithSessionIdentifier:(NSString *)sessionIdentifier {
+  return [self uploadFetcherForSessionIdentifier:sessionIdentifier];
+}
+
 + (instancetype)uploadFetcherForSessionIdentifier:(NSString *)sessionIdentifier {
   GTMSESSION_ASSERT_DEBUG(sessionIdentifier != nil, @"Invalid session identifier");
   NSArray *uploadFetchersForBackgroundSessions = [self uploadFetchersForBackgroundSessions];


### PR DESCRIPTION
`+[GTMSessionUploadFetcher fetcherWithSessionIdentifier:]` is declared to return `instancetype`, so it should return `GTMSessionUploadFetcher*`.

In reality, that method has no implementation in `GTMSessionUploadFetcher.m`, so it always returns `GTMSessionFetcher*`. That means calling `GTMSessionUploadFetcher`-only methods on the resulting object will crash, since they're not implemented.

The method `+[GTMSessionUploadFetcher uploadFetcherForSessionIdentifier:]` is implemented to return the correct type, so this PR implements `+[GTMSessionUploadFetcher fetcherWithSessionIdentifier:]` to thunk through to that method.

Fixes: #402