### PR TITLE
Delete uses of ATOMIC_VAR_INIT.

### DIFF
--- a/UnitTests/GTMSessionFetcherUserAgentTest.m
+++ b/UnitTests/GTMSessionFetcherUserAgentTest.m
@@ -5,7 +5,7 @@
 
 NS_ASSUME_NONNULL_BEGIN
 
-static atomic_bool gShouldStartThreads = ATOMIC_VAR_INIT(false);
+static atomic_bool gShouldStartThreads = false;
 
 typedef NS_ENUM(NSInteger, GTMSessionFetcherUserAgentThreadState) {
   GTMSessionFetcherUserAgentThreadStateDefault = 0,


### PR DESCRIPTION
This change is a no-op, as this macro has always simply expanded to its argument. It was therefore deprecated in C17 and C++20, and has now been deleted in C23.