### PR TITLE
Stop selecting the latest Xcode and use the image default.

### DIFF
--- a/.github/workflows/bazel.yml
+++ b/.github/workflows/bazel.yml
@@ -36,10 +36,6 @@ jobs:
         MODE: ["dbg", "opt"]
     steps:
       - uses: actions/checkout@v5
-      - name: Select Xcode Version
-        uses: maxim-lobanov/setup-xcode@v1
-        with:
-          xcode-version: 'latest-stable'
       - uses: bazel-contrib/setup-bazel@0.15.0
         with:
           bazelisk-cache: true

--- a/.github/workflows/cocoapods.yml
+++ b/.github/workflows/cocoapods.yml
@@ -33,10 +33,6 @@ jobs:
         CONFIGURATION: ["Debug", "Release"]
     steps:
     - uses: actions/checkout@v5
-    - name: Select Xcode Version
-      uses: maxim-lobanov/setup-xcode@v1
-      with:
-        xcode-version: 'latest-stable'
     # Manually expanding out static frameworks to avoid making to many jobs.
     - name: Pod lib lint
       run:  |

--- a/.github/workflows/swiftpm.yml
+++ b/.github/workflows/swiftpm.yml
@@ -33,10 +33,6 @@ jobs:
         CONFIGURATION: ["debug", "release"]
     steps:
     - uses: actions/checkout@v5
-    - name: Select Xcode Version
-      uses: maxim-lobanov/setup-xcode@v1
-      with:
-        xcode-version: 'latest-stable'
     - name: Build and Test
       run:  |
         set -eu
@@ -54,10 +50,6 @@ jobs:
         CONFIGURATION: ["Debug", "Release"]
     steps:
     - uses: actions/checkout@v5
-    - name: Select Xcode Version
-      uses: maxim-lobanov/setup-xcode@v1
-      with:
-        xcode-version: 'latest-stable'
     - name: Build and Test
       run:  |
         set -eu

--- a/.github/workflows/test_apps.yml
+++ b/.github/workflows/test_apps.yml
@@ -29,10 +29,6 @@ jobs:
         CONFIGURATION: ["Debug", "Release"]
     steps:
     - uses: actions/checkout@v5
-    - name: Select Xcode Version
-      uses: maxim-lobanov/setup-xcode@v1
-      with:
-        xcode-version: 'latest-stable'
     - name: Build
       run:  |
         set -eu


### PR DESCRIPTION
The latest GitHub images have the 26 RC, but they didn't install any defaults with that OS, so it makes actions fail. So just go back to using the default Xcode on the images.