### PR TITLE
Remove stale availability checks/annotations.

### DIFF
--- a/Sources/Core/GTMSessionFetcher.m
+++ b/Sources/Core/GTMSessionFetcher.m
@@ -1993,9 +1993,7 @@ NSData *_Nullable GTMDataFromInputStream(NSInputStream *inputStream, NSError **o
   self.retryBlock = nil;
   self.testBlock = nil;
   self.resumeDataBlock = nil;
-  if (@available(iOS 10.0, *)) {
-    self.metricsCollectionBlock = nil;
-  }
+  self.metricsCollectionBlock = nil;
 }
 
 - (void)forgetSessionIdentifierForFetcher {
@@ -3114,8 +3112,7 @@ static _Nullable id<GTMUIApplicationProtocol> gSubstituteUIApp;
 
 - (void)URLSession:(NSURLSession *)session
                           task:(NSURLSessionTask *)task
-    didFinishCollectingMetrics:(NSURLSessionTaskMetrics *)metrics
-    API_AVAILABLE(ios(10.0), macosx(10.12), tvos(10.0), watchos(6.0)) {
+    didFinishCollectingMetrics:(NSURLSessionTaskMetrics *)metrics {
   @synchronized(self) {
     GTMSessionMonitorSynchronized(self);
     GTMSessionFetcherMetricsCollectionBlock metricsCollectionBlock = _metricsCollectionBlock;

--- a/Sources/Core/GTMSessionFetcherService.m
+++ b/Sources/Core/GTMSessionFetcherService.m
@@ -219,9 +219,7 @@ static id<GTMUserAgentProvider> SharedStandardUserAgentProvider(void) {
   fetcher.retryBlock = self.retryBlock;
   fetcher.maxRetryInterval = self.maxRetryInterval;
   fetcher.minRetryInterval = self.minRetryInterval;
-  if (@available(iOS 10.0, *)) {
-    fetcher.metricsCollectionBlock = self.metricsCollectionBlock;
-  }
+  fetcher.metricsCollectionBlock = self.metricsCollectionBlock;
   fetcher.stopFetchingTriggersCompletionHandler = self.stopFetchingTriggersCompletionHandler;
   fetcher.properties = self.properties;
   fetcher.service = self;
@@ -1333,8 +1331,7 @@ static id<GTMUserAgentProvider> SharedStandardUserAgentProvider(void) {
 
 - (void)URLSession:(NSURLSession *)session
                           task:(NSURLSessionTask *)task
-    didFinishCollectingMetrics:(NSURLSessionTaskMetrics *)metrics
-    API_AVAILABLE(ios(10.0), macosx(10.12), tvos(10.0), watchos(6.0)) {
+    didFinishCollectingMetrics:(NSURLSessionTaskMetrics *)metrics {
   id<NSURLSessionTaskDelegate> fetcher = [self fetcherForTask:task];
   [fetcher URLSession:session task:task didFinishCollectingMetrics:metrics];
 }

--- a/Sources/Core/Public/GTMSessionFetcher/GTMSessionFetcher.h
+++ b/Sources/Core/Public/GTMSessionFetcher/GTMSessionFetcher.h
@@ -503,7 +503,6 @@ typedef void (^GTMSessionFetcherRetryResponse)(BOOL shouldRetry);
 typedef void (^GTMSessionFetcherRetryBlock)(BOOL suggestedWillRetry, NSError *_Nullable error,
                                             GTMSessionFetcherRetryResponse response);
 
-API_AVAILABLE(ios(10.0), macosx(10.12), tvos(10.0), watchos(6.0))
 typedef void (^GTMSessionFetcherMetricsCollectionBlock)(NSURLSessionTaskMetrics *metrics);
 
 typedef void (^GTMSessionFetcherTestResponse)(NSHTTPURLResponse *_Nullable response,
@@ -1077,9 +1076,7 @@ __deprecated_msg("implement GTMSessionFetcherAuthorizer instead")
 // The optional block for collecting the metrics of the present session.
 //
 // This is called on the callback queue.
-@property(atomic, copy, nullable)
-    GTMSessionFetcherMetricsCollectionBlock metricsCollectionBlock API_AVAILABLE(
-        ios(10.0), macosx(10.12), tvos(10.0), watchos(6.0));
+@property(atomic, copy, nullable) GTMSessionFetcherMetricsCollectionBlock metricsCollectionBlock;
 
 // Retry intervals must be strictly less than maxRetryInterval, else
 // they will be limited to maxRetryInterval and no further retries will

--- a/Sources/Core/Public/GTMSessionFetcher/GTMSessionFetcherService.h
+++ b/Sources/Core/Public/GTMSessionFetcher/GTMSessionFetcherService.h
@@ -65,9 +65,7 @@ extern NSString *const kGTMSessionFetcherServiceSessionKey;
 @property(atomic, assign) NSTimeInterval maxRetryInterval;
 @property(atomic, assign) NSTimeInterval minRetryInterval;
 @property(atomic, copy, nullable) NSDictionary<NSString *, id> *properties;
-@property(atomic, copy, nullable)
-    GTMSessionFetcherMetricsCollectionBlock metricsCollectionBlock API_AVAILABLE(
-        ios(10.0), macosx(10.12), tvos(10.0), watchos(6.0));
+@property(atomic, copy, nullable) GTMSessionFetcherMetricsCollectionBlock metricsCollectionBlock;
 @property(atomic, assign) BOOL stopFetchingTriggersCompletionHandler;
 
 #if GTM_BACKGROUND_TASK_FETCHING

--- a/UnitTests/GTMSessionFetcherFetchingTest.m
+++ b/UnitTests/GTMSessionFetcherFetchingTest.m
@@ -179,9 +179,7 @@ NSString *const kGTMGettysburgFileName = @"gettysburgaddress.txt";
   XCTAssertNil(fetcher.downloadProgressBlock);
   XCTAssertNil(fetcher.willCacheURLResponseBlock);
   XCTAssertNil(fetcher.retryBlock);
-  if (@available(iOS 10.0, *)) {
-    XCTAssertNil(fetcher.metricsCollectionBlock);
-  }
+  XCTAssertNil(fetcher.metricsCollectionBlock);
   XCTAssertNil(fetcher.testBlock);
 
   if ([fetcher isKindOfClass:[GTMSessionUploadFetcher class]]) {
@@ -2162,8 +2160,7 @@ NSString *const kGTMGettysburgFileName = @"gettysburgaddress.txt";
   [self testInsecureRequests];
 }
 
-- (void)testCollectingMetrics_WithSuccessfulFetch API_AVAILABLE(ios(10.0), macosx(10.12),
-                                                                tvos(10.0), watchos(6.0)) {
+- (void)testCollectingMetrics_WithSuccessfulFetch {
   if (!_isServerRunning) return;
 
   CREATE_START_STOP_NOTIFICATION_EXPECTATIONS(1, 1);
@@ -2197,15 +2194,12 @@ NSString *const kGTMGettysburgFileName = @"gettysburgaddress.txt";
   XCTAssertNotNil(collectedMetrics.transactionMetrics[0].responseEndDate);
 }
 
-- (void)testCollectingMetrics_WithSuccessfulFetch_WithoutFetcherService API_AVAILABLE(
-    ios(10.0), macosx(10.12), tvos(10.0), watchos(6.0)) {
+- (void)testCollectingMetrics_WithSuccessfulFetch_WithoutFetcherService {
   _fetcherService = nil;
   [self testCollectingMetrics_WithSuccessfulFetch];
 }
 
-- (void)testCollectingMetrics_WithWrongFetch_FaildToConnect API_AVAILABLE(ios(10.0), macosx(10.12),
-                                                                          tvos(10.0),
-                                                                          watchos(6.0)) {
+- (void)testCollectingMetrics_WithWrongFetch_FaildToConnect {
   if (!_isServerRunning) return;
 
   CREATE_START_STOP_NOTIFICATION_EXPECTATIONS(1, 1);
@@ -2243,14 +2237,12 @@ NSString *const kGTMGettysburgFileName = @"gettysburgaddress.txt";
   XCTAssertNil(collectedMetrics.transactionMetrics[0].responseEndDate);
 }
 
-- (void)testCollectingMetrics_WithWrongFetch_FaildToConnect_WithoutFetcherService API_AVAILABLE(
-    ios(10.0), macosx(10.12), tvos(10.0), watchos(6.0)) {
+- (void)testCollectingMetrics_WithWrongFetch_FaildToConnect_WithoutFetcherService {
   _fetcherService = nil;
   [self testCollectingMetrics_WithWrongFetch_FaildToConnect];
 }
 
-- (void)testCollectingMetrics_WithWrongFetch_BadStatusCode API_AVAILABLE(ios(10.0), macosx(10.12),
-                                                                         tvos(10.0), watchos(6.0)) {
+- (void)testCollectingMetrics_WithWrongFetch_BadStatusCode {
   if (!_isServerRunning) return;
 
   CREATE_START_STOP_NOTIFICATION_EXPECTATIONS(1, 1);
@@ -2290,8 +2282,7 @@ NSString *const kGTMGettysburgFileName = @"gettysburgaddress.txt";
   XCTAssertNotNil(collectedMetrics.transactionMetrics[0].responseEndDate);
 }
 
-- (void)testCollectingMetrics_WithWrongFetch_BadStatusCode_WithoutFetcherService API_AVAILABLE(
-    ios(10.0), macosx(10.12), tvos(10.0), watchos(6.0)) {
+- (void)testCollectingMetrics_WithWrongFetch_BadStatusCode_WithoutFetcherService {
   _fetcherService = nil;
   [self testCollectingMetrics_WithWrongFetch_BadStatusCode];
 }

--- a/UnitTests/GTMSessionFetcherServiceTest.m
+++ b/UnitTests/GTMSessionFetcherServiceTest.m
@@ -1751,10 +1751,7 @@ static bool IsCurrentProcessBeingDebugged(void) {
   [session invalidateAndCancel];
 }
 
-- (void)testFetcherUsingMetricsCollectionBlockFromFetcherService API_AVAILABLE(ios(10.0),
-                                                                               macosx(10.12),
-                                                                               tvos(10.0),
-                                                                               watchos(6.0)) {
+- (void)testFetcherUsingMetricsCollectionBlockFromFetcherService {
   if (!_isServerRunning) return;
 
   CREATE_START_STOP_NOTIFICATION_EXPECTATIONS(1, 1);


### PR DESCRIPTION
The current min version are above this (see GTMSessionFetcher.podspec or Package.swift), so none of these checks/annotations are needed.