### PR TITLE
Start validating the sessionUserInfo type.

### DIFF
--- a/Sources/Core/Public/GTMSessionFetcher/GTMSessionFetcher.h
+++ b/Sources/Core/Public/GTMSessionFetcher/GTMSessionFetcher.h
@@ -873,6 +873,8 @@ __deprecated_msg("implement GTMSessionFetcherAuthorizer instead")
 // The fetcher encodes information used to resume a session in the session identifier.
 // This method, intended for internal use returns the encoded information.  The sessionUserInfo
 // dictionary is stored as identifier metadata.
+// NOTE: This type is a lie and could be an issue for Swift. The values for private keys (prefixed
+// with an underscore) aren't always strings; but changing the type is a breaking change.
 - (nullable NSDictionary<NSString *, NSString *> *)sessionIdentifierMetadata;
 
 #if TARGET_OS_IPHONE && !TARGET_OS_WATCH


### PR DESCRIPTION
The api is documented as `NSString` to `NSString`, but nothing validates that. Add some `DEBUG` validations with the intent to eventually turn them into failure checks also.

Add a note to `sessionIdentifierMetadata` that the type there is already a lie, we'll have to look at fixing that in the future as it is a breaking change since it is a signature change.