### PR TITLE
Enable the test now that it passes.

### DIFF
--- a/UnitTests/GTMSessionFetcherFetchingTest.m
+++ b/UnitTests/GTMSessionFetcherFetchingTest.m
@@ -2592,11 +2592,11 @@ typedef void (^StopFetchingCallbackTestBlock)(GTMSessionFetcher *fetcher);
   // Using a UAProvider, trigger the provider after starting the fetch, then wait 1s before calling
   // `-stopFetching`.
 
-  XCTSkip(@"not currently passing");
   XCTestExpectation *providerExpect =
       [self expectationWithDescription:@"Expect for UAProvider block"];
 
-  [self runStopFetchingCallbackTestWithNotifications:NO
+  // The notifications will fire because after unblocking, the sleep allows the fetch to start.
+  [self runStopFetchingCallbackTestWithNotifications:YES
       preBegin:^(GTMSessionFetcher *fetcher) {
         fetcher.userAgentProvider =
             [[TestUserAgentBlockProvider alloc] initWithBlockedTimeout:1


### PR DESCRIPTION
The original problems were the handling of notifications within the core library itself, with those fixed, the test now can get fully to completion.