### PR TITLE
Add a check for `-stopFetching` before the final startup.

### DIFF
--- a/Sources/Core/GTMSessionFetcher.m
+++ b/Sources/Core/GTMSessionFetcher.m
@@ -872,6 +872,26 @@ static GTMSessionFetcherTestBlock _Nullable gGlobalTestBlock;
     }
   }
 
+  BOOL stopped;
+  @synchronized(self) {
+    GTMSessionMonitorSynchronized(self);
+    stopped = _userStoppedFetching;
+  }
+  if (stopped) {
+    GTMSESSION_ASSERT_DEBUG(_delayState == kDelayStateNotDelayed,
+                            @"Unexpected internal state: %lu", (unsigned long)_delayState);
+    // We end up here if someone calls `stopFetching` from another thread/queue while
+    // the fetch was being started up, so while `stopFetching` did the needed shutdown
+    // we have to ensure the requested callback was triggered.
+    if (self.stopFetchingTriggersCompletionHandler) {
+      NSError *error = [NSError errorWithDomain:kGTMSessionFetcherErrorDomain
+                                           code:GTMSessionFetcherErrorUserCancelled
+                                       userInfo:nil];
+      [self finishWithError:error shouldRetry:NO];
+    }
+    return;  // The fetch was stopped, go no further.
+  }
+
   // finally, start the connection
   NSURLSessionTask *newSessionTask;
   BOOL needsDataAccumulator = NO;

--- a/UnitTests/GTMSessionFetcherFetchingTest.m
+++ b/UnitTests/GTMSessionFetcherFetchingTest.m
@@ -2407,7 +2407,6 @@ typedef void (^StopFetchingCallbackTestBlock)(GTMSessionFetcher *fetcher);
 }
 
 - (void)testStopFetchWithCallback_PreBeginStop_WithoutFetcherService {
-  XCTSkip(@"not currently passing");
   _fetcherService = nil;
   [self testStopFetchWithCallback_PreBeginStop];
 }


### PR DESCRIPTION
When `-stopFetching` is called really early in the startup process and there is no configuration that might cause a delay (authorizer, UAProvider, etc.), then this ensure the fetch never really begins and if requested the completion is triggered.