### PR TITLE
Don't reset _waitSeconds, is a thread race.

### DIFF
--- a/UnitTests/GTMSessionFetcherFetchingTest.m
+++ b/UnitTests/GTMSessionFetcherFetchingTest.m
@@ -3460,7 +3460,6 @@ typedef void (^StopFetchingCallbackTestBlock)(GTMSessionFetcher *fetcher);
 - (void)unblock {
   NSAssert(_waitSeconds, @"This was not a blocked authorizer");
   dispatch_semaphore_signal(_semaphore);
-  _waitSeconds = 0;
 }
 
 + (instancetype)expiredSyncAuthorizer {
@@ -3608,7 +3607,6 @@ typedef void (^StopFetchingCallbackTestBlock)(GTMSessionFetcher *fetcher);
 - (void)unblock {
   NSAssert(_waitSeconds, @"This was not a blocked UAProvider");
   dispatch_semaphore_signal(_semaphore);
-  _waitSeconds = 0;
 }
 
 - (NSString *)userAgent {


### PR DESCRIPTION
It a test called `-unblock` before the helper reached the point it was going it wait, the support would be lost (or it would see it set, and then by the time the wait is invoked it would become zero).

There's no need to actually add sync, and the clearing wasn't required, so drop it.