### PR TITLE
Avoid indexing into `needle` if it was zero length.

### DIFF
--- a/Sources/Full/GTMMIMEDocument.m
+++ b/Sources/Full/GTMMIMEDocument.m
@@ -607,6 +607,10 @@ static void SearchDataForBytes(NSData *data, const void *targetBytes, NSUInteger
 static NSUInteger FindBytes(const unsigned char *needle, NSUInteger needleLen,
                             const unsigned char *haystack, NSUInteger haystackLen,
                             NSUInteger *foundOffset) {
+  if (needleLen == 0) {
+    if (foundOffset) *foundOffset = 0;
+    return 0;
+  }
   const unsigned char *ptr = haystack;
   NSInteger remain = (NSInteger)haystackLen;
   // Assume memchr is an efficient way to find a match for the first


### PR DESCRIPTION
The needle can come in via a developer, so one could argue a zero length is invalid, except the tests actually confirm this case works, so it likely should be supported. So add the missing boundary case check to ensure we don't read from `needle` if it is zero length.