### PR TITLE
Stop forcing Xcode versions and cocoapods updates.

### DIFF
--- a/.github/workflows/cocoapods.yml
+++ b/.github/workflows/cocoapods.yml
@@ -32,13 +32,6 @@ jobs:
         PLATFORM: ["ios", "macos", "tvos", "visionos", "watchos --skip-tests"]
         CONFIGURATION: ["Debug", "Release"]
     steps:
-    # The "macos-14" image defaults to 15.0.1, select the newer Xcode.
-    - name: Xcode version
-      run: sudo xcode-select -switch /Applications/Xcode_15.2.app
-    # The "macos-14" image has CocoaPods 1.14.x, and 1.15 is needed for visionOS
-    - name: Update CocoaPods
-      if: ${{ matrix.PLATFORM == 'visionos' }}
-      run: gem install cocoapods
     - uses: actions/checkout@v4
     # Manually expanding out static frameworks to avoid making to many jobs.
     - name: Pod lib lint

--- a/.github/workflows/cocoapods.yml
+++ b/.github/workflows/cocoapods.yml
@@ -29,7 +29,8 @@ jobs:
       matrix:
         # watchOS fails linting when there are test, wedge in --skip-tests for
         # those runs.
-        PLATFORM: ["ios", "macos", "tvos", "visionos", "watchos --skip-tests"]
+        # GitHub runners dropped visionOS. https://github.com/actions/runner-images/issues/10559
+        PLATFORM: ["ios", "macos", "tvos", "watchos --skip-tests"]
         CONFIGURATION: ["Debug", "Release"]
     steps:
     - uses: actions/checkout@v4

--- a/.github/workflows/swiftpm.yml
+++ b/.github/workflows/swiftpm.yml
@@ -46,7 +46,8 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        PLATFORM: ["ios", "macos", "tvos", "visionos", "watchos"]
+        # GitHub runners dropped visionOS. https://github.com/actions/runner-images/issues/10559
+        PLATFORM: ["ios", "macos", "tvos", "watchos"]
         CONFIGURATION: ["Debug", "Release"]
     steps:
     - uses: actions/checkout@v4

--- a/.github/workflows/swiftpm.yml
+++ b/.github/workflows/swiftpm.yml
@@ -32,9 +32,6 @@ jobs:
       matrix:
         CONFIGURATION: ["debug", "release"]
     steps:
-    # The "macos-14" image defaults to 15.0.1, select the newer Xcode.
-    - name: Xcode version
-      run: sudo xcode-select -switch /Applications/Xcode_15.2.app
     - uses: actions/checkout@v4
     - name: Build and Test
       run:  |
@@ -52,9 +49,6 @@ jobs:
         PLATFORM: ["ios", "macos", "tvos", "visionos", "watchos"]
         CONFIGURATION: ["Debug", "Release"]
     steps:
-    # The "macos-14" image defaults to 15.0.1, select the newer Xcode.
-    - name: Xcode version
-      run: sudo xcode-select -switch /Applications/Xcode_15.2.app
     - uses: actions/checkout@v4
     - name: Build and Test
       run:  |

--- a/.github/workflows/test_apps.yml
+++ b/.github/workflows/test_apps.yml
@@ -28,9 +28,6 @@ jobs:
         PLATFORM: ["macOS"]
         CONFIGURATION: ["Debug", "Release"]
     steps:
-    # The "macos-14" image defaults to 15.0.1, select the newer Xcode.
-    - name: Xcode version
-      run: sudo xcode-select -switch /Applications/Xcode_15.2.app
     - uses: actions/checkout@v4
     - name: Build
       run:  |


### PR DESCRIPTION
The base images are advanced enough that these don't need to be controlled any more.