### PR TITLE
Correct the type on sessionIdentifierMetadata.

### DIFF
--- a/Sources/Core/GTMSessionFetcher.m
+++ b/Sources/Core/GTMSessionFetcher.m
@@ -1686,7 +1686,7 @@ NSData *_Nullable GTMDataFromInputStream(NSInputStream *inputStream, NSError **o
   }
 }
 
-- (nullable NSDictionary *)sessionIdentifierMetadata {
+- (nullable NSDictionary<NSString *, id> *)sessionIdentifierMetadata {
   @synchronized(self) {
     GTMSessionMonitorSynchronized(self);
 
@@ -1694,7 +1694,7 @@ NSData *_Nullable GTMDataFromInputStream(NSInputStream *inputStream, NSError **o
   }
 }
 
-- (nullable NSDictionary *)sessionIdentifierMetadataUnsynchronized {
+- (nullable NSDictionary<NSString *, id> *)sessionIdentifierMetadataUnsynchronized {
   GTMSessionCheckSynchronized(self);
 
   // Session Identifier format: "com.google.<ClassName>_<UUID>_<Metadata in JSON format>

--- a/Sources/Core/Public/GTMSessionFetcher/GTMSessionFetcher.h
+++ b/Sources/Core/Public/GTMSessionFetcher/GTMSessionFetcher.h
@@ -872,10 +872,9 @@ __deprecated_msg("implement GTMSessionFetcherAuthorizer instead")
 
 // The fetcher encodes information used to resume a session in the session identifier.
 // This method, intended for internal use returns the encoded information.  The sessionUserInfo
-// dictionary is stored as identifier metadata.
-// NOTE: This type is a lie and could be an issue for Swift. The values for private keys (prefixed
-// with an underscore) aren't always strings; but changing the type is a breaking change.
-- (nullable NSDictionary<NSString *, NSString *> *)sessionIdentifierMetadata;
+// dictionary is stored as identifier metadata. The values here are limited to things that
+// can be stored in a plist, so they aren't completely open ended.
+- (nullable NSDictionary<NSString *, id> *)sessionIdentifierMetadata;
 
 #if TARGET_OS_IPHONE && !TARGET_OS_WATCH
 // The app should pass to this method the completion handler passed in the app delegate method


### PR DESCRIPTION
This has never been limited to `NSString` values, and if it was called from Swift it likely would cause problems. Luckily, it is really meant to be an internal api so clients shouldn't be calling it. But since it is public, it is a breaking change to Swift.

Part of #398