### PR TITLE
Use a slightly long test timeout.

### DIFF
--- a/UnitTests/GTMSessionFetcherFetchingTest.m
+++ b/UnitTests/GTMSessionFetcherFetchingTest.m
@@ -49,7 +49,7 @@ NSString *const kGTMGettysburgFileName = @"gettysburgaddress.txt";
 // Using -[XCTestCase waitForExpectations...] methods will NOT wait for them.
 #define WAIT_FOR_START_STOP_NOTIFICATION_EXPECTATIONS()                                   \
   [self waitForExpectations:@[ fetcherStartedExpectation__, fetcherStoppedExpectation__ ] \
-                    timeout:5.0];
+                    timeout:10.0];
 
 @interface GTMSessionFetcher (ExposedForTesting)
 + (nullable NSURL *)redirectURLWithOriginalRequestURL:(nullable NSURL *)originalRequestURL


### PR DESCRIPTION
Seeing some CI setups where things run a little slower and things were timing out, so increase the wait time for safety sake.