### PR TITLE
Improve tests around stopFetches and max fetches per host.

### DIFF
--- a/Sources/Core/GTMSessionFetcherService.m
+++ b/Sources/Core/GTMSessionFetcherService.m
@@ -659,6 +659,8 @@ static id<GTMUserAgentProvider> SharedStandardUserAgentProvider(void) {
     [_runningFetchersByHost removeAllObjects];
   }
 
+  // Stop the delayed fetchers first so a delayed one doesn't get started when canceling
+  // a running one.
   for (NSArray *delayedForHost in delayedFetchersByHost) {
     for (GTMSessionFetcher *fetcher in delayedForHost) {
       [self stopFetcher:fetcher];


### PR DESCRIPTION
- Document where order is important when stopping fetchers.
- Improve the existing tests to be more complete about what happens when stopping fetches that get deferred.

This exposes a current fail case, so a TODO was left to enable part of it once things are fixed.