### PR TITLE
Expand the tests for a stopping a single fetcher.

### DIFF
--- a/UnitTests/GTMSessionFetcherFetchingTest.h
+++ b/UnitTests/GTMSessionFetcherFetchingTest.h
@@ -81,10 +81,15 @@ extern NSString *const kGTMGettysburgFileName;
 - (nullable NSMutableURLRequest *)mutableRequestForTesting;
 @end
 
+typedef void (^TestAuthorizerWaitBlock)(void);
+
 // Authorization testing.
 @interface TestAuthorizer : NSObject <GTMSessionFetcherAuthorizer>
 
 @property(atomic, assign, getter=isAsync) BOOL async;
+// Only honored if async, will get called on a work queue and when it returns authorization will be
+// completed.
+@property(atomic) TestAuthorizerWaitBlock waitBlock;
 @property(atomic, assign) NSUInteger delay;  // Only honored if async
 @property(atomic, assign, getter=isExpired) BOOL expired;
 @property(atomic, assign) BOOL willFailWithError;
@@ -92,6 +97,7 @@ extern NSString *const kGTMGettysburgFileName;
 + (instancetype)syncAuthorizer;
 + (instancetype)asyncAuthorizer;
 + (instancetype)asyncAuthorizerDelayed:(NSUInteger)delaySeconds;
++ (instancetype)asyncAuthorizerBlocked:(TestAuthorizerWaitBlock)delayBlock;
 + (instancetype)expiredSyncAuthorizer;
 + (instancetype)expiredAsyncAuthorizer;
 

--- a/UnitTests/GTMSessionFetcherFetchingTest.m
+++ b/UnitTests/GTMSessionFetcherFetchingTest.m
@@ -1682,91 +1682,143 @@ NSString *const kGTMGettysburgFileName = @"gettysburgaddress.txt";
 #endif
 }
 
+typedef NS_ENUM(NSInteger, TestAuthorizerMode) {
+  TestAuthorizerModeNone = 0,
+  TestAuthorizerModeSync,
+  TestAuthorizerModeAsync,
+  TestAuthorizerModeWaitPreSleep,
+  TestAuthorizerModeWaitPreStop,
+  TestAuthorizerModeWaitPostStop,
+};
+
 - (void)testDelayedCancelFetchWithCallback {
-  [self internalCancelFetchWithCallback:1];
+  [self internalCancelFetchWithCallback:1 authorizerMode:TestAuthorizerModeNone];
 }
 
 - (void)testDelayedCancelFetchWithCallback_WithoutFetcherService {
   _fetcherService = nil;
-  [self internalCancelFetchWithCallback:1];
+  [self testDelayedCancelFetchWithCallback];
 }
 
 - (void)testImmediateCancelFetchWithCallback {
-  [self internalCancelFetchWithCallback:0];
+  [self internalCancelFetchWithCallback:0 authorizerMode:TestAuthorizerModeNone];
 }
 
 - (void)testImmediateCancelFetchWithCallback_WithoutFetcherService {
   _fetcherService = nil;
-  [self internalCancelFetchWithCallback:0];
+  [self testImmediateCancelFetchWithCallback];
+}
+
+- (void)testPreCancelFetchWithCallback {
+  [self internalCancelFetchWithCallback:-1 authorizerMode:TestAuthorizerModeNone];
+}
+
+- (void)PerCancelFetchWithCallback_WithoutFetcherService {
+  _fetcherService = nil;
+  [self testPreCancelFetchWithCallback];
 }
 
 - (void)testDelayedSyncAuthCancelFetchWithCallback {
-  [self internalCancelFetchWithCallback:1 authorizer:[TestAuthorizer syncAuthorizer]];
+  [self internalCancelFetchWithCallback:1 authorizerMode:TestAuthorizerModeSync];
 }
 
 - (void)testDelayedSyncAuthCancelFetchWithCallback_WithoutFetcherService {
   _fetcherService = nil;
-  [self internalCancelFetchWithCallback:1 authorizer:[TestAuthorizer syncAuthorizer]];
+  [self testDelayedSyncAuthCancelFetchWithCallback];
 }
 
 - (void)testImmediateSyncAuthCancelFetchWithCallback {
-  [self internalCancelFetchWithCallback:0 authorizer:[TestAuthorizer syncAuthorizer]];
+  [self internalCancelFetchWithCallback:0 authorizerMode:TestAuthorizerModeSync];
 }
 
 - (void)testImmediateSyncAuthCancelFetchWithCallback_WithoutFetcherService {
   _fetcherService = nil;
-  [self internalCancelFetchWithCallback:0 authorizer:[TestAuthorizer syncAuthorizer]];
+  [self testImmediateSyncAuthCancelFetchWithCallback];
+}
+
+- (void)testPreSyncAuthCancelFetchWithCallback {
+  [self internalCancelFetchWithCallback:-1 authorizerMode:TestAuthorizerModeSync];
+}
+
+- (void)testPreSyncAuthCancelFetchWithCallback_WithoutFetcherService {
+  _fetcherService = nil;
+  [self testPreSyncAuthCancelFetchWithCallback];
 }
 
 - (void)testDelayedAsyncAuthCancelFetchWithCallback {
-  [self internalCancelFetchWithCallback:1 authorizer:[TestAuthorizer asyncAuthorizer]];
+  [self internalCancelFetchWithCallback:1 authorizerMode:TestAuthorizerModeAsync];
 }
 
 - (void)testDelayedAsyncAuthCancelFetchWithCallback_WithoutFetcherService {
   _fetcherService = nil;
-  [self internalCancelFetchWithCallback:1 authorizer:[TestAuthorizer asyncAuthorizer]];
+  [self testDelayedAsyncAuthCancelFetchWithCallback];
 }
 
 - (void)testImmediateAsyncAuthCancelFetchWithCallback {
-  [self internalCancelFetchWithCallback:0 authorizer:[TestAuthorizer asyncAuthorizer]];
+  [self internalCancelFetchWithCallback:0 authorizerMode:TestAuthorizerModeAsync];
 }
 
 - (void)testImmediateAsyncAuthCancelFetchWithCallback_WithoutFetcherService {
   _fetcherService = nil;
-  [self internalCancelFetchWithCallback:0 authorizer:[TestAuthorizer asyncAuthorizer]];
+  [self testImmediateAsyncAuthCancelFetchWithCallback];
+}
+
+- (void)testPreAsyncAuthCancelFetchWithCallback {
+  [self internalCancelFetchWithCallback:-1 authorizerMode:TestAuthorizerModeAsync];
+}
+
+- (void)testPreAsyncAuthCancelFetchWithCallback_WithoutFetcherService {
+  _fetcherService = nil;
+  [self testPreAsyncAuthCancelFetchWithCallback];
 }
 
 - (void)testDelayedAsyncDelayedAuthCancelFetchWithCallback {
-  [self internalCancelFetchWithCallback:1 authorizer:[TestAuthorizer asyncAuthorizerDelayed:2]];
+  [self internalCancelFetchWithCallback:1 authorizerMode:TestAuthorizerModeWaitPreSleep];
+  [self internalCancelFetchWithCallback:1 authorizerMode:TestAuthorizerModeWaitPreStop];
+  [self internalCancelFetchWithCallback:1 authorizerMode:TestAuthorizerModeWaitPostStop];
 }
 
 - (void)testDelayedAsyncDelayedAuthCancelFetchWithCallback_WithoutFetcherService {
   _fetcherService = nil;
-  [self internalCancelFetchWithCallback:1 authorizer:[TestAuthorizer asyncAuthorizerDelayed:2]];
+  [self testDelayedAsyncDelayedAuthCancelFetchWithCallback];
 }
 
 - (void)testImmediateAsyncDelayedAuthCancelFetchWithCallback {
-  [self internalCancelFetchWithCallback:0 authorizer:[TestAuthorizer asyncAuthorizerDelayed:1]];
+  // No sleep
+  [self internalCancelFetchWithCallback:0 authorizerMode:TestAuthorizerModeWaitPreStop];
+  [self internalCancelFetchWithCallback:0 authorizerMode:TestAuthorizerModeWaitPostStop];
 }
 
 - (void)testImmediateAsyncDelayedAuthCancelFetchWithCallback_WithoutFetcherService {
   _fetcherService = nil;
-  [self internalCancelFetchWithCallback:0 authorizer:[TestAuthorizer asyncAuthorizerDelayed:1]];
+  [self testImmediateAsyncDelayedAuthCancelFetchWithCallback];
 }
 
-- (void)internalCancelFetchWithCallback:(unsigned int)sleepTime {
-  [self internalCancelFetchWithCallback:sleepTime authorizer:nil];
+- (void)testPreAsyncDelayedAuthCancelFetchWithCallback {
+  // No sleep
+  [self internalCancelFetchWithCallback:-1 authorizerMode:TestAuthorizerModeWaitPreStop];
+  [self internalCancelFetchWithCallback:-1 authorizerMode:TestAuthorizerModeWaitPostStop];
+}
+
+- (void)testPreAsyncDelayedAuthCancelFetchWithCallback_WithoutFetcherService {
+  _fetcherService = nil;
+  [self testPreAsyncDelayedAuthCancelFetchWithCallback];
 }
 
 #pragma clang diagnostic ignored "-Wdeprecated"
-- (void)internalCancelFetchWithCallback:(unsigned int)sleepTime
-                             authorizer:(nullable id<GTMFetcherAuthorizationProtocol>)authorizer {
+- (void)internalCancelFetchWithCallback:(int)sleepTime
+                         authorizerMode:(TestAuthorizerMode)authorizerMode {
 #pragma clang diagnostic pop
   if (!_isServerRunning) return;
 
   // If the authorizer is async, then the fetch won't fully begin, and there won't ever be
-  // a start notification (and thus stop notification).
-  int expectedNotificationCount = ((TestAuthorizer*)authorizer).isAsync ? 0 : 1;
+  // a start notification (and thus stop notification). Likewise, if the fetch is stopped before
+  // it even starts, there won't be a notification.
+  int expectedNotificationCount =
+      (authorizerMode != TestAuthorizerModeNone && authorizerMode != TestAuthorizerModeSync) ||
+              (sleepTime < 0)
+          ? 0
+          : 1;
   XCTestExpectation *fetcherStartedExpectation = nil;
   XCTestExpectation *fetcherStoppedExpectation = nil;
   if (expectedNotificationCount) {
@@ -1783,10 +1835,48 @@ NSString *const kGTMGettysburgFileName = @"gettysburgaddress.txt";
                                                            parameters:@{@"sleep" : @"5"}];
   GTMSessionFetcher *fetcher = [self fetcherWithURLString:timeoutFileURLString];
   fetcher.stopFetchingTriggersCompletionHandler = YES;
-  if (authorizer) {
-    fetcher.authorizer = authorizer;
+
+  dispatch_semaphore_t authSemaphone = dispatch_semaphore_create(0);
+
+  if (sleepTime < 0) {
+    if (authorizerMode != TestAuthorizerModeNone) {
+      fetcher.authorizer = [TestAuthorizer asyncAuthorizerBlocked:^{
+        XCTFail(@"stopFetching called before begin should have prevented the authorizer from ever "
+                @"being called.");
+      }];
+    }
+  } else {
+    switch (authorizerMode) {
+      case TestAuthorizerModeNone:
+        break;
+      case TestAuthorizerModeSync:
+        fetcher.authorizer = [TestAuthorizer syncAuthorizer];
+        break;
+      case TestAuthorizerModeAsync:
+        fetcher.authorizer = [TestAuthorizer asyncAuthorizer];
+        break;
+      case TestAuthorizerModeWaitPreSleep:
+        XCTAssertGreaterThan(sleepTime, 0,
+                             @"PreSleep when 'stop' was before 'begin' doesn't make sense.");
+      case TestAuthorizerModeWaitPreStop:
+      case TestAuthorizerModeWaitPostStop: {
+        XCTestExpectation *authExpect = [self expectationWithDescription:@"Expect for auth block"];
+        fetcher.authorizer = [TestAuthorizer asyncAuthorizerBlocked:^{
+          NSUInteger waitTime =
+              1 + (authorizerMode != TestAuthorizerModeWaitPreSleep ? sleepTime : 0);
+          intptr_t waitResult = dispatch_semaphore_wait(
+              authSemaphone, dispatch_time(DISPATCH_TIME_NOW, waitTime * NSEC_PER_SEC));
+          XCTAssertEqual(0, waitResult);
+          [authExpect fulfill];
+        }];
+      } break;
+    }
   }
+
   XCTestExpectation *expectation = [self expectationWithDescription:@"Expect to call callback"];
+  if (sleepTime < 0) {  // <0 means stop before begin.
+    [fetcher stopFetching];
+  }
   [fetcher beginFetchWithCompletionHandler:^(NSData *data, NSError *error) {
     XCTAssertNil(data, @"error data unexpected");
     XCTAssertEqual(error.code, GTMSessionFetcherErrorUserCancelled);
@@ -1794,17 +1884,32 @@ NSString *const kGTMGettysburgFileName = @"gettysburgaddress.txt";
     [expectation fulfill];
   }];
 
-  if (sleepTime) {
-    sleep(sleepTime);
+  if (sleepTime >= 0) {
+    if (authorizerMode == TestAuthorizerModeWaitPreSleep) {
+      dispatch_semaphore_signal(authSemaphone);
+    }
+    if (sleepTime) {
+      sleep(sleepTime);
+    }
+    if (authorizerMode == TestAuthorizerModeWaitPreStop) {
+      dispatch_semaphore_signal(authSemaphone);
+    }
+    [fetcher stopFetching];
+    if (authorizerMode == TestAuthorizerModeWaitPostStop) {
+      dispatch_semaphore_signal(authSemaphone);
+    }
+  } else {
+    // No harm in signaling even if not needed.
+    dispatch_semaphore_signal(authSemaphone);
   }
-  [fetcher stopFetching];
 
   [self waitForExpectationsWithTimeout:_timeoutInterval handler:nil];
 
   [self assertCallbacksReleasedForFetcher:fetcher];
 
   // Check the notifications.
-  XCTAssertEqual(fnctr.fetchStarted, expectedNotificationCount, @"%@", fnctr.fetchersStartedDescriptions);
+  XCTAssertEqual(fnctr.fetchStarted, expectedNotificationCount, @"%@",
+                 fnctr.fetchersStartedDescriptions);
   XCTAssertEqual(fnctr.fetchStopped, fnctr.fetchStarted, @"%@", fnctr.fetchersStoppedDescriptions);
   XCTAssertEqual(fnctr.fetchCompletionInvoked, 1);
 #if GTM_BACKGROUND_TASK_FETCHING
@@ -3077,6 +3182,13 @@ NSString *const kGTMGettysburgFileName = @"gettysburgaddress.txt";
   return authorizer;
 }
 
++ (instancetype)asyncAuthorizerBlocked:(TestAuthorizerWaitBlock)waitBlock {
+  TestAuthorizer *authorizer = [self syncAuthorizer];
+  authorizer.async = YES;
+  authorizer.waitBlock = waitBlock;
+  return authorizer;
+}
+
 + (instancetype)expiredSyncAuthorizer {
   TestAuthorizer *authorizer = [self syncAuthorizer];
   authorizer.expired = YES;
@@ -3102,7 +3214,14 @@ NSString *const kGTMGettysburgFileName = @"gettysburgaddress.txt";
   }
 
   if (self.async) {
-    if (self.delay) {
+    if (self.waitBlock) {
+      dispatch_async(dispatch_get_global_queue(DISPATCH_QUEUE_PRIORITY_DEFAULT, 0), ^{
+        self.waitBlock();
+        dispatch_async(dispatch_get_main_queue(), ^{
+          handler(error);
+        });
+      });
+    } else if (self.delay) {
       dispatch_time_t delay_time =
           dispatch_time(DISPATCH_TIME_NOW, (int64_t)(self.delay * NSEC_PER_SEC));
       dispatch_after(delay_time, dispatch_get_main_queue(), ^{

--- a/UnitTests/GTMSessionFetcherServiceTest.m
+++ b/UnitTests/GTMSessionFetcherServiceTest.m
@@ -414,40 +414,40 @@ static bool IsCurrentProcessBeingDebugged(void) {
     [observers addObject:startObserver];
 
     // Fetcher stopped notification.
-    id stopObserver = [nc
-        addObserverForName:kGTMSessionFetcherStoppedNotification
-                    object:fetcher
-                     queue:nil
-                usingBlock:^(NSNotification *note) {
-                  XCTAssertTrue([running containsObject:fetcher]);
+    id stopObserver =
+        [nc addObserverForName:kGTMSessionFetcherStoppedNotification
+                        object:fetcher
+                         queue:nil
+                    usingBlock:^(NSNotification *note) {
+                      XCTAssertTrue([running containsObject:fetcher]);
 
-                  // Verify that we only have two fetchers running.
-                  [completed addObject:fetcher];
-                  [running removeObject:fetcher];
+                      // Verify that we only have two fetchers running.
+                      [completed addObject:fetcher];
+                      [running removeObject:fetcher];
 
-                  // A fetcher that gets stopped should not trigger any notifications.
-                  NSURL *fetcherReqURL = fetcher.request.URL;
-                  XCTAssertFalse([fetcherReqURL.query hasPrefix:@"stop="]);
+                      // A fetcher that gets stopped should not trigger any notifications.
+                      NSURL *fetcherReqURL = fetcher.request.URL;
+                      XCTAssertFalse([fetcherReqURL.query hasPrefix:@"stop="]);
 
-                  NSString *host = fetcherReqURL.host;
-                  NSUInteger numberRunning = FetchersPerHost(running, host);
-                  NSUInteger numberPending = FetchersPerHost(pending, host);
-                  NSUInteger numberCompleted = FetchersPerHost(completed, host);
-                  NSUInteger numberStopped = FetchersPerHost(stopped, host);
+                      NSString *host = fetcherReqURL.host;
+                      NSUInteger numberRunning = FetchersPerHost(running, host);
+                      NSUInteger numberPending = FetchersPerHost(pending, host);
+                      NSUInteger numberCompleted = FetchersPerHost(completed, host);
+                      NSUInteger numberStopped = FetchersPerHost(stopped, host);
 
-                  XCTAssertLessThanOrEqual(numberRunning, kMaxRunningFetchersPerHost,
-                                           @"too many running");
-                  XCTAssertLessThanOrEqual(
-                      numberPending + numberRunning + numberCompleted + numberStopped,
-                      URLsPerHost(urlArray, host),
-                      @"%d issued running (pending:%u running:%u completed:%u stopped: %u)",
-                      (unsigned int)totalNumberOfFetchers, (unsigned int)numberPending,
-                      (unsigned int)numberRunning, (unsigned int)numberCompleted,
-                      (unsigned int)numberStopped);
+                      XCTAssertLessThanOrEqual(numberRunning, kMaxRunningFetchersPerHost,
+                                               @"too many running");
+                      XCTAssertLessThanOrEqual(
+                          numberPending + numberRunning + numberCompleted + numberStopped,
+                          URLsPerHost(urlArray, host),
+                          @"%d issued running (pending:%u running:%u completed:%u stopped: %u)",
+                          (unsigned int)totalNumberOfFetchers, (unsigned int)numberPending,
+                          (unsigned int)numberRunning, (unsigned int)numberCompleted,
+                          (unsigned int)numberStopped);
 
-                  // The stop notification may be posted on the main thread before or after the
-                  // fetcher service has been notified the fetcher has stopped.
-                }];
+                      // The stop notification may be posted on the main thread before or after the
+                      // fetcher service has been notified the fetcher has stopped.
+                    }];
     [observers addObject:stopObserver];
 
     // Set the fetch priority to a value that cycles 0, 1, -1, 0, ...
@@ -488,7 +488,8 @@ static bool IsCurrentProcessBeingDebugged(void) {
         XCTAssertNil(fetchError, @"unexpected %@ %@", fetchError, fetchError.userInfo);
       } else {
         if ([query isEqual:@"stop=callback"]) {
-          XCTAssertEqualObjects(fetchError.domain, kGTMSessionFetcherErrorDomain, @"expected error");
+          XCTAssertEqualObjects(fetchError.domain, kGTMSessionFetcherErrorDomain,
+                                @"expected error");
           XCTAssertEqual(fetchError.code, GTMSessionFetcherErrorUserCancelled, @"expected error");
         } else if ([query hasPrefix:@"stop="]) {
           XCTFail(@"Should not have gotten completion for stopped call");
@@ -516,8 +517,7 @@ static bool IsCurrentProcessBeingDebugged(void) {
   // Check the notification counts.
   XCTAssertEqual(pending.count, (NSUInteger)0, @"still pending: %@", pending);
   XCTAssertEqual(running.count, (NSUInteger)0, @"still running: %@", running);
-  XCTAssertEqual(completed.count + stopped.count, (NSUInteger)totalNumberOfFetchers,
-                 @"incomplete");
+  XCTAssertEqual(completed.count + stopped.count, (NSUInteger)totalNumberOfFetchers, @"incomplete");
   // All the expected callbacks happened.
   XCTAssertEqual(fetchersInFlight.count, (NSUInteger)0, @"Uncompleted: %@", fetchersInFlight);
 


### PR DESCRIPTION
- Chain the non service test to call the the others to reduce chance for coding errors.
- Add support for calling `stopFetching` even before beginning the fetch.
- Add support to `TestAuthorizer` to have a block called on a work queue before the authorization completes.
- Ensure the authorizer isn't called if the stop is done before the fetch starts.
- Ensure the authorizer is called if the stop happens after starting the fetch.
- When delaying the authorizer, control exactly when it triggers to control where in the flow of starting a fetcher things things happen.

This also remove some of the "sleep" delays in the tests, to speed up these tests.