### PR TITLE
Don't allow service limit delays after a UAProvider.

### DIFF
--- a/Sources/Core/GTMSessionFetcher.m
+++ b/Sources/Core/GTMSessionFetcher.m
@@ -789,7 +789,6 @@ static GTMSessionFetcherTestBlock _Nullable gGlobalTestBlock;
       // The User-Agent is not cached in memory. Fetch it asynchronously.
       [self updateUserAgentAsynchronouslyForRequest:fetchRequest
                                   userAgentProvider:userAgentProvider
-                                           mayDelay:mayDelay
                                        mayAuthorize:mayAuthorize
                                         mayDecorate:mayDecorate];
       // This method can't continue until the User-Agent header is fetched. The above
@@ -1092,7 +1091,6 @@ static GTMSessionFetcherTestBlock _Nullable gGlobalTestBlock;
 // sets it in |fetchRequest| and continues the request.
 - (void)updateUserAgentAsynchronouslyForRequest:(NSMutableURLRequest *)fetchRequest
                               userAgentProvider:(id<GTMUserAgentProvider>)userAgentProvider
-                                       mayDelay:(BOOL)mayDelay
                                    mayAuthorize:(BOOL)mayAuthorize
                                     mayDecorate:(BOOL)mayDecorate {
   GTMSESSION_LOG_DEBUG_VERBOSE(
@@ -1125,7 +1123,7 @@ static GTMSessionFetcherTestBlock _Nullable gGlobalTestBlock;
       }
       [strongSelf->_request setValue:userAgent forHTTPHeaderField:@"User-Agent"];
     }
-    [strongSelf beginFetchMayDelay:mayDelay mayAuthorize:mayAuthorize mayDecorate:mayDecorate];
+    [strongSelf beginFetchMayDelay:NO mayAuthorize:mayAuthorize mayDecorate:mayDecorate];
   });
 }
 

--- a/Sources/Core/GTMSessionFetcherService.m
+++ b/Sources/Core/GTMSessionFetcherService.m
@@ -399,8 +399,7 @@ static id<GTMUserAgentProvider> SharedStandardUserAgentProvider(void) {
 
     NSMutableArray *runningForHost = [_runningFetchersByHost objectForKey:host];
     if (runningForHost != nil && [runningForHost indexOfObjectIdenticalTo:fetcher] != NSNotFound) {
-      // It was already running, this can be caused by a fetch that needed to do authorization,
-      // invoke a UserAgent provider or decorators.
+      GTMSESSION_ASSERT_DEBUG(NO, @"%@ was already running", fetcher);
       return YES;
     }
 


### PR DESCRIPTION
When resuming the being sequence after using a UAProvider, the fetch is already in progress and thus should not go through the server limit delay. This has been a standing issue since the UAProvider got added.

This undoes a change in #454 because of the error in the UAProvider flow, the assert was correct.