### PR TITLE
Some `-stopFetching` testing improvements/cleanups.

### DIFF
--- a/UnitTests/GTMSessionFetcherFetchingTest.h
+++ b/UnitTests/GTMSessionFetcherFetchingTest.h
@@ -83,12 +83,18 @@ extern NSString *const kGTMGettysburgFileName;
 
 #pragma mark - Authorization testing helper
 
+typedef void (^TestAuthorizerBlock)(void);
+
 @interface TestAuthorizer : NSObject <GTMSessionFetcherAuthorizer>
 
 @property(atomic, readonly, getter=isAsync) BOOL async;
 
 @property(atomic, assign, getter=isExpired) BOOL expired;
 @property(atomic, assign) BOOL willFailWithError;
+
+// And extra block that will be invoked before the authorizer returns, this can do any extra
+// validations desired. It is called on the main thread, so it should *not* delay things.
+@property(atomic, copy) TestAuthorizerBlock workBlock;
 
 // An expectation to `-fulfill` after completing the authorization.
 @property(atomic, nullable) XCTestExpectation *testExpectation;
@@ -111,13 +117,6 @@ extern NSString *const kGTMGettysburgFileName;
 + (instancetype)expiredSyncAuthorizer;
 + (instancetype)expiredAsyncAuthorizer;
 
-@end
-
-// This authorizer will call XCTFail with the given message, the inherrited properties change
-// nothing about it's behavior.
-@interface TestFailingAuthorizer : TestAuthorizer
-- (instancetype)init NS_UNAVAILABLE;
-- (instancetype)initWithFailureMessage:(NSString *)failureMessage NS_DESIGNATED_INITIALIZER;
 @end
 
 #pragma mark - User Agent Caching testing helper

--- a/UnitTests/GTMSessionFetcherServiceTest.m
+++ b/UnitTests/GTMSessionFetcherServiceTest.m
@@ -1843,8 +1843,10 @@ static bool IsCurrentProcessBeingDebugged(void) {
   fetcher1.authorizer = [TestAuthorizer asyncWithBlockedTimeout:1 testExpectation:authExpect];
 
   GTMSessionFetcher *fetcher2 = [service fetcherWithURL:fetchURL];
-  fetcher2.authorizer = [[TestFailingAuthorizer alloc]
-      initWithFailureMessage:@"Should not get here since it was canceled"];
+  fetcher2.authorizer = [TestAuthorizer syncAuthorizer];
+  ((TestAuthorizer *)fetcher2.authorizer).workBlock = ^{
+    XCTFail(@"Should not get here since it was stopped.");
+  };
 
   GTMSessionFetcher *fetcher3 = [service fetcherWithURL:fetchURL];
 


### PR DESCRIPTION
- Avoid blocking the main thread.

  Using `sleep` could block the main thread and thus delay things like the notifications, so rather than doing that, queue a delayed block to the main thread to do the work and thus avoid the blocking.

- Add a "work block" to the TestAuthorizer to support injecting extra work into when the authorization is completed.

- Shrink some of the delay times to speed things up. Could also remove some of these delays by making some things trigger off the "fetch started" notification but not doing that at this point.

- Move some of the `-stopFetching` calls into the TestAuthorizer or UAProvider so we explicitly control where the core fetcher workflow will notice the stop instead of it being a race between multiple possible places would could change the outcomes.

- Move some of the stop calls that were intended to be after the fetch starts so they trigger after the notification for start are fired. Ensuring things are deterministic between queues.