### PR TITLE
When restoring uploads, maintain the sessionUserInfo api contract.

### DIFF
--- a/Sources/Core/GTMSessionUploadFetcher.m
+++ b/Sources/Core/GTMSessionUploadFetcher.m
@@ -300,8 +300,17 @@ NSString *const kGTMSessionFetcherUploadInitialBackoffStartedNotification =
   // Set the upload file length before setting the upload file URL tries to determine the length.
   [uploadFetcher setUploadFileLength:uploadFileLength];
 
+  // Remove the private keys (or any invalid keys) from the sessionUserInfo to maintain that api's
+  // type contract.
+  NSSet *keysToRemove = [metadata keysOfEntriesPassingTest:^BOOL(id key, id obj, BOOL *stop) {
+    return ![key isKindOfClass:[NSString class]] || ![obj isKindOfClass:[NSString class]] ||
+           [key hasPrefix:@"_"];
+  }];
+  NSMutableDictionary *sessionUserInfo = [metadata mutableCopy];
+  [sessionUserInfo removeObjectsForKeys:[keysToRemove allObjects]];
+  uploadFetcher.sessionUserInfo = sessionUserInfo;
+
   uploadFetcher.uploadFileURL = uploadFileURL;
-  uploadFetcher.sessionUserInfo = metadata;
   uploadFetcher.useBackgroundSession = YES;
   uploadFetcher.currentOffset = currentOffset;
   uploadFetcher.delegateCallbackQueue = uploadFetcher.callbackQueue;


### PR DESCRIPTION
After using the metadata to restore things, prune out things before relaying any sessionUserInfo value so the api contract is maintained.